### PR TITLE
Free image patch after determining the stride

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovxmeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxmeta.c
@@ -142,6 +142,8 @@ gst_tiovx_buffer_pool_get_plane_stride (const vx_image image,
     return -1;
   }
 
+  vxUnmapImagePatch (image, map_id);
+
   return addr.stride_y;
 }
 


### PR DESCRIPTION
This change fixes an error message that appeared when using a pool size larger than 8, for example:
```
reset; GST_DEBUG="*ti*:2" gst-launch-1.0 videotestsrc is-live=true num-buffers=20 ! "video/x-raw,format=NV12,width=1280,height=720" ! tiovxmultiscaler name=multi src_0::pool-size=16  multi. ! "video/x-raw,format=NV12,width=640,height=480" !  filesink location=/tmp/frames.bin
```
which caused the following error:
```
 74627.984019 s:  VX_ZONE_ERROR:[vxMapImagePatch:2016] No available image maps
 74627.984044 s:  VX_ZONE_ERROR:[vxMapImagePatch:2017] May need to increase the value of TIVX_IMAGE_MAX_MAPS in tiovx/include/TI/tivx_config.h
```