### PR TITLE
Fix/modules phase 1.2 rel1

### DIFF
--- a/ext/tiovx/gsttiovxmultiscaler.c
+++ b/ext/tiovx/gsttiovxmultiscaler.c
@@ -71,7 +71,7 @@
 #include "gst-libs/gst/tiovx/gsttiovxpad.h"
 #include "gst-libs/gst/tiovx/gsttiovxutils.h"
 
-#include "app_scaler_module.h"
+#include "tiovx_multi_scaler_module.h"
 
 /* TODO: Implement method to choose number of channels dynamically */
 #define DEFAULT_NUM_CHANNELS 1
@@ -174,7 +174,7 @@ static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src_%u",
 struct _GstTIOVXMultiScaler
 {
   GstTIOVXSimo element;
-  ScalerObj obj;
+  TIOVXMultiScalerModuleObj obj;
   gint interpolation_method;
   gint target_id;
 };
@@ -357,7 +357,7 @@ gst_tiovx_multi_scaler_init_module (GstTIOVXSimo * simo, vx_context context,
     GList * src_caps_list)
 {
   GstTIOVXMultiScaler *self = NULL;
-  ScalerObj *multiscaler = NULL;
+  TIOVXMultiScalerModuleObj *multiscaler = NULL;
   GList *l = NULL;
   gboolean ret = TRUE;
   GstVideoInfo in_info = { };
@@ -422,13 +422,13 @@ gst_tiovx_multi_scaler_init_module (GstTIOVXSimo * simo, vx_context context,
 
   /* Initialize general parameters */
   GST_OBJECT_LOCK (GST_OBJECT (self));
-  multiscaler->method = self->interpolation_method;
+  multiscaler->interpolation_method = self->interpolation_method;
   GST_OBJECT_UNLOCK (GST_OBJECT (self));
-  multiscaler->num_ch = DEFAULT_NUM_CHANNELS;
+  multiscaler->num_channels = DEFAULT_NUM_CHANNELS;
   multiscaler->num_outputs = g_list_length (src_caps_list);
 
   GST_INFO_OBJECT (self, "Initializing scaler object");
-  status = app_init_scaler (context, multiscaler);
+  status = tiovx_multi_scaler_module_init (context, multiscaler);
   if (VX_SUCCESS != status) {
     GST_ERROR_OBJECT (self, "Module init failed with error: %d", status);
     ret = FALSE;
@@ -450,7 +450,7 @@ gst_tiovx_multi_scaler_configure_module (GstTIOVXSimo * simo)
   self = GST_TIOVX_MULTI_SCALER (simo);
 
   GST_DEBUG_OBJECT (self, "Update filter coeffs");
-  status = app_update_scaler_filter_coeffs (&self->obj);
+  status = tiovx_multi_scaler_module_update_filter_coeffs (&self->obj);
   if (VX_SUCCESS != status) {
     GST_ERROR_OBJECT (self,
         "Module configure filter coefficients failed with error: %d", status);
@@ -459,7 +459,7 @@ gst_tiovx_multi_scaler_configure_module (GstTIOVXSimo * simo)
   }
 
   GST_DEBUG_OBJECT (self, "Release buffer scaler");
-  status = app_release_buffer_scaler (&self->obj);
+  status = tiovx_multi_scaler_module_release_buffers (&self->obj);
   if (VX_SUCCESS != status) {
     GST_ERROR_OBJECT (self,
         "Module configure release buffer failed with error: %d", status);
@@ -514,7 +514,7 @@ gst_tiovx_multi_scaler_create_graph (GstTIOVXSimo * simo, vx_context context,
     vx_graph graph)
 {
   GstTIOVXMultiScaler *self = NULL;
-  ScalerObj *multiscaler = NULL;
+  TIOVXMultiScalerModuleObj *multiscaler = NULL;
   vx_status status = VX_FAILURE;
   gboolean ret = TRUE;
   const gchar *target = NULL;
@@ -534,7 +534,7 @@ gst_tiovx_multi_scaler_create_graph (GstTIOVXSimo * simo, vx_context context,
   multiscaler = &self->obj;
 
   GST_DEBUG_OBJECT (self, "Creating scaler graph");
-  status = app_create_graph_scaler (context, graph, multiscaler, NULL, target);
+  status = tiovx_multi_scaler_module_create (graph, multiscaler, NULL, target);
   if (VX_SUCCESS != status) {
     GST_ERROR_OBJECT (self, "Create graph failed with error: %d", status);
     ret = FALSE;
@@ -817,7 +817,7 @@ static gboolean
 gst_tiovx_multi_scaler_deinit_module (GstTIOVXSimo * simo)
 {
   GstTIOVXMultiScaler *self = NULL;
-  ScalerObj *multiscaler = NULL;
+  TIOVXMultiScalerModuleObj *multiscaler = NULL;
   vx_status status = VX_FAILURE;
   gboolean ret = TRUE;
 
@@ -827,7 +827,7 @@ gst_tiovx_multi_scaler_deinit_module (GstTIOVXSimo * simo)
   multiscaler = &self->obj;
 
   /* Delete graph */
-  status = app_delete_scaler (multiscaler);
+  status = tiovx_multi_scaler_module_delete (multiscaler);
   if (VX_SUCCESS != status) {
     GST_ERROR_OBJECT (self, "Module graph delete failed with error: %d",
         status);
@@ -835,7 +835,7 @@ gst_tiovx_multi_scaler_deinit_module (GstTIOVXSimo * simo)
     goto out;
   }
 
-  status = app_deinit_scaler (multiscaler);
+  status = tiovx_multi_scaler_module_deinit (multiscaler);
   if (VX_SUCCESS != status) {
     GST_ERROR_OBJECT (self, "Module deinit failed with error: %d", status);
     ret = FALSE;

--- a/pkgconfig/vision_apps_modules.pc
+++ b/pkgconfig/vision_apps_modules.pc
@@ -4,7 +4,7 @@ libdir=${prefix}/lib/
 libdir1=${prefix}/lib/python3.8/site-packages/dlr/
 
 includedir=${prefix}/include/processor_sdk/vision_apps/
-includedirs_vision_modules=${prefix}/include/processor_sdk/vision_apps/modules/include/
+includedirs_vision_modules=${prefix}/include/processor_sdk/vision_apps/edgeai_tiovx_modules/include/
 includedirs_tirtos=${prefix}/include/processor_sdk/vision_apps/apps/basic_demos/app_tirtos/tirtos_qnx/mpu1/
 includedirs_kernels_img=${prefix}/include/processor_sdk/vision_apps/kernels/img_proc/include/
 includedirs_fileio=${prefix}/include/processor_sdk/vision_apps/kernels/fileio/include/


### PR DESCRIPTION
Updates to color-convert and multi-scaler modules, mostly changes in API names.
_create module functions don't require context handle. Some opportunity to clean the GST wrapper function.