### PR TITLE
Make a manual copy to TIs memory

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovxallocator.c
+++ b/gst-libs/gst/tiovx/gsttiovxallocator.c
@@ -63,8 +63,7 @@
 
 #include "gsttiovxallocator.h"
 
-static GQuark _tiovx_mem_ptr_quark;
-static const char *_tiovx_mem_ptr_quark_str = "mem_ptr";
+const char *_tiovx_mem_ptr_quark_str = "mem_ptr";
 
 /**
  * SECTION:gsttiovxallocator

--- a/gst-libs/gst/tiovx/gsttiovxallocator.h
+++ b/gst-libs/gst/tiovx/gsttiovxallocator.h
@@ -68,6 +68,9 @@
 
 G_BEGIN_DECLS
 
+
+GQuark _tiovx_mem_ptr_quark;
+
 #define GST_TIOVX_TYPE_ALLOCATOR gst_tiovx_allocator_get_type ()
 
 /**

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -417,6 +417,7 @@ gst_tiovx_buffer_copy (GstDebugCategory * category, GstBufferPool * pool,
   memcpy ((void *) ti_memory->mem_ptr.host_ptr, in_info.data, size);
 
   gst_buffer_unmap (in_buffer, &in_info);
+  gst_memory_unref (memory);
 
 out:
   return out_buffer;

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -561,7 +561,7 @@ gst_tiovx_validate_tiovx_buffer (GstDebugCategory * category,
       *pool = (buffer)->pool;
       gst_object_ref (*pool);
     } else {
-      GST_CAT_INFO (category,
+      GST_CAT_LOG (category,
           "Buffer doesn't come from TIOVX, copying the buffer");
 
       buffer =


### PR DESCRIPTION
Using gst_buffer_copy will create a new memory appended to our buffer,
we are now manually copying the memory from the input buffer to ensure
valid data in the meta.