### PR TITLE
Enhancement/make all pointer guards consistent

### DIFF
--- a/ext/tiovx/gsttiovx.c
+++ b/ext/tiovx/gsttiovx.c
@@ -96,7 +96,7 @@ ti_ovx_init (GstPlugin * plugin)
   }
 
   ret = gst_element_register (plugin, "tiovxdlpreproc", GST_RANK_NONE,
-      GST_TYPE_GST_TIOVX_DL_PRE_PROC);
+      GST_TYPE_TIOVX_DL_PRE_PROC);
   if (!ret) {
     GST_ERROR ("Failed to register the tiovxdlpreproc element");
     goto out;

--- a/ext/tiovx/gsttiovx.c
+++ b/ext/tiovx/gsttiovx.c
@@ -110,7 +110,7 @@ ti_ovx_init (GstPlugin * plugin)
   }
 
   ret = gst_element_register (plugin, "tiovxmultiscaler", GST_RANK_NONE,
-      GST_TYPE_GST_TIOVX_MULTI_SCALER);
+      GST_TYPE_TIOVX_MULTI_SCALER);
   if (!ret) {
     GST_ERROR ("Failed to register the tiovxmultiscaler element");
     goto out;

--- a/ext/tiovx/gsttiovx.c
+++ b/ext/tiovx/gsttiovx.c
@@ -82,7 +82,7 @@ ti_ovx_init (GstPlugin * plugin)
   gboolean ret = FALSE;
 
   ret = gst_element_register (plugin, "tiovxcolorconvert", GST_RANK_NONE,
-      GST_TYPE_GST_TIOVX_COLOR_CONVERT);
+      GST_TYPE_TIOVX_COLOR_CONVERT);
   if (!ret) {
     GST_ERROR ("Failed to register the tiovxcolorconvert element");
     goto out;

--- a/ext/tiovx/gsttiovx.c
+++ b/ext/tiovx/gsttiovx.c
@@ -102,17 +102,17 @@ ti_ovx_init (GstPlugin * plugin)
     goto out;
   }
 
+  ret = gst_element_register (plugin, "tiovxmosaic", GST_RANK_NONE,
+      GST_TYPE_TIOVX_MOSAIC);
+  if (!ret) {
+    GST_ERROR ("Failed to register the tiovxmosaic element");
+    goto out;
+  }
+
   ret = gst_element_register (plugin, "tiovxmultiscaler", GST_RANK_NONE,
       GST_TYPE_GST_TIOVX_MULTI_SCALER);
   if (!ret) {
     GST_ERROR ("Failed to register the tiovxmultiscaler element");
-    goto out;
-  }
-
-  ret = gst_element_register (plugin, "tiovxmosaic", GST_RANK_NONE,
-      GST_TYPE_GST_TIOVX_MOSAIC);
-  if (!ret) {
-    GST_ERROR ("Failed to register the tiovxmosaic element");
     goto out;
   }
 

--- a/ext/tiovx/gsttiovx.c
+++ b/ext/tiovx/gsttiovx.c
@@ -89,7 +89,7 @@ ti_ovx_init (GstPlugin * plugin)
   }
 
   ret = gst_element_register (plugin, "tiovxdlcolorblend", GST_RANK_NONE,
-      GST_TYPE_GST_TIOVX_DL_COLOR_BLEND);
+      GST_TYPE_TIOVX_DL_COLOR_BLEND);
   if (!ret) {
     GST_ERROR ("Failed to register the tiovxdlcolorblend element");
     goto out;

--- a/ext/tiovx/gsttiovxcolorconvert.c
+++ b/ext/tiovx/gsttiovxcolorconvert.c
@@ -152,7 +152,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tiovx_color_convert_debug);
 
 #define gst_tiovx_color_convert_parent_class parent_class
 G_DEFINE_TYPE (GstTIOVXColorconvert, gst_tiovx_color_convert,
-    GST_TIOVX_SISO_TYPE);
+    GST_TYPE_TIOVX_SISO);
 
 static void
 gst_tiovx_color_convert_set_property (GObject * object, guint prop_id,

--- a/ext/tiovx/gsttiovxcolorconvert.h
+++ b/ext/tiovx/gsttiovxcolorconvert.h
@@ -79,7 +79,7 @@ G_BEGIN_DECLS
  * Returns: TRUE if @ptr is a TIOVX colorconvert
  * 
  */
-#define GST_TYPE_GST_TIOVX_COLOR_CONVERT (gst_tiovx_color_convert_get_type())
+#define GST_TYPE_TIOVX_COLOR_CONVERT (gst_tiovx_color_convert_get_type())
 G_DECLARE_FINAL_TYPE(GstTIOVXColorconvert, gst_tiovx_color_convert, GST,
                      TIOVX_COLOR_CONVERT, GstTIOVXSiso)
 

--- a/ext/tiovx/gsttiovxdlcolorblend.c
+++ b/ext/tiovx/gsttiovxdlcolorblend.c
@@ -95,7 +95,7 @@
 #define DEFAULT_TIOVX_DL_COLOR_BLEND_TARGET TIVX_CPU_ID_DSP1
 
 /* Data type definition */
-#define GST_TIOVX_TYPE_DL_COLOR_BLEND_DATA_TYPE (gst_tiovx_dl_color_blend_data_type_get_type())
+#define GST_TYPE_TIOVX_DL_COLOR_BLEND_DATA_TYPE (gst_tiovx_dl_color_blend_data_type_get_type())
 #define DEFAULT_TIOVX_DL_COLOR_BLEND_DATA_TYPE VX_TYPE_FLOAT32
 
 /* Formats definition */
@@ -290,7 +290,7 @@ gst_tiovx_dl_color_blend_class_init (GstTIOVXDLColorBlendClass * klass)
   g_object_class_install_property (gobject_class, PROP_DATA_TYPE,
       g_param_spec_enum ("data-type", "Data Type",
           "Data Type of tensor at the output",
-          GST_TIOVX_TYPE_DL_COLOR_BLEND_DATA_TYPE,
+          GST_TYPE_TIOVX_DL_COLOR_BLEND_DATA_TYPE,
           DEFAULT_TIOVX_DL_COLOR_BLEND_DATA_TYPE,
           G_PARAM_READWRITE | GST_PARAM_CONTROLLABLE | G_PARAM_STATIC_STRINGS));
 

--- a/ext/tiovx/gsttiovxdlcolorblend.c
+++ b/ext/tiovx/gsttiovxdlcolorblend.c
@@ -91,7 +91,7 @@
 #define DEFAULT_NUM_CLASSES 8
 
 /* Target definition */
-#define GST_TIOVX_TYPE_DL_COLOR_BLEND_TARGET (gst_tiovx_dl_color_blend_target_get_type())
+#define GST_TYPE_TIOVX_DL_COLOR_BLEND_TARGET (gst_tiovx_dl_color_blend_target_get_type())
 #define DEFAULT_TIOVX_DL_COLOR_BLEND_TARGET TIVX_CPU_ID_DSP1
 
 /* Data type definition */
@@ -283,7 +283,7 @@ gst_tiovx_dl_color_blend_class_init (GstTIOVXDLColorBlendClass * klass)
   g_object_class_install_property (gobject_class, PROP_TARGET,
       g_param_spec_enum ("target", "Target",
           "TIOVX target to use by this element",
-          GST_TIOVX_TYPE_DL_COLOR_BLEND_TARGET,
+          GST_TYPE_TIOVX_DL_COLOR_BLEND_TARGET,
           DEFAULT_TIOVX_DL_COLOR_BLEND_TARGET,
           G_PARAM_READWRITE | GST_PARAM_CONTROLLABLE | G_PARAM_STATIC_STRINGS));
 

--- a/ext/tiovx/gsttiovxdlcolorblend.c
+++ b/ext/tiovx/gsttiovxdlcolorblend.c
@@ -217,7 +217,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tiovx_dl_color_blend_debug);
 
 #define gst_tiovx_dl_color_blend_parent_class parent_class
 G_DEFINE_TYPE_WITH_CODE (GstTIOVXDLColorBlend, gst_tiovx_dl_color_blend,
-    GST_TIOVX_MISO_TYPE,
+    GST_TYPE_TIOVX_MISO,
     GST_DEBUG_CATEGORY_INIT (gst_tiovx_dl_color_blend_debug,
         "tiovxdlcolorblend", 0,
         "debug category for the tiovxdlcolorblend element"););

--- a/ext/tiovx/gsttiovxdlcolorblend.h
+++ b/ext/tiovx/gsttiovxdlcolorblend.h
@@ -79,7 +79,7 @@ G_BEGIN_DECLS
  * Returns: TRUE if @ptr is a TIOVX color blend
  * 
  */
-#define GST_TYPE_GST_TIOVX_DL_COLOR_BLEND (gst_tiovx_dl_color_blend_get_type())
+#define GST_TYPE_TIOVX_DL_COLOR_BLEND (gst_tiovx_dl_color_blend_get_type())
 G_DECLARE_FINAL_TYPE(GstTIOVXDLColorBlend, gst_tiovx_dl_color_blend, GST,
                      TIOVX_DL_COLOR_BLEND, GstTIOVXMiso)
 

--- a/ext/tiovx/gsttiovxdlpreproc.c
+++ b/ext/tiovx/gsttiovxdlpreproc.c
@@ -104,7 +104,7 @@
 #define DEFAULT_TIOVX_DL_PRE_PROC_DATA_TYPE VX_TYPE_FLOAT32
 
 /* Tensor format definition */
-#define GST_TIOVX_TYPE_DL_PRE_PROC_TENSOR_FORMAT (gst_tiovx_dl_pre_proc_tensor_format_get_type())
+#define GST_TYPE_TIOVX_DL_PRE_PROC_TENSOR_FORMAT (gst_tiovx_dl_pre_proc_tensor_format_get_type())
 #define DEFAULT_TIOVX_DL_PRE_PROC_TENSOR_FORMAT TIVX_DL_PRE_PROC_TENSOR_FORMAT_RGB
 
 /* Formats definition */
@@ -367,7 +367,7 @@ gst_tiovx_dl_pre_proc_class_init (GstTIOVXDLPreProcClass * klass)
   g_object_class_install_property (gobject_class, PROP_TENSOR_FORMAT,
       g_param_spec_enum ("tensor-format", "Tensor Format",
           "Tensor format at the output",
-          GST_TIOVX_TYPE_DL_PRE_PROC_TENSOR_FORMAT,
+          GST_TYPE_TIOVX_DL_PRE_PROC_TENSOR_FORMAT,
           DEFAULT_TIOVX_DL_PRE_PROC_TENSOR_FORMAT,
           G_PARAM_READWRITE | GST_PARAM_CONTROLLABLE | G_PARAM_STATIC_STRINGS));
 

--- a/ext/tiovx/gsttiovxdlpreproc.c
+++ b/ext/tiovx/gsttiovxdlpreproc.c
@@ -92,7 +92,7 @@
 #define NUM_CHANNELS_SUPPORTED 3
 
 /* Target definition */
-#define GST_TIOVX_TYPE_DL_PRE_PROC_TARGET (gst_tiovx_dl_pre_proc_target_get_type())
+#define GST_TYPE_TIOVX_DL_PRE_PROC_TARGET (gst_tiovx_dl_pre_proc_target_get_type())
 #define DEFAULT_TIOVX_DL_PRE_PROC_TARGET TIVX_CPU_ID_DSP1
 
 /* Channel order definition */
@@ -320,7 +320,7 @@ gst_tiovx_dl_pre_proc_class_init (GstTIOVXDLPreProcClass * klass)
   g_object_class_install_property (gobject_class, PROP_TARGET,
       g_param_spec_enum ("target", "Target",
           "TIOVX target to use by this element",
-          GST_TIOVX_TYPE_DL_PRE_PROC_TARGET,
+          GST_TYPE_TIOVX_DL_PRE_PROC_TARGET,
           DEFAULT_TIOVX_DL_PRE_PROC_TARGET,
           G_PARAM_READWRITE | GST_PARAM_CONTROLLABLE | G_PARAM_STATIC_STRINGS));
 

--- a/ext/tiovx/gsttiovxdlpreproc.c
+++ b/ext/tiovx/gsttiovxdlpreproc.c
@@ -96,7 +96,7 @@
 #define DEFAULT_TIOVX_DL_PRE_PROC_TARGET TIVX_CPU_ID_DSP1
 
 /* Channel order definition */
-#define GST_TIOVX_TYPE_DL_PRE_PROC_CHANNEL_ORDER (gst_tiovx_dl_pre_proc_channel_order_get_type())
+#define GST_TYPE_TIOVX_DL_PRE_PROC_CHANNEL_ORDER (gst_tiovx_dl_pre_proc_channel_order_get_type())
 #define DEFAULT_TIOVX_DL_PRE_PROC_CHANNEL_ORDER TIVX_DL_PRE_PROC_CHANNEL_ORDER_NCHW
 
 /* Data type definition */
@@ -353,7 +353,7 @@ gst_tiovx_dl_pre_proc_class_init (GstTIOVXDLPreProcClass * klass)
   g_object_class_install_property (gobject_class, PROP_CHANNEL_ORDER,
       g_param_spec_enum ("channel-order", "Channel Order",
           "Channel order for the tensor dimensions",
-          GST_TIOVX_TYPE_DL_PRE_PROC_CHANNEL_ORDER,
+          GST_TYPE_TIOVX_DL_PRE_PROC_CHANNEL_ORDER,
           DEFAULT_TIOVX_DL_PRE_PROC_CHANNEL_ORDER,
           G_PARAM_READWRITE | GST_PARAM_CONTROLLABLE | G_PARAM_STATIC_STRINGS));
 

--- a/ext/tiovx/gsttiovxdlpreproc.c
+++ b/ext/tiovx/gsttiovxdlpreproc.c
@@ -100,7 +100,7 @@
 #define DEFAULT_TIOVX_DL_PRE_PROC_CHANNEL_ORDER TIVX_DL_PRE_PROC_CHANNEL_ORDER_NCHW
 
 /* Data type definition */
-#define GST_TIOVX_TYPE_DL_PRE_PROC_DATA_TYPE (gst_tiovx_dl_pre_proc_data_type_get_type())
+#define GST_TYPE_TIOVX_DL_PRE_PROC_DATA_TYPE (gst_tiovx_dl_pre_proc_data_type_get_type())
 #define DEFAULT_TIOVX_DL_PRE_PROC_DATA_TYPE VX_TYPE_FLOAT32
 
 /* Tensor format definition */
@@ -360,7 +360,7 @@ gst_tiovx_dl_pre_proc_class_init (GstTIOVXDLPreProcClass * klass)
   g_object_class_install_property (gobject_class, PROP_DATA_TYPE,
       g_param_spec_enum ("data-type", "Data Type",
           "Data Type of tensor at the output",
-          GST_TIOVX_TYPE_DL_PRE_PROC_DATA_TYPE,
+          GST_TYPE_TIOVX_DL_PRE_PROC_DATA_TYPE,
           DEFAULT_TIOVX_DL_PRE_PROC_DATA_TYPE,
           G_PARAM_READWRITE | GST_PARAM_CONTROLLABLE | G_PARAM_STATIC_STRINGS));
 

--- a/ext/tiovx/gsttiovxdlpreproc.c
+++ b/ext/tiovx/gsttiovxdlpreproc.c
@@ -259,7 +259,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tiovx_dl_pre_proc_debug);
 #define GST_CAT_DEFAULT gst_tiovx_dl_pre_proc_debug
 
 #define gst_tiovx_dl_pre_proc_parent_class parent_class
-G_DEFINE_TYPE (GstTIOVXDLPreProc, gst_tiovx_dl_pre_proc, GST_TIOVX_SISO_TYPE);
+G_DEFINE_TYPE (GstTIOVXDLPreProc, gst_tiovx_dl_pre_proc, GST_TYPE_TIOVX_SISO);
 
 static void gst_tiovx_dl_pre_proc_finalize (GObject * obj);
 

--- a/ext/tiovx/gsttiovxdlpreproc.h
+++ b/ext/tiovx/gsttiovxdlpreproc.h
@@ -79,7 +79,7 @@ G_BEGIN_DECLS
  * Returns: TRUE if @ptr is a TIOVX pre proc
  * 
  */
-#define GST_TYPE_GST_TIOVX_DL_PRE_PROC (gst_tiovx_dl_pre_proc_get_type())
+#define GST_TYPE_TIOVX_DL_PRE_PROC (gst_tiovx_dl_pre_proc_get_type())
 G_DECLARE_FINAL_TYPE(GstTIOVXDLPreProc, gst_tiovx_dl_pre_proc, GST,
                      TIOVX_DL_PRE_PROC, GstTIOVXSiso)
 

--- a/ext/tiovx/gsttiovxmosaic.c
+++ b/ext/tiovx/gsttiovxmosaic.c
@@ -71,10 +71,10 @@
 #include "gst-libs/gst/tiovx/gsttiovxmiso.h"
 #include "gst-libs/gst/tiovx/gsttiovxutils.h"
 
-static const int k_output_param_id = 1;
-static const int k_input_param_id_start = 3;
+static const int output_param_id = 1;
+static const int input_param_id_start = 3;
 
-static const int k_window_downscaling_max_ratio = 4;
+static const int window_downscaling_max_ratio = 4;
 
 /* TIOVX Mosaic Pad */
 
@@ -87,13 +87,13 @@ struct _GstTIOVXMosaicPadClass
   GstTIOVXMisoPadClass parent_class;
 };
 
-static const guint k_min_dim_value = 0;
-static const guint k_max_dim_value = G_MAXUINT32;
-static const guint k_default_dim_value = 0;
+static const guint min_dim_value = 0;
+static const guint max_dim_value = G_MAXUINT32;
+static const guint default_dim_value = 0;
 
-static const guint k_min_start_value = 0;
-static const guint k_max_start_value = G_MAXUINT32;
-static const guint k_default_start_value = 0;
+static const guint min_start_value = 0;
+static const guint max_start_value = G_MAXUINT32;
+static const guint default_start_value = 0;
 
 enum
 {
@@ -137,22 +137,22 @@ gst_tiovx_mosaic_pad_class_init (GstTIOVXMosaicPadClass * klass)
   g_object_class_install_property (gobject_class, PROP_STARTX,
       g_param_spec_uint ("startx", "Start X",
           "Starting X coordinate of the image",
-          k_min_start_value, k_max_start_value, k_default_start_value,
+          min_start_value, max_start_value, default_start_value,
           G_PARAM_READWRITE));
   g_object_class_install_property (gobject_class, PROP_STARTY,
       g_param_spec_uint ("starty", "Start Y",
-          "Starting Y coordinate of the image", k_min_start_value,
-          k_max_start_value, k_default_start_value, G_PARAM_READWRITE));
+          "Starting Y coordinate of the image", min_start_value,
+          max_start_value, default_start_value, G_PARAM_READWRITE));
   g_object_class_install_property (gobject_class, PROP_WIDTH,
       g_param_spec_uint ("width", "Width", "Width of the image.\n"
           "Cannot be smaller than 1/4 of the input width or larger than the input width.\n"
-          "Set to 0 to default to the input width.", k_min_dim_value,
-          k_max_dim_value, k_default_dim_value, G_PARAM_READWRITE));
+          "Set to 0 to default to the input width.", min_dim_value,
+          max_dim_value, default_dim_value, G_PARAM_READWRITE));
   g_object_class_install_property (gobject_class, PROP_HEIGHT,
       g_param_spec_uint ("height", "Height", "Height of the image.\n"
           "Cannot be smaller than 1/4 of the input hieght or larger than the input height.\n"
           "Set to 0 to default to the input height.",
-          k_min_dim_value, k_max_dim_value, k_default_dim_value,
+          min_dim_value, max_dim_value, default_dim_value,
           G_PARAM_READWRITE));
 }
 
@@ -161,10 +161,10 @@ gst_tiovx_mosaic_pad_init (GstTIOVXMosaicPad * self)
 {
   GST_DEBUG_OBJECT (self, "gst_tiovx_mosaic_pad_init");
 
-  self->startx = k_default_start_value;
-  self->starty = k_default_start_value;
-  self->width = k_default_dim_value;
-  self->height = k_default_dim_value;
+  self->startx = default_start_value;
+  self->starty = default_start_value;
+  self->width = default_dim_value;
+  self->height = default_dim_value;
 }
 
 static void
@@ -467,16 +467,16 @@ gst_tiovx_mosaic_check_dimension (GstTIOVXMosaic * self,
     GST_DEBUG_OBJECT (self, "Pad %s is 0, default to image %s: %d",
         dimension_name, dimension_name, dimension_value);
     *output_value = dimension_value;
-  } else if ((input_value >= dimension_value / k_window_downscaling_max_ratio)
+  } else if ((input_value >= dimension_value / window_downscaling_max_ratio)
       && (input_value <= dimension_value)) {
     *output_value = input_value;
-  } else if (input_value < dimension_value / k_window_downscaling_max_ratio) {
+  } else if (input_value < dimension_value / window_downscaling_max_ratio) {
     GST_WARNING_OBJECT (self,
         "Pad %s: %d is less than 1/%d of input %s: %d, setting 1/4 of input %s: %d",
-        dimension_name, input_value, k_window_downscaling_max_ratio,
+        dimension_name, input_value, window_downscaling_max_ratio,
         dimension_name, dimension_value, dimension_name,
-        dimension_value / k_window_downscaling_max_ratio);
-    *output_value = dimension_value / k_window_downscaling_max_ratio;
+        dimension_value / window_downscaling_max_ratio);
+    *output_value = dimension_value / window_downscaling_max_ratio;
   } else if (input_value > dimension_value) {
     GST_WARNING_OBJECT (self,
         "Pad %s: %d is larger than input %s: %d, setting input %s",
@@ -710,13 +710,13 @@ gst_tiovx_mosaic_get_node_info (GstTIOVXMiso * agg,
     gst_tiovx_miso_pad_set_params (pad,
         (vx_reference *) & mosaic->obj.inputs[i].image_handle[0],
         mosaic->obj.inputs[i].graph_parameter_index,
-        k_input_param_id_start + i);
+        input_param_id_start + i);
     i++;
   }
 
   gst_tiovx_miso_pad_set_params (GST_TIOVX_MISO_PAD (src_pad),
       (vx_reference *) & mosaic->obj.output_image[0],
-      mosaic->obj.output_graph_parameter_index, k_output_param_id);
+      mosaic->obj.output_graph_parameter_index, output_param_id);
 
   if (background_pad) {
     /* Background image isn't queued/dequeued use -1 to skip it */

--- a/ext/tiovx/gsttiovxmosaic.c
+++ b/ext/tiovx/gsttiovxmosaic.c
@@ -326,7 +326,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tiovx_mosaic_debug);
 
 #define gst_tiovx_mosaic_parent_class parent_class
 G_DEFINE_TYPE_WITH_CODE (GstTIOVXMosaic, gst_tiovx_mosaic,
-    GST_TIOVX_MISO_TYPE, GST_DEBUG_CATEGORY_INIT (gst_tiovx_mosaic_debug,
+    GST_TYPE_TIOVX_MISO, GST_DEBUG_CATEGORY_INIT (gst_tiovx_mosaic_debug,
         "tiovxmosaic", 0, "debug category for the tiovxmosaic element"));
 
 static const gchar *target_id_to_target_name (gint target_id);

--- a/ext/tiovx/gsttiovxmosaic.c
+++ b/ext/tiovx/gsttiovxmosaic.c
@@ -78,7 +78,7 @@ static const int k_window_downscaling_max_ratio = 4;
 
 /* TIOVX Mosaic Pad */
 
-#define GST_TIOVX_TYPE_MOSAIC_PAD (gst_tiovx_mosaic_pad_get_type())
+#define GST_TYPE_TIOVX_MOSAIC_PAD (gst_tiovx_mosaic_pad_get_type())
 G_DECLARE_FINAL_TYPE (GstTIOVXMosaicPad, gst_tiovx_mosaic_pad,
     GST_TIOVX, MOSAIC_PAD, GstTIOVXMisoPad);
 
@@ -378,7 +378,7 @@ gst_tiovx_mosaic_class_init (GstTIOVXMosaicClass * klass)
       &src_template, GST_TYPE_TIOVX_MISO_PAD);
 
   gst_element_class_add_static_pad_template_with_gtype (gstelement_class,
-      &sink_template, GST_TIOVX_TYPE_MOSAIC_PAD);
+      &sink_template, GST_TYPE_TIOVX_MOSAIC_PAD);
 
   gst_element_class_add_static_pad_template_with_gtype (gstelement_class,
       &background_template, GST_TYPE_TIOVX_MISO_PAD);

--- a/ext/tiovx/gsttiovxmosaic.h
+++ b/ext/tiovx/gsttiovxmosaic.h
@@ -81,7 +81,7 @@ G_BEGIN_DECLS
  * Returns: TRUE if @ptr is a TIOVX mosaic
  * 
  */
-#define GST_TYPE_GST_TIOVX_MOSAIC (gst_tiovx_mosaic_get_type())
+#define GST_TYPE_TIOVX_MOSAIC (gst_tiovx_mosaic_get_type())
 G_DECLARE_FINAL_TYPE(GstTIOVXMosaic, gst_tiovx_mosaic, GST,
                      TIOVX_MOSAIC, GstTIOVXMiso)
 

--- a/ext/tiovx/gsttiovxmultiscaler.c
+++ b/ext/tiovx/gsttiovxmultiscaler.c
@@ -248,12 +248,12 @@ gst_tiovx_multi_scaler_class_init (GstTIOVXMultiScalerClass * klass)
 
   src_temp =
       gst_pad_template_new_from_static_pad_template_with_gtype (&src_template,
-      GST_TIOVX_TYPE_MULTISCALER_PAD);
+      GST_TYPE_TIOVX_MULTISCALER_PAD);
   gst_element_class_add_pad_template (gstelement_class, src_temp);
 
   sink_temp =
       gst_pad_template_new_from_static_pad_template_with_gtype (&sink_template,
-      GST_TIOVX_TYPE_MULTISCALER_PAD);
+      GST_TYPE_TIOVX_MULTISCALER_PAD);
   gst_element_class_add_pad_template (gstelement_class, sink_temp);
 
   gobject_class->set_property = gst_tiovx_multi_scaler_set_property;

--- a/ext/tiovx/gsttiovxmultiscaler.c
+++ b/ext/tiovx/gsttiovxmultiscaler.c
@@ -184,7 +184,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tiovx_multi_scaler_debug);
 
 #define gst_tiovx_multi_scaler_parent_class parent_class
 G_DEFINE_TYPE_WITH_CODE (GstTIOVXMultiScaler, gst_tiovx_multi_scaler,
-    GST_TIOVX_SIMO_TYPE, GST_DEBUG_CATEGORY_INIT (gst_tiovx_multi_scaler_debug,
+    GST_TYPE_TIOVX_SIMO, GST_DEBUG_CATEGORY_INIT (gst_tiovx_multi_scaler_debug,
         "tiovxmultiscaler", 0,
         "debug category for the tiovxmultiscaler element"));
 

--- a/ext/tiovx/gsttiovxmultiscaler.h
+++ b/ext/tiovx/gsttiovxmultiscaler.h
@@ -81,7 +81,7 @@ G_BEGIN_DECLS
  * Returns: TRUE if @ptr is a TIOVX multiscaler
  * 
  */
-#define GST_TYPE_GST_TIOVX_MULTI_SCALER (gst_tiovx_multi_scaler_get_type())
+#define GST_TYPE_TIOVX_MULTI_SCALER (gst_tiovx_multi_scaler_get_type())
 G_DECLARE_FINAL_TYPE(GstTIOVXMultiScaler, gst_tiovx_multi_scaler, GST,
                      TIOVX_MULTI_SCALER, GstTIOVXSimo)
 

--- a/ext/tiovx/gsttiovxmultiscalerpad.c
+++ b/ext/tiovx/gsttiovxmultiscalerpad.c
@@ -88,7 +88,7 @@ GST_DEBUG_CATEGORY_STATIC (gst_tiovx_multiscaler_pad_debug_category);
 #define GST_CAT_DEFAULT gst_tiovx_multiscaler_pad_debug_category
 
 G_DEFINE_TYPE_WITH_CODE (GstTIOVXMultiScalerPad, gst_tiovx_multiscaler_pad,
-    GST_TIOVX_TYPE_PAD,
+    GST_TYPE_TIOVX_PAD,
     GST_DEBUG_CATEGORY_INIT (gst_tiovx_multiscaler_pad_debug_category,
         "tiovxmultiscalerpad", 0,
         "debug category for TIOVX multiscaler pad class"));

--- a/ext/tiovx/gsttiovxmultiscalerpad.h
+++ b/ext/tiovx/gsttiovxmultiscalerpad.h
@@ -79,7 +79,7 @@ G_BEGIN_DECLS
  * Returns: TRUE if @ptr is a TIOVX multiscaler pad
  * 
  */
-#define GST_TIOVX_TYPE_MULTISCALER_PAD (gst_tiovx_multiscaler_pad_get_type())
+#define GST_TYPE_TIOVX_MULTISCALER_PAD (gst_tiovx_multiscaler_pad_get_type())
 G_DECLARE_FINAL_TYPE (GstTIOVXMultiScalerPad, gst_tiovx_multiscaler_pad,
     GST_TIOVX, MULTISCALER_PAD, GstTIOVXPad)
 

--- a/ext/tiovx/gsttiovxmultiscalerpad.h
+++ b/ext/tiovx/gsttiovxmultiscalerpad.h
@@ -81,7 +81,7 @@ G_BEGIN_DECLS
  */
 #define GST_TYPE_TIOVX_MULTISCALER_PAD (gst_tiovx_multiscaler_pad_get_type())
 G_DECLARE_FINAL_TYPE (GstTIOVXMultiScalerPad, gst_tiovx_multiscaler_pad,
-    GST_TIOVX, MULTISCALER_PAD, GstTIOVXPad)
+    GST, TIOVX_MULTISCALER_PAD, GstTIOVXPad)
 
 struct _GstTIOVXMultiScalerPadClass
 {

--- a/gst-libs/gst/tiovx/gsttiovxallocator.c
+++ b/gst-libs/gst/tiovx/gsttiovxallocator.c
@@ -112,11 +112,7 @@ gst_tiovx_memory_get_data (GstMemory * memory)
 static void
 gst_tiovx_allocator_class_init (GstTIOVXAllocatorClass * klass)
 {
-  GstAllocatorClass *allocator_class = NULL;
-
-  g_return_if_fail (klass);
-
-  allocator_class = GST_ALLOCATOR_CLASS (klass);
+  GstAllocatorClass *allocator_class = GST_ALLOCATOR_CLASS (klass);
 
   allocator_class->alloc = GST_DEBUG_FUNCPTR (gst_tiovx_allocator_alloc);
   allocator_class->free = GST_DEBUG_FUNCPTR (gst_tiovx_allocator_free);
@@ -127,11 +123,7 @@ gst_tiovx_allocator_class_init (GstTIOVXAllocatorClass * klass)
 static void
 gst_tiovx_allocator_init (GstTIOVXAllocator * self)
 {
-  GstAllocator *allocator = NULL;
-
-  g_return_if_fail (self);
-
-  allocator = GST_ALLOCATOR_CAST (self);
+  GstAllocator *allocator = GST_ALLOCATOR_CAST (self);
 
   GST_INFO_OBJECT (self, "New TIOVX allocator");
 
@@ -145,7 +137,7 @@ gst_tiovx_allocator_mem_free (gpointer mem)
 
   /* Avoid freeing NULL pointer */
   if (NULL == mem) {
-      return;
+    return;
   }
 
   ti_memory = (GstTIOVXMemoryData *) mem;

--- a/gst-libs/gst/tiovx/gsttiovxallocator.c
+++ b/gst-libs/gst/tiovx/gsttiovxallocator.c
@@ -144,7 +144,7 @@ gst_tiovx_allocator_mem_free (gpointer mem)
   GstTIOVXMemoryData *ti_memory = NULL;
 
   /* Avoid freeing NULL pointer */
-  if (!mem) {
+  if (NULL == mem) {
       return;
   }
 

--- a/gst-libs/gst/tiovx/gsttiovxallocator.c
+++ b/gst-libs/gst/tiovx/gsttiovxallocator.c
@@ -98,7 +98,7 @@ static void gst_tiovx_allocator_mem_free (gpointer mem);
 GstTIOVXMemoryData *
 gst_tiovx_memory_get_data (GstMemory * memory)
 {
-  GstTIOVXMemoryData *ti_memory;
+  GstTIOVXMemoryData *ti_memory = NULL;
 
   g_return_val_if_fail (memory, NULL);
 
@@ -112,7 +112,11 @@ gst_tiovx_memory_get_data (GstMemory * memory)
 static void
 gst_tiovx_allocator_class_init (GstTIOVXAllocatorClass * klass)
 {
-  GstAllocatorClass *allocator_class = GST_ALLOCATOR_CLASS (klass);
+  GstAllocatorClass *allocator_class = NULL;
+
+  g_return_if_fail (klass);
+
+  allocator_class = GST_ALLOCATOR_CLASS (klass);
 
   allocator_class->alloc = GST_DEBUG_FUNCPTR (gst_tiovx_allocator_alloc);
   allocator_class->free = GST_DEBUG_FUNCPTR (gst_tiovx_allocator_free);
@@ -123,7 +127,11 @@ gst_tiovx_allocator_class_init (GstTIOVXAllocatorClass * klass)
 static void
 gst_tiovx_allocator_init (GstTIOVXAllocator * self)
 {
-  GstAllocator *allocator = GST_ALLOCATOR_CAST (self);
+  GstAllocator *allocator = NULL;
+
+  g_return_if_fail (self);
+
+  allocator = GST_ALLOCATOR_CAST (self);
 
   GST_INFO_OBJECT (self, "New TIOVX allocator");
 
@@ -135,7 +143,10 @@ gst_tiovx_allocator_mem_free (gpointer mem)
 {
   GstTIOVXMemoryData *ti_memory = NULL;
 
-  g_return_if_fail (mem);
+  /* Avoid freeing NULL pointer */
+  if (!mem) {
+      return;
+  }
 
   ti_memory = (GstTIOVXMemoryData *) mem;
 

--- a/gst-libs/gst/tiovx/gsttiovxallocator.h
+++ b/gst-libs/gst/tiovx/gsttiovxallocator.h
@@ -68,7 +68,7 @@
 
 G_BEGIN_DECLS
 
-#define GST_TIOVX_TYPE_ALLOCATOR gst_tiovx_allocator_get_type ()
+#define GST_TYPE_TIOVX_ALLOCATOR gst_tiovx_allocator_get_type ()
 
 /**
  * GstDmaBufAllocator:

--- a/gst-libs/gst/tiovx/gsttiovxbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxbufferpool.c
@@ -127,7 +127,7 @@ gst_tiovx_buffer_pool_class_init (GstTIOVXBufferPoolClass * klass)
 static void
 gst_tiovx_buffer_pool_init (GstTIOVXBufferPool * self)
 {
-    g_return_if_fail (self);
+  g_return_if_fail (self);
 
   GST_INFO_OBJECT (self, "New TIOVX buffer pool");
 

--- a/gst-libs/gst/tiovx/gsttiovxbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxbufferpool.c
@@ -228,7 +228,7 @@ gst_tiovx_buffer_pool_set_config (GstBufferPool * pool, GstStructure * config)
 
   gst_buffer_pool_config_get_allocator (config, &allocator, NULL);
   if (NULL == allocator) {
-    allocator = g_object_new (GST_TIOVX_TYPE_ALLOCATOR, NULL);
+    allocator = g_object_new (GST_TYPE_TIOVX_ALLOCATOR, NULL);
     gst_buffer_pool_config_set_allocator (config,
         GST_ALLOCATOR (allocator), NULL);
   } else if (!GST_TIOVX_IS_ALLOCATOR (allocator)) {

--- a/gst-libs/gst/tiovx/gsttiovxbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxbufferpool.c
@@ -340,7 +340,7 @@ gst_tiovx_buffer_pool_free_buffer (GstBufferPool * pool, GstBuffer * buffer)
   vx_reference ref = NULL;
 
   tiovxmeta =
-      (GstTIOVXMeta *) gst_buffer_get_meta (buffer, GST_TIOVX_META_API_TYPE);
+      (GstTIOVXMeta *) gst_buffer_get_meta (buffer, GST_TYPE_TIOVX_META_API);
   if (NULL != tiovxmeta) {
     if (NULL != tiovxmeta->array) {
       /* We currently support a single channel */

--- a/gst-libs/gst/tiovx/gsttiovxbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxbufferpool.c
@@ -183,8 +183,6 @@ gst_tiovx_buffer_pool_set_config (GstBufferPool * pool, GstStructure * config)
   guint max_buffers = 0;
   guint size = 0;
 
-  self = GST_TIOVX_BUFFER_POOL (pool);
-
   if (!gst_buffer_pool_config_get_params (config, &caps, &size, &min_buffers,
           &max_buffers)) {
     GST_ERROR_OBJECT (self, "Error getting parameters from buffer pool config");

--- a/gst-libs/gst/tiovx/gsttiovxbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxbufferpool.c
@@ -108,13 +108,8 @@ static void gst_tiovx_buffer_pool_finalize (GObject * object);
 static void
 gst_tiovx_buffer_pool_class_init (GstTIOVXBufferPoolClass * klass)
 {
-  GObjectClass *o_class = NULL;
-  GstBufferPoolClass *bp_class = NULL;
-
-  g_return_if_fail (klass);
-
-  o_class = G_OBJECT_CLASS (klass);
-  bp_class = GST_BUFFER_POOL_CLASS (klass);
+  GObjectClass *o_class = G_OBJECT_CLASS (klass);
+  GstBufferPoolClass *bp_class = GST_BUFFER_POOL_CLASS (klass);
 
   o_class->finalize = gst_tiovx_buffer_pool_finalize;
 
@@ -127,8 +122,6 @@ gst_tiovx_buffer_pool_class_init (GstTIOVXBufferPoolClass * klass)
 static void
 gst_tiovx_buffer_pool_init (GstTIOVXBufferPool * self)
 {
-  g_return_if_fail (self);
-
   GST_INFO_OBJECT (self, "New TIOVX buffer pool");
 
   self->allocator = NULL;
@@ -181,7 +174,7 @@ out:
 static gboolean
 gst_tiovx_buffer_pool_set_config (GstBufferPool * pool, GstStructure * config)
 {
-  GstTIOVXBufferPool *self = NULL;
+  GstTIOVXBufferPool *self = GST_TIOVX_BUFFER_POOL (pool);
   GstAllocator *allocator = NULL;
   vx_reference exemplar = NULL;
   vx_status status = VX_FAILURE;
@@ -189,8 +182,6 @@ gst_tiovx_buffer_pool_set_config (GstBufferPool * pool, GstStructure * config)
   guint min_buffers = 0;
   guint max_buffers = 0;
   guint size = 0;
-
-  g_return_val_if_fail (pool, FALSE);
 
   self = GST_TIOVX_BUFFER_POOL (pool);
 
@@ -267,7 +258,7 @@ static GstFlowReturn
 gst_tiovx_buffer_pool_alloc_buffer (GstBufferPool * pool, GstBuffer ** buffer,
     GstBufferPoolAcquireParams * params)
 {
-  GstTIOVXBufferPool *self = NULL;
+  GstTIOVXBufferPool *self = GST_TIOVX_BUFFER_POOL (pool);
   GstFlowReturn ret = GST_FLOW_ERROR;
   GstBuffer *outbuf = NULL;
   GstMemory *outmem = NULL;
@@ -275,10 +266,6 @@ gst_tiovx_buffer_pool_alloc_buffer (GstBufferPool * pool, GstBuffer ** buffer,
   GstTIOVXMeta *tiovxmeta = NULL;
   GstTIOVXMemoryData *ti_memory = NULL;
   vx_size img_size = 0;
-
-  g_return_val_if_fail (pool, GST_FLOW_ERROR);
-
-  self = GST_TIOVX_BUFFER_POOL (pool);
 
   GST_DEBUG_OBJECT (self, "Allocating TIOVX buffer");
 

--- a/gst-libs/gst/tiovx/gsttiovxbufferpool.h
+++ b/gst-libs/gst/tiovx/gsttiovxbufferpool.h
@@ -71,7 +71,7 @@
 
 G_BEGIN_DECLS 
 
-#define GST_TIOVX_TYPE_BUFFER_POOL gst_tiovx_buffer_pool_get_type ()
+#define GST_TYPE_TIOVX_BUFFER_POOL gst_tiovx_buffer_pool_get_type ()
 
 /**
  * GST_TIOVX_IS_BUFFER_POOL:

--- a/gst-libs/gst/tiovx/gsttiovxcontext.c
+++ b/gst-libs/gst/tiovx/gsttiovxcontext.c
@@ -95,7 +95,11 @@ gst_tiovx_context_new (void)
 static void
 gst_tiovx_context_class_init (GstTIOVXContextClass * klass)
 {
-  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GObjectClass *gobject_class = NULL;
+
+  g_return_if_fail (klass);
+
+  gobject_class = G_OBJECT_CLASS (klass);
 
   gobject_class->constructor = gst_tiovx_context_constructor;
   gobject_class->finalize = gst_tiovx_context_finalize;
@@ -132,6 +136,8 @@ gst_tiovx_context_init (GstTIOVXContext * self)
   gint init_flag = 1;
   const gchar *strVal = NULL;
 
+  g_return_if_fail (self);
+
   strVal = g_getenv ("SKIP_TIOVX_INIT");
 
   if (strVal != NULL) {
@@ -153,6 +159,8 @@ gst_tiovx_context_finalize (GObject * object)
   gint ret = 0;
   gint init_flag = 1;
   const gchar *strVal = NULL;
+
+  g_return_if_fail (object);
 
   strVal = g_getenv ("SKIP_TIOVX_INIT");
 

--- a/gst-libs/gst/tiovx/gsttiovxcontext.c
+++ b/gst-libs/gst/tiovx/gsttiovxcontext.c
@@ -95,11 +95,7 @@ gst_tiovx_context_new (void)
 static void
 gst_tiovx_context_class_init (GstTIOVXContextClass * klass)
 {
-  GObjectClass *gobject_class = NULL;
-
-  g_return_if_fail (klass);
-
-  gobject_class = G_OBJECT_CLASS (klass);
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
   gobject_class->constructor = gst_tiovx_context_constructor;
   gobject_class->finalize = gst_tiovx_context_finalize;
@@ -136,8 +132,6 @@ gst_tiovx_context_init (GstTIOVXContext * self)
   gint init_flag = 1;
   const gchar *strVal = NULL;
 
-  g_return_if_fail (self);
-
   strVal = g_getenv ("SKIP_TIOVX_INIT");
 
   if (strVal != NULL) {
@@ -148,7 +142,7 @@ gst_tiovx_context_init (GstTIOVXContext * self)
   }
 
   if (init_flag == 1) {
-    ret = appInit();
+    ret = appInit ();
     g_assert (0 == ret);
   }
 }
@@ -159,8 +153,6 @@ gst_tiovx_context_finalize (GObject * object)
   gint ret = 0;
   gint init_flag = 1;
   const gchar *strVal = NULL;
-
-  g_return_if_fail (object);
 
   strVal = g_getenv ("SKIP_TIOVX_INIT");
 
@@ -174,7 +166,7 @@ gst_tiovx_context_finalize (GObject * object)
   if (init_flag == 1) {
     g_mutex_lock (&mutex);
 
-    ret = appDeInit();
+    ret = appDeInit ();
     g_assert (0 == ret);
 
     singleton = NULL;

--- a/gst-libs/gst/tiovx/gsttiovxcontext.c
+++ b/gst-libs/gst/tiovx/gsttiovxcontext.c
@@ -89,7 +89,7 @@ static void gst_tiovx_context_finalize (GObject * object);
 GstTIOVXContext *
 gst_tiovx_context_new (void)
 {
-  return GST_TIOVX_CONTEXT (g_object_new (GST_TIOVX_TYPE_CONTEXT, NULL));
+  return GST_TIOVX_CONTEXT (g_object_new (GST_TYPE_TIOVX_CONTEXT, NULL));
 }
 
 static void

--- a/gst-libs/gst/tiovx/gsttiovxcontext.h
+++ b/gst-libs/gst/tiovx/gsttiovxcontext.h
@@ -66,7 +66,7 @@
 
 G_BEGIN_DECLS 
 
-#define GST_TIOVX_TYPE_CONTEXT gst_tiovx_context_get_type ()
+#define GST_TYPE_TIOVX_CONTEXT gst_tiovx_context_get_type ()
 
 /**
  * GST_TIOVX_IS_CONTEXT:

--- a/gst-libs/gst/tiovx/gsttiovxmeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxmeta.c
@@ -161,9 +161,15 @@ gst_buffer_add_tiovx_meta (GstBuffer * buffer, const vx_reference exemplar,
   vx_df_image vx_format = VX_DF_IMAGE_VIRT;
   vx_status status;
 
-  g_return_val_if_fail (buffer, NULL);
-  g_return_val_if_fail (VX_SUCCESS == vxGetStatus ((vx_reference) exemplar),
-      NULL);
+  if (NULL == buffer) {
+    GST_ERROR_OBJECT (buffer, "Cannot add meta, invalid buffer pointer");
+    goto out;
+  }
+
+  if (VX_SUCCESS != vxGetStatus ((vx_reference) exemplar)) {
+    GST_ERROR_OBJECT (buffer, "Cannot add meta, invalid exemplar reference");
+    goto out;
+  }
 
   /* Get plane and size information */
   tivxReferenceExportHandle ((vx_reference) exemplar,

--- a/gst-libs/gst/tiovx/gsttiovxmeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxmeta.c
@@ -92,7 +92,7 @@ gst_tiovx_meta_get_info (void)
   static const GstMetaInfo *info = NULL;
 
   if (g_once_init_enter (&info)) {
-    const GstMetaInfo *meta = gst_meta_register (GST_TIOVX_META_API_TYPE,
+    const GstMetaInfo *meta = gst_meta_register (GST_TYPE_TIOVX_META_API,
         "GstTIOVXMeta",
         sizeof (GstTIOVXMeta),
         gst_tiovx_meta_init,

--- a/gst-libs/gst/tiovx/gsttiovxmeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxmeta.c
@@ -67,7 +67,7 @@
 
 #include "gsttiovxutils.h"
 
-static const vx_size k_tiovx_array_lenght = 1;
+static const vx_size tiovx_array_lenght = 1;
 
 static gboolean gst_tiovx_meta_init (GstMeta * meta,
     gpointer params, GstBuffer * buffer);
@@ -180,7 +180,7 @@ gst_buffer_add_tiovx_meta (GstBuffer * buffer, const vx_reference exemplar,
 
   array =
       vxCreateObjectArray (vxGetContext (exemplar), exemplar,
-      k_tiovx_array_lenght);
+      tiovx_array_lenght);
 
   /* Import memory into the meta's vx reference */
   ref = (vx_image) vxGetObjectArrayItem (array, 0);

--- a/gst-libs/gst/tiovx/gsttiovxmeta.h
+++ b/gst-libs/gst/tiovx/gsttiovxmeta.h
@@ -70,7 +70,7 @@
 
 G_BEGIN_DECLS 
 
-#define GST_TIOVX_META_API_TYPE (gst_tiovx_meta_api_get_type())
+#define GST_TYPE_TIOVX_META_API (gst_tiovx_meta_api_get_type())
 #define GST_TIOVX_META_INFO  (gst_tiovx_meta_get_info())
 
 /**

--- a/gst-libs/gst/tiovx/gsttiovxmiso.c
+++ b/gst-libs/gst/tiovx/gsttiovxmiso.c
@@ -1303,8 +1303,7 @@ could_not_create:
 static void
 gst_tiovx_miso_release_pad (GstElement * element, GstPad * pad)
 {
-  GstTIOVXMiso *miso;
-  miso = GST_TIOVX_MISO (element);
+  GstTIOVXMiso *miso = GST_TIOVX_MISO (element);
   GST_DEBUG_OBJECT (miso, "release pad %s:%s", GST_DEBUG_PAD_NAME (pad));
   gst_child_proxy_child_removed (GST_CHILD_PROXY (miso), G_OBJECT (pad),
       GST_OBJECT_NAME (pad));

--- a/gst-libs/gst/tiovx/gsttiovxmiso.c
+++ b/gst-libs/gst/tiovx/gsttiovxmiso.c
@@ -1267,9 +1267,6 @@ gst_tiovx_miso_sink_event (GstAggregator * agg,
   GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
   GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
 
-  g_return_val_if_fail (agg, FALSE);
-  g_return_val_if_fail (agg_pad, FALSE);
-
   switch (GST_EVENT_TYPE (event)) {
     case GST_EVENT_EOS:
     {

--- a/gst-libs/gst/tiovx/gsttiovxmiso.c
+++ b/gst-libs/gst/tiovx/gsttiovxmiso.c
@@ -111,13 +111,8 @@ static void
 gst_tiovx_miso_pad_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXMisoPad *pad = NULL;
-  GstTIOVXMisoPadPrivate *priv = NULL;
-
-  g_return_if_fail (object);
-
-  pad = GST_TIOVX_MISO_PAD (object);
-  priv = gst_tiovx_miso_pad_get_instance_private (pad);
+  GstTIOVXMisoPad *pad = GST_TIOVX_MISO_PAD (object);
+  GstTIOVXMisoPadPrivate *priv = gst_tiovx_miso_pad_get_instance_private (pad);
 
   GST_OBJECT_LOCK (pad);
   switch (prop_id) {
@@ -135,13 +130,8 @@ static void
 gst_tiovx_miso_pad_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXMisoPad *pad = NULL;
-  GstTIOVXMisoPadPrivate *priv = NULL;
-
-  g_return_if_fail (object);
-
-  pad = GST_TIOVX_MISO_PAD (object);
-  priv = gst_tiovx_miso_pad_get_instance_private (pad);
+  GstTIOVXMisoPad *pad = GST_TIOVX_MISO_PAD (object);
+  GstTIOVXMisoPadPrivate *priv = gst_tiovx_miso_pad_get_instance_private (pad);
 
   GST_OBJECT_LOCK (pad);
   switch (prop_id) {
@@ -158,13 +148,8 @@ gst_tiovx_miso_pad_set_property (GObject * object, guint prop_id,
 static void
 gst_tiovx_miso_pad_finalize (GObject * obj)
 {
-  GstTIOVXMisoPad *self = NULL;
-  GstTIOVXMisoPadPrivate *priv = NULL;
-
-  g_return_if_fail (obj);
-
-  self = GST_TIOVX_MISO_PAD (obj);
-  priv = gst_tiovx_miso_pad_get_instance_private (self);
+  GstTIOVXMisoPad *self = GST_TIOVX_MISO_PAD (obj);
+  GstTIOVXMisoPadPrivate *priv = gst_tiovx_miso_pad_get_instance_private (self);
 
   if (priv->exemplar) {
     vxReleaseReference (priv->exemplar);
@@ -180,11 +165,7 @@ gst_tiovx_miso_pad_finalize (GObject * obj)
 static void
 gst_tiovx_miso_pad_class_init (GstTIOVXMisoPadClass * klass)
 {
-  GObjectClass *gobject_class = NULL;
-
-  g_return_if_fail (klass);
-
-  gobject_class = (GObjectClass *) klass;
+  GObjectClass *gobject_class = (GObjectClass *) klass;
 
   gobject_class->set_property = gst_tiovx_miso_pad_set_property;
   gobject_class->get_property = gst_tiovx_miso_pad_get_property;
@@ -200,11 +181,8 @@ gst_tiovx_miso_pad_class_init (GstTIOVXMisoPadClass * klass)
 static void
 gst_tiovx_miso_pad_init (GstTIOVXMisoPad * tiovx_miso_pad)
 {
-  GstTIOVXMisoPadPrivate *priv = NULL;
-
-  g_return_if_fail (tiovx_miso_pad);
-
-  priv = gst_tiovx_miso_pad_get_instance_private (tiovx_miso_pad);
+  GstTIOVXMisoPadPrivate *priv =
+      gst_tiovx_miso_pad_get_instance_private (tiovx_miso_pad);
 
   priv->pool_size = DEFAULT_POOL_SIZE;
   priv->graph_param_id = -1;
@@ -297,15 +275,9 @@ static void gst_tiovx_miso_release_pad (GstElement * element, GstPad * pad);
 static void
 gst_tiovx_miso_class_init (GstTIOVXMisoClass * klass)
 {
-  GstElementClass *gstelement_class = NULL;
-  GstAggregatorClass *aggregator_class = NULL;
-  GObjectClass *gobject_class = NULL;
-
-  g_return_if_fail (klass);
-
-  gstelement_class = GST_ELEMENT_CLASS (klass);
-  aggregator_class = GST_AGGREGATOR_CLASS (klass);
-  gobject_class = (GObjectClass *) klass;
+  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
+  GstAggregatorClass *aggregator_class = GST_AGGREGATOR_CLASS (klass);
+  GObjectClass *gobject_class = (GObjectClass *) klass;
 
   gobject_class->finalize = GST_DEBUG_FUNCPTR (gst_tiovx_miso_finalize);
 
@@ -340,11 +312,7 @@ gst_tiovx_miso_class_init (GstTIOVXMisoClass * klass)
 static void
 gst_tiovx_miso_init (GstTIOVXMiso * self)
 {
-  GstTIOVXMisoPrivate *priv = NULL;
-
-  g_return_if_fail (self);
-
-  priv = gst_tiovx_miso_get_instance_private (self);
+  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
 
   priv->context = NULL;
   priv->graph = NULL;
@@ -360,13 +328,8 @@ gst_tiovx_miso_init (GstTIOVXMiso * self)
 static void
 gst_tiovx_miso_finalize (GObject * obj)
 {
-  GstTIOVXMiso *self = NULL;
-  GstTIOVXMisoPrivate *priv = NULL;
-
-  g_return_if_fail (obj);
-
-  self = GST_TIOVX_MISO (obj);
-  priv = gst_tiovx_miso_get_instance_private (self);
+  GstTIOVXMiso *self = GST_TIOVX_MISO (obj);
+  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "finalize");
 
@@ -403,7 +366,8 @@ gst_tiovx_miso_buffer_to_valid_pad_exemplar (GstTIOVXMisoPad * pad,
   priv = gst_tiovx_miso_pad_get_instance_private (pad);
 
   if (NULL == buffer) {
-    GST_ERROR_OBJECT (pad, "Unable to validate pad exemplar, invalid buffer pointer");
+    GST_ERROR_OBJECT (pad,
+        "Unable to validate pad exemplar, invalid buffer pointer");
     goto exit;
   }
 
@@ -543,19 +507,14 @@ exit:
 static GstFlowReturn
 gst_tiovx_miso_aggregate (GstAggregator * agg, gboolean timeout)
 {
-  GstTIOVXMiso *self = NULL;
-  GstTIOVXMisoPrivate *priv = NULL;
+  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
+  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
   GstBuffer *outbuf = NULL;
   GstFlowReturn ret = GST_FLOW_ERROR;
   GList *l = NULL;
   GstClockTime pts = GST_CLOCK_TIME_NONE;
   GstClockTime dts = GST_CLOCK_TIME_NONE;
   GstClockTime duration = 0;
-
-  g_return_val_if_fail (agg, ret);
-
-  self = GST_TIOVX_MISO (agg);
-  priv = gst_tiovx_miso_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "TIOVX Miso aggregate");
 
@@ -648,8 +607,7 @@ exit:
 }
 
 static GstFlowReturn
-gst_tiovx_miso_create_output_buffer (GstTIOVXMiso * self,
-    GstBuffer ** outbuf)
+gst_tiovx_miso_create_output_buffer (GstTIOVXMiso * self, GstBuffer ** outbuf)
 {
   GstAggregator *aggregator = NULL;
   GstBufferPool *pool;
@@ -686,8 +644,8 @@ static gboolean
 gst_tiovx_miso_propose_allocation (GstAggregator * agg,
     GstAggregatorPad * agg_pad, GstQuery * decide_query, GstQuery * query)
 {
-  GstTIOVXMiso *self = NULL;
-  GstTIOVXMisoPad *tiovx_miso_pad = NULL;
+  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
+  GstTIOVXMisoPad *tiovx_miso_pad = GST_TIOVX_MISO_PAD (agg_pad);
   GstTIOVXMisoPadPrivate *pad_priv = NULL;
   GstTIOVXMisoClass *klass = NULL;
   GstBufferPool *pool = NULL;
@@ -695,12 +653,6 @@ gst_tiovx_miso_propose_allocation (GstAggregator * agg,
   vx_reference reference = NULL;
   gsize size = 0;
   gboolean ret = FALSE;
-
-  g_return_val_if_fail (agg, ret);
-  g_return_val_if_fail (agg_pad, ret);
-
-  self = GST_TIOVX_MISO (agg);
-  tiovx_miso_pad = GST_TIOVX_MISO_PAD (agg_pad);
 
   GST_LOG_OBJECT (self, "Propose allocation");
 
@@ -749,14 +701,10 @@ exit:
 static gboolean
 gst_tiovx_miso_decide_allocation (GstAggregator * agg, GstQuery * query)
 {
-  GstTIOVXMiso *self = NULL;
+  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
   gboolean ret = TRUE;
   gint npool = 0;
   gboolean pool_needed = TRUE;
-
-  g_return_val_if_fail (agg, ret);
-
-  self = GST_TIOVX_MISO (agg);
 
   GST_LOG_OBJECT (self, "Decide allocation");
 
@@ -819,14 +767,9 @@ gst_tiovx_miso_decide_allocation (GstAggregator * agg, GstQuery * query)
 static gboolean
 gst_tiovx_miso_start (GstAggregator * agg)
 {
-  GstTIOVXMiso *self = NULL;
-  GstTIOVXMisoPrivate *priv = NULL;
+  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
+  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
   gboolean ret = FALSE;
-
-  g_return_val_if_fail (agg, ret);
-
-  self = GST_TIOVX_MISO (agg);
-  priv = gst_tiovx_miso_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "start");
 
@@ -848,18 +791,12 @@ gst_tiovx_miso_start (GstAggregator * agg)
 static gboolean
 gst_tiovx_miso_stop (GstAggregator * agg)
 {
-  GstTIOVXMiso *self = NULL;
-  GstTIOVXMisoClass *klass = NULL;
-  GstTIOVXMisoPrivate *priv = NULL;
+  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
+  GstTIOVXMisoClass *klass = GST_TIOVX_MISO_GET_CLASS (agg);
+  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
   GstTIOVXMisoPadPrivate *pad_priv = NULL;
   GList *sink_pad_list = NULL;
   gboolean ret = FALSE;
-
-  g_return_val_if_fail (agg, ret);
-
-  self = GST_TIOVX_MISO (agg);
-  priv = gst_tiovx_miso_get_instance_private (self);
-  klass = GST_TIOVX_MISO_GET_CLASS (agg);
 
   GST_DEBUG_OBJECT (self, "stop");
 
@@ -1205,10 +1142,6 @@ gst_tiovx_miso_negotiated_src_caps (GstAggregator * agg, GstCaps * caps)
   gboolean ret = FALSE;
   GList *l = NULL;
 
-  g_return_val_if_fail (agg, ret);
-
-  self = GST_TIOVX_MISO (agg);
-
   GST_DEBUG_OBJECT (self, "Negotiated src caps");
 
   /* We are calling this manually to ensure that during module initialization
@@ -1331,14 +1264,11 @@ static gboolean
 gst_tiovx_miso_sink_event (GstAggregator * agg,
     GstAggregatorPad * agg_pad, GstEvent * event)
 {
-  GstTIOVXMiso *self = NULL;
-  GstTIOVXMisoPrivate *priv = NULL;
+  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
+  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
 
   g_return_val_if_fail (agg, FALSE);
   g_return_val_if_fail (agg_pad, FALSE);
-
-  self = GST_TIOVX_MISO (agg);
-  priv = gst_tiovx_miso_get_instance_private (self);
 
   switch (GST_EVENT_TYPE (event)) {
     case GST_EVENT_EOS:

--- a/gst-libs/gst/tiovx/gsttiovxmiso.c
+++ b/gst-libs/gst/tiovx/gsttiovxmiso.c
@@ -111,9 +111,12 @@ static void
 gst_tiovx_miso_pad_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXMisoPad *pad = GST_TIOVX_MISO_PAD (object);
+  GstTIOVXMisoPad *pad = NULL;
   GstTIOVXMisoPadPrivate *priv = NULL;
 
+  g_return_if_fail (object);
+
+  pad = GST_TIOVX_MISO_PAD (object);
   priv = gst_tiovx_miso_pad_get_instance_private (pad);
 
   GST_OBJECT_LOCK (pad);
@@ -132,9 +135,12 @@ static void
 gst_tiovx_miso_pad_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXMisoPad *pad = GST_TIOVX_MISO_PAD (object);
+  GstTIOVXMisoPad *pad = NULL;
   GstTIOVXMisoPadPrivate *priv = NULL;
 
+  g_return_if_fail (object);
+
+  pad = GST_TIOVX_MISO_PAD (object);
   priv = gst_tiovx_miso_pad_get_instance_private (pad);
 
   GST_OBJECT_LOCK (pad);
@@ -152,9 +158,12 @@ gst_tiovx_miso_pad_set_property (GObject * object, guint prop_id,
 static void
 gst_tiovx_miso_pad_finalize (GObject * obj)
 {
-  GstTIOVXMisoPad *self = GST_TIOVX_MISO_PAD (obj);
+  GstTIOVXMisoPad *self = NULL;
   GstTIOVXMisoPadPrivate *priv = NULL;
 
+  g_return_if_fail (obj);
+
+  self = GST_TIOVX_MISO_PAD (obj);
   priv = gst_tiovx_miso_pad_get_instance_private (self);
 
   if (priv->exemplar) {
@@ -171,7 +180,11 @@ gst_tiovx_miso_pad_finalize (GObject * obj)
 static void
 gst_tiovx_miso_pad_class_init (GstTIOVXMisoPadClass * klass)
 {
-  GObjectClass *gobject_class = (GObjectClass *) klass;
+  GObjectClass *gobject_class = NULL;
+
+  g_return_if_fail (klass);
+
+  gobject_class = (GObjectClass *) klass;
 
   gobject_class->set_property = gst_tiovx_miso_pad_set_property;
   gobject_class->get_property = gst_tiovx_miso_pad_get_property;
@@ -188,6 +201,8 @@ static void
 gst_tiovx_miso_pad_init (GstTIOVXMisoPad * tiovx_miso_pad)
 {
   GstTIOVXMisoPadPrivate *priv = NULL;
+
+  g_return_if_fail (tiovx_miso_pad);
 
   priv = gst_tiovx_miso_pad_get_instance_private (tiovx_miso_pad);
 
@@ -208,14 +223,12 @@ gst_tiovx_miso_pad_set_params (GstTIOVXMisoPad * pad, vx_reference * exemplar,
 
   priv = gst_tiovx_miso_pad_get_instance_private (pad);
 
-
   GST_OBJECT_LOCK (pad);
 
   if (priv->exemplar) {
     vxReleaseReference (priv->exemplar);
     priv->exemplar = NULL;
   }
-
 
   priv->exemplar = exemplar;
   priv->graph_param_id = graph_param_id;
@@ -284,9 +297,15 @@ static void gst_tiovx_miso_release_pad (GstElement * element, GstPad * pad);
 static void
 gst_tiovx_miso_class_init (GstTIOVXMisoClass * klass)
 {
-  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
-  GstAggregatorClass *aggregator_class = GST_AGGREGATOR_CLASS (klass);
-  GObjectClass *gobject_class = (GObjectClass *) klass;
+  GstElementClass *gstelement_class = NULL;
+  GstAggregatorClass *aggregator_class = NULL;
+  GObjectClass *gobject_class = NULL;
+
+  g_return_if_fail (klass);
+
+  gstelement_class = GST_ELEMENT_CLASS (klass);
+  aggregator_class = GST_AGGREGATOR_CLASS (klass);
+  gobject_class = (GObjectClass *) klass;
 
   gobject_class->finalize = GST_DEBUG_FUNCPTR (gst_tiovx_miso_finalize);
 
@@ -321,7 +340,11 @@ gst_tiovx_miso_class_init (GstTIOVXMisoClass * klass)
 static void
 gst_tiovx_miso_init (GstTIOVXMiso * self)
 {
-  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
+  GstTIOVXMisoPrivate *priv = NULL;
+
+  g_return_if_fail (self);
+
+  priv = gst_tiovx_miso_get_instance_private (self);
 
   priv->context = NULL;
   priv->graph = NULL;
@@ -337,8 +360,13 @@ gst_tiovx_miso_init (GstTIOVXMiso * self)
 static void
 gst_tiovx_miso_finalize (GObject * obj)
 {
-  GstTIOVXMiso *self = GST_TIOVX_MISO (obj);
-  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
+  GstTIOVXMiso *self = NULL;
+  GstTIOVXMisoPrivate *priv = NULL;
+
+  g_return_if_fail (obj);
+
+  self = GST_TIOVX_MISO (obj);
+  priv = gst_tiovx_miso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "finalize");
 
@@ -371,9 +399,13 @@ gst_tiovx_miso_buffer_to_valid_pad_exemplar (GstTIOVXMisoPad * pad,
   gboolean ret = FALSE;
 
   g_return_val_if_fail (pad, FALSE);
-  g_return_val_if_fail (buffer, FALSE);
 
   priv = gst_tiovx_miso_pad_get_instance_private (pad);
+
+  if (NULL == buffer) {
+    GST_ERROR_OBJECT (pad, "Unable to validate pad exemplar, invalid buffer pointer");
+    goto exit;
+  }
 
   caps = gst_pad_get_current_caps (GST_PAD (pad));
 
@@ -382,7 +414,7 @@ gst_tiovx_miso_buffer_to_valid_pad_exemplar (GstTIOVXMisoPad * pad,
       gst_tiovx_validate_tiovx_buffer (GST_CAT_DEFAULT,
       &priv->buffer_pool, buffer, priv->exemplar, caps, priv->pool_size);
   gst_caps_unref (caps);
-  if (!buffer) {
+  if (NULL == buffer) {
     GST_ERROR_OBJECT (pad, "Unable to validate buffer");
     goto exit;
   }
@@ -417,7 +449,7 @@ exit:
 static GstFlowReturn
 gst_tiovx_miso_process_graph (GstAggregator * agg)
 {
-  GstTIOVXMiso *tiovx_miso = GST_TIOVX_MISO (agg);
+  GstTIOVXMiso *tiovx_miso = NULL;
   GstTIOVXMisoPrivate *priv = NULL;
   GstTIOVXMisoPad *pad = NULL;
   GstTIOVXMisoPadPrivate *pad_priv = NULL;
@@ -428,6 +460,7 @@ gst_tiovx_miso_process_graph (GstAggregator * agg)
 
   g_return_val_if_fail (agg, ret);
 
+  tiovx_miso = GST_TIOVX_MISO (agg);
   priv = gst_tiovx_miso_get_instance_private (tiovx_miso);
 
   /* Enqueueing parameters */
@@ -510,14 +543,19 @@ exit:
 static GstFlowReturn
 gst_tiovx_miso_aggregate (GstAggregator * agg, gboolean timeout)
 {
-  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
-  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
+  GstTIOVXMiso *self = NULL;
+  GstTIOVXMisoPrivate *priv = NULL;
   GstBuffer *outbuf = NULL;
   GstFlowReturn ret = GST_FLOW_ERROR;
   GList *l = NULL;
   GstClockTime pts = GST_CLOCK_TIME_NONE;
   GstClockTime dts = GST_CLOCK_TIME_NONE;
   GstClockTime duration = 0;
+
+  g_return_val_if_fail (agg, ret);
+
+  self = GST_TIOVX_MISO (agg);
+  priv = gst_tiovx_miso_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "TIOVX Miso aggregate");
 
@@ -562,7 +600,7 @@ gst_tiovx_miso_aggregate (GstAggregator * agg, gboolean timeout)
       duration = tmp_duration;
     }
 
-    if (!in_buffer) {
+    if (NULL == in_buffer) {
       GST_ERROR_OBJECT (self, "No input buffer in pad: %" GST_PTR_FORMAT, pad);
       goto finish_buffer;
     }
@@ -610,19 +648,23 @@ exit:
 }
 
 static GstFlowReturn
-gst_tiovx_miso_create_output_buffer (GstTIOVXMiso * tiovx_miso,
+gst_tiovx_miso_create_output_buffer (GstTIOVXMiso * self,
     GstBuffer ** outbuf)
 {
-  GstAggregator *aggregator = GST_AGGREGATOR (tiovx_miso);
+  GstAggregator *aggregator = NULL;
   GstBufferPool *pool;
   GstFlowReturn ret = GST_FLOW_ERROR;
+
+  g_return_val_if_fail (self, ret);
+
+  aggregator = GST_AGGREGATOR (self);
 
   pool = gst_aggregator_get_buffer_pool (aggregator);
 
   if (pool) {
     if (!gst_buffer_pool_is_active (pool)) {
       if (!gst_buffer_pool_set_active (pool, TRUE)) {
-        GST_ERROR_OBJECT (tiovx_miso, "Failed to activate bufferpool");
+        GST_ERROR_OBJECT (self, "Failed to activate bufferpool");
         goto exit;
       }
     }
@@ -632,7 +674,7 @@ gst_tiovx_miso_create_output_buffer (GstTIOVXMiso * tiovx_miso,
     pool = NULL;
     ret = GST_FLOW_OK;
   } else {
-    GST_ERROR_OBJECT (tiovx_miso,
+    GST_ERROR_OBJECT (self,
         "An output buffer can only be created from a buffer pool");
   }
 
@@ -644,8 +686,8 @@ static gboolean
 gst_tiovx_miso_propose_allocation (GstAggregator * agg,
     GstAggregatorPad * agg_pad, GstQuery * decide_query, GstQuery * query)
 {
-  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
-  GstTIOVXMisoPad *tiovx_miso_pad = GST_TIOVX_MISO_PAD (agg_pad);
+  GstTIOVXMiso *self = NULL;
+  GstTIOVXMisoPad *tiovx_miso_pad = NULL;
   GstTIOVXMisoPadPrivate *pad_priv = NULL;
   GstTIOVXMisoClass *klass = NULL;
   GstBufferPool *pool = NULL;
@@ -653,6 +695,12 @@ gst_tiovx_miso_propose_allocation (GstAggregator * agg,
   vx_reference reference = NULL;
   gsize size = 0;
   gboolean ret = FALSE;
+
+  g_return_val_if_fail (agg, ret);
+  g_return_val_if_fail (agg_pad, ret);
+
+  self = GST_TIOVX_MISO (agg);
+  tiovx_miso_pad = GST_TIOVX_MISO_PAD (agg_pad);
 
   GST_LOG_OBJECT (self, "Propose allocation");
 
@@ -689,7 +737,7 @@ gst_tiovx_miso_propose_allocation (GstAggregator * agg,
 
   pad_priv->buffer_pool = pool;
 
-  if (!pad_priv->exemplar) {
+  if (NULL == pad_priv->exemplar) {
     vxReleaseReference (&reference);
     reference = NULL;
   }
@@ -701,10 +749,14 @@ exit:
 static gboolean
 gst_tiovx_miso_decide_allocation (GstAggregator * agg, GstQuery * query)
 {
-  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
+  GstTIOVXMiso *self = NULL;
   gboolean ret = TRUE;
   gint npool = 0;
   gboolean pool_needed = TRUE;
+
+  g_return_val_if_fail (agg, ret);
+
+  self = GST_TIOVX_MISO (agg);
 
   GST_LOG_OBJECT (self, "Decide allocation");
 
@@ -767,8 +819,14 @@ gst_tiovx_miso_decide_allocation (GstAggregator * agg, GstQuery * query)
 static gboolean
 gst_tiovx_miso_start (GstAggregator * agg)
 {
-  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
-  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
+  GstTIOVXMiso *self = NULL;
+  GstTIOVXMisoPrivate *priv = NULL;
+  gboolean ret = FALSE;
+
+  g_return_val_if_fail (agg, ret);
+
+  self = GST_TIOVX_MISO (agg);
+  priv = gst_tiovx_miso_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "start");
 
@@ -782,24 +840,28 @@ gst_tiovx_miso_start (GstAggregator * agg)
   }
 
   priv->is_eos = FALSE;
+  ret = TRUE;
 
-  return TRUE;
+  return ret;
 }
 
 static gboolean
 gst_tiovx_miso_stop (GstAggregator * agg)
 {
-  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
+  GstTIOVXMiso *self = NULL;
   GstTIOVXMisoClass *klass = NULL;
   GstTIOVXMisoPrivate *priv = NULL;
   GstTIOVXMisoPadPrivate *pad_priv = NULL;
   GList *sink_pad_list = NULL;
   gboolean ret = FALSE;
 
-  GST_DEBUG_OBJECT (self, "stop");
+  g_return_val_if_fail (agg, ret);
 
+  self = GST_TIOVX_MISO (agg);
   priv = gst_tiovx_miso_get_instance_private (self);
   klass = GST_TIOVX_MISO_GET_CLASS (agg);
+
+  GST_DEBUG_OBJECT (self, "stop");
 
   if ((NULL == priv->graph)
       || (VX_SUCCESS != vxGetStatus ((vx_reference) priv->graph))) {
@@ -827,7 +889,7 @@ gst_tiovx_miso_stop (GstAggregator * agg)
     }
   }
 
-  if (!klass->deinit_module) {
+  if (NULL == klass->deinit_module) {
     GST_ERROR_OBJECT (self, "Subclass did not implement deinit_module method");
     goto release_graph;
   }
@@ -848,11 +910,13 @@ free_common:
 static GList *
 gst_tiovx_miso_get_sink_caps_list (GstTIOVXMiso * self)
 {
-  GstAggregator *agg = GST_AGGREGATOR (self);
+  GstAggregator *agg = NULL;
   GList *sink_caps_list = NULL;
   GList *l = NULL;
 
-  g_return_val_if_fail (self, NULL);
+  g_return_val_if_fail (self, sink_caps_list);
+
+  agg = GST_AGGREGATOR (self);
 
   GST_DEBUG_OBJECT (self, "Generating sink caps list");
 
@@ -877,6 +941,8 @@ gst_tiovx_miso_default_fixate_caps (GstTIOVXMiso * self, GList * sink_caps_list,
 {
   GstCaps *fixated_src_caps = NULL;
 
+  g_return_val_if_fail (self, fixated_src_caps);
+
   GST_DEBUG_OBJECT (self, "Fixating caps");
 
   g_return_val_if_fail (src_caps, FALSE);
@@ -890,7 +956,7 @@ gst_tiovx_miso_default_fixate_caps (GstTIOVXMiso * self, GList * sink_caps_list,
 static gboolean
 gst_tiovx_miso_modules_init (GstTIOVXMiso * self)
 {
-  GstAggregator *agg = GST_AGGREGATOR (self);
+  GstAggregator *agg = NULL;
   GstTIOVXMisoPadPrivate *pad_priv = NULL;
   GstTIOVXMisoPad *miso_pad = NULL;
   GstTIOVXMisoClass *klass = NULL;
@@ -903,6 +969,7 @@ gst_tiovx_miso_modules_init (GstTIOVXMiso * self)
 
   g_return_val_if_fail (self, FALSE);
 
+  agg = GST_AGGREGATOR (self);
   priv = gst_tiovx_miso_get_instance_private (self);
   klass = GST_TIOVX_MISO_GET_CLASS (self);
 
@@ -915,7 +982,7 @@ gst_tiovx_miso_modules_init (GstTIOVXMiso * self)
     goto exit;
   }
 
-  if (!klass->init_module) {
+  if (NULL == klass->init_module) {
     GST_ERROR_OBJECT (self, "Subclass did not implement init_module method.");
     goto exit;
   }
@@ -935,7 +1002,7 @@ gst_tiovx_miso_modules_init (GstTIOVXMiso * self)
   }
 
   GST_DEBUG_OBJECT (self, "Creating graph in subclass");
-  if (!klass->create_graph) {
+  if (NULL == klass->create_graph) {
     GST_ERROR_OBJECT (self, "Subclass did not implement create_graph method.");
     goto free_graph;
   }
@@ -945,7 +1012,7 @@ gst_tiovx_miso_modules_init (GstTIOVXMiso * self)
   }
 
   GST_DEBUG_OBJECT (self, "Get node info");
-  if (!klass->get_node_info) {
+  if (NULL == klass->get_node_info) {
     GST_ERROR_OBJECT (self, "Subclass did not implement get_node_info method");
     goto free_graph;
   }
@@ -984,7 +1051,7 @@ gst_tiovx_miso_modules_init (GstTIOVXMiso * self)
     goto free_graph;
   }
 
-  if (!priv->node) {
+  if (NULL == priv->node) {
     GST_ERROR_OBJECT (self, "Incomplete info from subclass: node missing");
     goto free_graph;
   }
@@ -1059,7 +1126,7 @@ gst_tiovx_miso_modules_init (GstTIOVXMiso * self)
   }
 
   /* Release buffer. This is needed in order to free resources allocated by vxVerifyGraph function */
-  if (!klass->release_buffer) {
+  if (NULL == klass->release_buffer) {
     GST_ERROR_OBJECT (self,
         "Subclass did not implement release buffer method. Skipping node configuration");
     goto free_graph;
@@ -1071,7 +1138,7 @@ gst_tiovx_miso_modules_init (GstTIOVXMiso * self)
   }
 
   GST_DEBUG_OBJECT (self, "Configure Module");
-  if (!klass->configure_module) {
+  if (NULL == klass->configure_module) {
     GST_LOG_OBJECT (self,
         "Subclass did not implement configure node method. Skipping node configuration");
   } else {
@@ -1093,7 +1160,7 @@ free_graph:
   priv->graph = NULL;
 
 deinit_module:
-  if (!klass->deinit_module) {
+  if (NULL == klass->deinit_module) {
     GST_ERROR_OBJECT (self, "Subclass did not implement deinit_module method");
     goto exit;
   }
@@ -1122,7 +1189,7 @@ gst_tiovx_miso_fixate_src_caps (GstAggregator * agg, GstCaps * src_caps)
 
   /* Should return the fixated caps the element will use on the src pads */
   fixated_caps = klass->fixate_caps (self, sink_caps_list, src_caps);
-  if (!fixated_caps) {
+  if (NULL == fixated_caps) {
     GST_ERROR_OBJECT (self, "Subclass did not fixate caps");
     goto exit;
   }
@@ -1137,6 +1204,10 @@ gst_tiovx_miso_negotiated_src_caps (GstAggregator * agg, GstCaps * caps)
   GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
   gboolean ret = FALSE;
   GList *l = NULL;
+
+  g_return_val_if_fail (agg, ret);
+
+  self = GST_TIOVX_MISO (agg);
 
   GST_DEBUG_OBJECT (self, "Negotiated src caps");
 
@@ -1260,8 +1331,14 @@ static gboolean
 gst_tiovx_miso_sink_event (GstAggregator * agg,
     GstAggregatorPad * agg_pad, GstEvent * event)
 {
-  GstTIOVXMiso *self = GST_TIOVX_MISO (agg);
-  GstTIOVXMisoPrivate *priv = gst_tiovx_miso_get_instance_private (self);
+  GstTIOVXMiso *self = NULL;
+  GstTIOVXMisoPrivate *priv = NULL;
+
+  g_return_val_if_fail (agg, FALSE);
+  g_return_val_if_fail (agg_pad, FALSE);
+
+  self = GST_TIOVX_MISO (agg);
+  priv = gst_tiovx_miso_get_instance_private (self);
 
   switch (GST_EVENT_TYPE (event)) {
     case GST_EVENT_EOS:

--- a/gst-libs/gst/tiovx/gsttiovxmiso.h
+++ b/gst-libs/gst/tiovx/gsttiovxmiso.h
@@ -69,7 +69,7 @@
 
 G_BEGIN_DECLS
 
-#define GST_TIOVX_MISO_TYPE   (gst_tiovx_miso_get_type())
+#define GST_TYPE_TIOVX_MISO   (gst_tiovx_miso_get_type())
 G_DECLARE_DERIVABLE_TYPE (GstTIOVXMiso, gst_tiovx_miso, GST,
 	TIOVX_MISO, GstAggregator)
 

--- a/gst-libs/gst/tiovx/gsttiovxpad.c
+++ b/gst-libs/gst/tiovx/gsttiovxpad.c
@@ -112,7 +112,11 @@ static void gst_tiovx_pad_get_property (GObject * object, guint prop_id,
 static void
 gst_tiovx_pad_class_init (GstTIOVXPadClass * klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GObjectClass *object_class = NULL;
+
+  g_return_if_fail (klass);
+
+  object_class = G_OBJECT_CLASS (klass);
 
   object_class->set_property = gst_tiovx_pad_set_property;
   object_class->get_property = gst_tiovx_pad_get_property;
@@ -130,8 +134,12 @@ static void
 gst_tiovx_pad_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXPad *self = GST_TIOVX_PAD (object);
+  GstTIOVXPad *self = NULL;
   GstTIOVXPadPrivate *priv = NULL;
+
+  g_return_if_fail (object);
+
+  self = GST_TIOVX_PAD (object);
 
   GST_LOG_OBJECT (self, "set_property");
 
@@ -153,8 +161,12 @@ static void
 gst_tiovx_pad_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXPad *self = GST_TIOVX_PAD (object);
+  GstTIOVXPad *self = NULL ;
   GstTIOVXPadPrivate *priv = NULL;
+
+  g_return_if_fail (object);
+
+  self = GST_TIOVX_PAD (object);
 
   GST_LOG_OBJECT (self, "get_property");
 
@@ -178,6 +190,8 @@ gst_tiovx_pad_init (GstTIOVXPad * self)
 {
   GstTIOVXPadPrivate *priv = NULL;
 
+  g_return_if_fail (self);
+
   priv = gst_tiovx_pad_get_instance_private (self);
 
   priv->buffer_pool = NULL;
@@ -189,6 +203,8 @@ void
 gst_tiovx_pad_set_exemplar (GstTIOVXPad * self, const vx_reference exemplar)
 {
   GstTIOVXPadPrivate *priv = NULL;
+
+  g_return_if_fail (self);
 
   priv = gst_tiovx_pad_get_instance_private (self);
 
@@ -208,8 +224,8 @@ gst_tiovx_pad_peer_query_allocation (GstTIOVXPad * self, GstCaps * caps)
   GstPad *peer = NULL;
   GstBufferPool *pool = NULL;
 
-  g_return_val_if_fail (self, FALSE);
-  g_return_val_if_fail (caps, FALSE);
+  g_return_val_if_fail (self, ret);
+  g_return_val_if_fail (caps, ret);
 
   priv = gst_tiovx_pad_get_instance_private (self);
 
@@ -276,10 +292,10 @@ gst_tiovx_pad_process_allocation_query (GstTIOVXPad * self, GstQuery * query)
   gboolean ret = FALSE;
   gsize size = 0;
 
-  priv = gst_tiovx_pad_get_instance_private (self);
+  g_return_val_if_fail (self, ret);
+  g_return_val_if_fail (query, ret);
 
-  g_return_val_if_fail (self, FALSE);
-  g_return_val_if_fail (query, FALSE);
+  priv = gst_tiovx_pad_get_instance_private (self);
 
   if (NULL == priv->exemplar) {
     GST_ERROR_OBJECT (self,
@@ -294,7 +310,7 @@ gst_tiovx_pad_process_allocation_query (GstTIOVXPad * self, GstQuery * query)
   }
 
   gst_query_parse_allocation (query, &caps, NULL);
-  if (!caps) {
+  if (NULL == caps) {
     GST_ERROR_OBJECT (self, "Unable to parse caps from query");
     ret = FALSE;
     goto out;
@@ -375,7 +391,7 @@ gst_tiovx_pad_chain (GstPad * pad, GstObject * parent, GstBuffer ** buffer)
     gst_caps_unref (caps);
   }
 
-  if (!*buffer) {
+  if (NULL == *buffer) {
     GST_ERROR_OBJECT (pad, "Unable to validate buffer");
     goto exit;
   }
@@ -440,10 +456,13 @@ exit:
 static void
 gst_tiovx_pad_finalize (GObject * object)
 {
-  GstTIOVXPad *tiovx_pad = GST_TIOVX_PAD (object);
+  GstTIOVXPad *self = NULL;
   GstTIOVXPadPrivate *priv = NULL;
 
-  priv = gst_tiovx_pad_get_instance_private (tiovx_pad);
+  g_return_if_fail (object);
+
+  self = GST_TIOVX_PAD (object);
+  priv = gst_tiovx_pad_get_instance_private (self);
 
   if (NULL != priv->buffer_pool) {
     gst_object_unref (priv->buffer_pool);

--- a/gst-libs/gst/tiovx/gsttiovxpad.c
+++ b/gst-libs/gst/tiovx/gsttiovxpad.c
@@ -419,7 +419,7 @@ gst_tiovx_pad_acquire_buffer (GstTIOVXPad * self, GstBuffer ** buffer,
 
   /* Ensure that the exemplar & the meta have the same data */
   meta =
-      (GstTIOVXMeta *) gst_buffer_get_meta (*buffer, GST_TIOVX_META_API_TYPE);
+      (GstTIOVXMeta *) gst_buffer_get_meta (*buffer, GST_TYPE_TIOVX_META_API);
 
   array = meta->array;
 

--- a/gst-libs/gst/tiovx/gsttiovxpad.c
+++ b/gst-libs/gst/tiovx/gsttiovxpad.c
@@ -112,11 +112,7 @@ static void gst_tiovx_pad_get_property (GObject * object, guint prop_id,
 static void
 gst_tiovx_pad_class_init (GstTIOVXPadClass * klass)
 {
-  GObjectClass *object_class = NULL;
-
-  g_return_if_fail (klass);
-
-  object_class = G_OBJECT_CLASS (klass);
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
 
   object_class->set_property = gst_tiovx_pad_set_property;
   object_class->get_property = gst_tiovx_pad_get_property;
@@ -134,16 +130,10 @@ static void
 gst_tiovx_pad_set_property (GObject * object, guint prop_id,
     const GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXPad *self = NULL;
-  GstTIOVXPadPrivate *priv = NULL;
-
-  g_return_if_fail (object);
-
-  self = GST_TIOVX_PAD (object);
+  GstTIOVXPad *self = GST_TIOVX_PAD (object);
+  GstTIOVXPadPrivate *priv = gst_tiovx_pad_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "set_property");
-
-  priv = gst_tiovx_pad_get_instance_private (self);
 
   GST_OBJECT_LOCK (self);
   switch (prop_id) {
@@ -161,16 +151,10 @@ static void
 gst_tiovx_pad_get_property (GObject * object, guint prop_id,
     GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXPad *self = NULL ;
-  GstTIOVXPadPrivate *priv = NULL;
-
-  g_return_if_fail (object);
-
-  self = GST_TIOVX_PAD (object);
+  GstTIOVXPad *self = GST_TIOVX_PAD (object);
+  GstTIOVXPadPrivate *priv = gst_tiovx_pad_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "get_property");
-
-  priv = gst_tiovx_pad_get_instance_private (self);
 
   GST_OBJECT_LOCK (self);
   switch (prop_id) {
@@ -188,11 +172,7 @@ gst_tiovx_pad_get_property (GObject * object, guint prop_id,
 static void
 gst_tiovx_pad_init (GstTIOVXPad * self)
 {
-  GstTIOVXPadPrivate *priv = NULL;
-
-  g_return_if_fail (self);
-
-  priv = gst_tiovx_pad_get_instance_private (self);
+  GstTIOVXPadPrivate *priv = gst_tiovx_pad_get_instance_private (self);
 
   priv->buffer_pool = NULL;
   priv->exemplar = NULL;
@@ -456,13 +436,8 @@ exit:
 static void
 gst_tiovx_pad_finalize (GObject * object)
 {
-  GstTIOVXPad *self = NULL;
-  GstTIOVXPadPrivate *priv = NULL;
-
-  g_return_if_fail (object);
-
-  self = GST_TIOVX_PAD (object);
-  priv = gst_tiovx_pad_get_instance_private (self);
+  GstTIOVXPad *self = GST_TIOVX_PAD (object);
+  GstTIOVXPadPrivate *priv = gst_tiovx_pad_get_instance_private (self);
 
   if (NULL != priv->buffer_pool) {
     gst_object_unref (priv->buffer_pool);

--- a/gst-libs/gst/tiovx/gsttiovxpad.h
+++ b/gst-libs/gst/tiovx/gsttiovxpad.h
@@ -70,7 +70,7 @@
 
 G_BEGIN_DECLS 
 
-#define GST_TIOVX_TYPE_PAD gst_tiovx_pad_get_type ()
+#define GST_TYPE_TIOVX_PAD gst_tiovx_pad_get_type ()
 
 /**
  * GstTIOVXPad:

--- a/gst-libs/gst/tiovx/gsttiovxsimo.c
+++ b/gst-libs/gst/tiovx/gsttiovxsimo.c
@@ -1195,7 +1195,7 @@ gst_tiovx_simo_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
   }
 
   in_meta =
-      (GstTIOVXMeta *) gst_buffer_get_meta (buffer, GST_TIOVX_META_API_TYPE);
+      (GstTIOVXMeta *) gst_buffer_get_meta (buffer, GST_TYPE_TIOVX_META_API);
   if (!in_meta) {
     GST_ERROR_OBJECT (self, "Input Buffer is not a TIOVX buffer");
     goto exit;

--- a/gst-libs/gst/tiovx/gsttiovxsimo.c
+++ b/gst-libs/gst/tiovx/gsttiovxsimo.c
@@ -206,6 +206,8 @@ gst_tiovx_simo_class_init (GstTIOVXSimoClass * klass)
   GstElementClass *gstelement_class = NULL;
   GObjectClass *gobject_class = NULL;
 
+  g_return_if_fail (klass);
+
   gstelement_class = GST_ELEMENT_CLASS (klass);
   gobject_class = G_OBJECT_CLASS (klass);
 
@@ -239,6 +241,8 @@ gst_tiovx_simo_init (GstTIOVXSimo * self, GstTIOVXSimoClass * klass)
   GstElementClass *gstelement_class = NULL;
   GstTIOVXSimoPrivate *priv = NULL;
   vx_status status = VX_FAILURE;
+
+  g_return_if_fail (self);
 
   GST_DEBUG_OBJECT (self, "gst_tiovx_simo_init");
 
@@ -365,8 +369,8 @@ gst_tiovx_simo_modules_init (GstTIOVXSimo * self, GstCaps * sink_caps,
   guint batch_size = 0;
   guint num_pads = 0;
 
-  g_return_val_if_fail (self, FALSE);
-  g_return_val_if_fail (sink_caps, FALSE);
+  g_return_val_if_fail (self, ret);
+  g_return_val_if_fail (sink_caps, ret);
 
   priv = gst_tiovx_simo_get_instance_private (self);
   klass = GST_TIOVX_SIMO_GET_CLASS (self);
@@ -380,7 +384,7 @@ gst_tiovx_simo_modules_init (GstTIOVXSimo * self, GstCaps * sink_caps,
     goto exit;
   }
 
-  if (!klass->init_module) {
+  if (NULL == klass->init_module) {
     GST_ERROR_OBJECT (self, "Subclass did not implement init_module method.");
     goto exit;
   }
@@ -402,7 +406,7 @@ gst_tiovx_simo_modules_init (GstTIOVXSimo * self, GstCaps * sink_caps,
   }
 
   GST_DEBUG_OBJECT (self, "Creating graph in subclass");
-  if (!klass->create_graph) {
+  if (NULL == klass->create_graph) {
     GST_ERROR_OBJECT (self, "Subclass did not implement create_graph method.");
     goto free_graph;
   }
@@ -415,7 +419,7 @@ gst_tiovx_simo_modules_init (GstTIOVXSimo * self, GstCaps * sink_caps,
   priv->output_refs =
       g_malloc (sizeof (vx_reference) * g_list_length (priv->srcpads));
   GST_DEBUG_OBJECT (self, "Get node info");
-  if (!klass->get_node_info) {
+  if (NULL == klass->get_node_info) {
     GST_ERROR_OBJECT (self, "Subclass did not implement get_node_info method");
     goto free_graph;
   }
@@ -427,16 +431,16 @@ gst_tiovx_simo_modules_init (GstTIOVXSimo * self, GstCaps * sink_caps,
     goto free_graph;
   }
 
-  if (!priv->input_refs) {
+  if (NULL == priv->input_refs) {
     GST_ERROR_OBJECT (self, "Incomplete info from subclass: input missing");
     goto free_graph;
   }
 
-  if (!priv->output_refs) {
+  if (NULL == priv->output_refs) {
     GST_ERROR_OBJECT (self, "Incomplete info from subclass: output missing");
     goto free_graph;
   }
-  if (!priv->node) {
+  if (NULL == priv->node) {
     GST_ERROR_OBJECT (self, "Incomplete info from subclass: node missing");
     goto free_graph;
   }
@@ -499,7 +503,7 @@ gst_tiovx_simo_modules_init (GstTIOVXSimo * self, GstCaps * sink_caps,
   }
 
   GST_DEBUG_OBJECT (self, "Configure Module");
-  if (!klass->configure_module) {
+  if (NULL == klass->configure_module) {
     GST_LOG_OBJECT (self,
         "Subclass did not implement configure node method. Skipping node configuration");
   } else {
@@ -522,7 +526,7 @@ free_graph:
   priv->graph = NULL;
 
 deinit_module:
-  if (!klass->deinit_module) {
+  if (NULL == klass->deinit_module) {
     GST_ERROR_OBJECT (self, "Subclass did not implement deinit_module method");
     goto exit;
   }
@@ -544,9 +548,9 @@ gst_tiovx_simo_stop (GstTIOVXSimo * self)
   guint num_pads = 0;
   guint i = 0;
 
-  GST_DEBUG_OBJECT (self, "gst_tiovx_simo_modules_deinit");
+  g_return_val_if_fail (self, ret);
 
-  g_return_val_if_fail (self, FALSE);
+  GST_DEBUG_OBJECT (self, "gst_tiovx_simo_modules_deinit");
 
   priv = gst_tiovx_simo_get_instance_private (self);
   klass = GST_TIOVX_SIMO_GET_CLASS (self);
@@ -572,7 +576,7 @@ gst_tiovx_simo_stop (GstTIOVXSimo * self)
     }
   }
 
-  if (!klass->deinit_module) {
+  if (NULL == klass->deinit_module) {
     GST_ERROR_OBJECT (self, "Subclass did not implement deinit_module method");
     goto release_graph;
   }
@@ -599,6 +603,8 @@ gst_tiovx_simo_finalize (GObject * gobject)
 {
   GstTIOVXSimo *self = NULL;
   GstTIOVXSimoPrivate *priv = NULL;
+
+  g_return_if_fail (gobject);
 
   self = GST_TIOVX_SIMO (gobject);
 
@@ -631,7 +637,9 @@ gst_tiovx_simo_change_state (GstElement * element, GstStateChange transition)
 {
   GstTIOVXSimo *self = NULL;
   gboolean ret = FALSE;
-  GstStateChangeReturn result = GST_STATE_CHANGE_SUCCESS;
+  GstStateChangeReturn result = GST_STATE_CHANGE_FAILURE;
+
+  g_return_val_if_fail (element, result);
 
   self = GST_TIOVX_SIMO (element);
 
@@ -679,6 +687,8 @@ gst_tiovx_simo_request_new_pad (GstElement * element, GstPadTemplate * templ,
   guint name_index = 0;
   GstPad *src_pad = NULL;
   gchar *name = NULL;
+
+  g_return_val_if_fail (element, NULL);
 
   self = GST_TIOVX_SIMO (element);
   priv = gst_tiovx_simo_get_instance_private (self);
@@ -771,6 +781,8 @@ gst_tiovx_simo_release_pad (GstElement * element, GstPad * pad)
   GstTIOVXSimo *self = NULL;
   GstTIOVXSimoPrivate *priv = NULL;
   GList *node = NULL;
+
+  g_return_if_fail (element);
 
   self = GST_TIOVX_SIMO (element);
   priv = gst_tiovx_simo_get_instance_private (self);
@@ -898,6 +910,10 @@ gst_tiovx_simo_sink_query (GstPad * pad, GstObject * parent, GstQuery * query)
   GstCaps *sink_caps = NULL;
   gboolean ret = FALSE;
 
+  g_return_val_if_fail (pad, FALSE);
+  g_return_val_if_fail (parent, FALSE);
+  g_return_val_if_fail (query, FALSE);
+
   self = GST_TIOVX_SIMO (parent);
   klass = GST_TIOVX_SIMO_GET_CLASS (self);
   priv = gst_tiovx_simo_get_instance_private (self);
@@ -908,7 +924,7 @@ gst_tiovx_simo_sink_query (GstPad * pad, GstObject * parent, GstQuery * query)
       GstCaps *filter;
       GList *src_caps_list = NULL;
 
-      if (!priv->srcpads) {
+      if (NULL == priv->srcpads) {
         break;
       }
 
@@ -956,6 +972,10 @@ gst_tiovx_simo_src_query (GstPad * pad, GstObject * parent, GstQuery * query)
   GstTIOVXSimoClass *klass = NULL;
   GstTIOVXSimoPrivate *priv = NULL;
   gboolean ret = FALSE;
+
+  g_return_val_if_fail (pad, FALSE);
+  g_return_val_if_fail (parent, FALSE);
+  g_return_val_if_fail (query, FALSE);
 
   self = GST_TIOVX_SIMO (parent);
   klass = GST_TIOVX_SIMO_GET_CLASS (self);
@@ -1011,20 +1031,22 @@ gst_tiovx_simo_trigger_downstream_pads (GList * srcpads)
   GList *src_pads_sublist = NULL;
   gboolean ret = FALSE;
 
+  g_return_val_if_fail (srcpads, FALSE);
+
   src_pads_sublist = srcpads;
   while (NULL != src_pads_sublist) {
     GstPad *src_pad = NULL;
     GList *next = g_list_next (src_pads_sublist);
 
     src_pad = GST_PAD (src_pads_sublist->data);
-    if (!src_pad) {
+    if (NULL == src_pad) {
       goto exit;
     }
 
     /* Ask peer for what should the source caps (sink caps in the other end) be */
     peer_caps = gst_pad_get_current_caps (src_pad);
 
-    if (!peer_caps) {
+    if (NULL == peer_caps) {
       goto exit;
     }
 
@@ -1058,7 +1080,7 @@ gst_tiovx_simo_set_caps (GstTIOVXSimo * self, GstPad * pad, GstCaps * sink_caps,
   klass = GST_TIOVX_SIMO_GET_CLASS (self);
   priv = gst_tiovx_simo_get_instance_private (self);
 
-  if (!klass->compare_caps) {
+  if (NULL == klass->compare_caps) {
     GST_WARNING_OBJECT (self,
         "Subclass did not implement compare_caps method.");
   } /* Caps have not changed, skip module reinitialization */
@@ -1104,6 +1126,7 @@ gst_tiovx_simo_default_fixate_caps (GstTIOVXSimo * self, GstCaps * sink_caps,
   GList *node = NULL;
   GList *ret = NULL;
 
+  g_return_val_if_fail (self, FALSE);
   g_return_val_if_fail (sink_caps, FALSE);
   g_return_val_if_fail (src_caps_list, FALSE);
 
@@ -1178,6 +1201,10 @@ gst_tiovx_simo_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
   gint num_pads = 0;
   gint i = 0;
 
+  g_return_val_if_fail (pad, FALSE);
+  g_return_val_if_fail (parent, FALSE);
+  g_return_val_if_fail (buffer, FALSE);
+
   self = GST_TIOVX_SIMO (parent);
   priv = gst_tiovx_simo_get_instance_private (self);
 
@@ -1196,7 +1223,7 @@ gst_tiovx_simo_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
 
   in_meta =
       (GstTIOVXMeta *) gst_buffer_get_meta (buffer, GST_TYPE_TIOVX_META_API);
-  if (!in_meta) {
+  if (NULL == in_meta) {
     GST_ERROR_OBJECT (self, "Input Buffer is not a TIOVX buffer");
     goto exit;
   }
@@ -1276,6 +1303,10 @@ gst_tiovx_simo_sink_event (GstPad * pad, GstObject * parent, GstEvent * event)
   GList *pads_node = NULL;
   gboolean ret = FALSE;
 
+  g_return_val_if_fail (pad, FALSE);
+  g_return_val_if_fail (parent, FALSE);
+  g_return_val_if_fail (event, FALSE);
+
   self = GST_TIOVX_SIMO (parent);
   klass = GST_TIOVX_SIMO_GET_CLASS (self);
   priv = gst_tiovx_simo_get_instance_private (self);
@@ -1293,7 +1324,7 @@ gst_tiovx_simo_sink_event (GstPad * pad, GstObject * parent, GstEvent * event)
 
       /* Should return the fixated caps the element will use on the src pads */
       fixated_list = klass->fixate_caps (self, sink_caps, src_caps_list);
-      if (!fixated_list) {
+      if (NULL == fixated_list) {
         GST_ERROR_OBJECT (self, "Subclass did not fixate caps");
         gst_event_unref (event);
         break;
@@ -1342,6 +1373,9 @@ gst_tiovx_simo_free_buffer_list (GstBuffer ** buffer_list, gint list_length)
 {
   gint i = 0;
 
+  g_return_if_fail (buffer_list);
+  g_return_if_fail (list_length >= 0);
+
   for (i = 0; i < list_length; i++) {
     if (NULL != buffer_list[i]) {
       gst_buffer_unref (buffer_list[i]);
@@ -1357,6 +1391,10 @@ gst_tiovx_simo_push_buffers (GstTIOVXSimo * simo, GList * pads,
   GstFlowReturn ret = GST_FLOW_OK;
   GList *pads_sublist = NULL;
   gint i = 0;
+
+  g_return_val_if_fail (simo, GST_FLOW_ERROR);
+  g_return_val_if_fail (pads, GST_FLOW_ERROR);
+  g_return_val_if_fail (buffer_list, GST_FLOW_ERROR);
 
   pads_sublist = pads;
   while (NULL != pads_sublist) {
@@ -1396,7 +1434,7 @@ gst_tiovx_simo_process_graph (GstTIOVXSimo * self)
   gint i = 0;
   guint num_pads = 0;
 
-  g_return_val_if_fail (self, VX_FAILURE);
+  g_return_val_if_fail (self, ret);
 
   priv = gst_tiovx_simo_get_instance_private (self);
   num_pads = gst_tiovx_simo_get_num_pads (self);

--- a/gst-libs/gst/tiovx/gsttiovxsimo.c
+++ b/gst-libs/gst/tiovx/gsttiovxsimo.c
@@ -203,13 +203,8 @@ gst_tiovx_simo_get_num_pads (GstTIOVXSimo * self)
 static void
 gst_tiovx_simo_class_init (GstTIOVXSimoClass * klass)
 {
-  GstElementClass *gstelement_class = NULL;
-  GObjectClass *gobject_class = NULL;
-
-  g_return_if_fail (klass);
-
-  gstelement_class = GST_ELEMENT_CLASS (klass);
-  gobject_class = G_OBJECT_CLASS (klass);
+  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
 
   if (private_offset != 0)
     g_type_class_adjust_private_offset (klass, &private_offset);
@@ -237,17 +232,12 @@ gst_tiovx_simo_class_init (GstTIOVXSimoClass * klass)
 static void
 gst_tiovx_simo_init (GstTIOVXSimo * self, GstTIOVXSimoClass * klass)
 {
+  GstElementClass *gstelement_class = GST_ELEMENT_CLASS (klass);
+  GstTIOVXSimoPrivate *priv = gst_tiovx_simo_get_instance_private (self);
   GstPadTemplate *pad_template = NULL;
-  GstElementClass *gstelement_class = NULL;
-  GstTIOVXSimoPrivate *priv = NULL;
   vx_status status = VX_FAILURE;
 
-  g_return_if_fail (self);
-
   GST_DEBUG_OBJECT (self, "gst_tiovx_simo_init");
-
-  gstelement_class = GST_ELEMENT_CLASS (klass);
-  priv = gst_tiovx_simo_get_instance_private (self);
 
   pad_template = gst_element_class_get_pad_template (gstelement_class, "sink");
   g_return_if_fail (pad_template != NULL);
@@ -542,18 +532,13 @@ exit:
 static gboolean
 gst_tiovx_simo_stop (GstTIOVXSimo * self)
 {
-  GstTIOVXSimoPrivate *priv = NULL;
-  GstTIOVXSimoClass *klass = NULL;
+  GstTIOVXSimoPrivate *priv = gst_tiovx_simo_get_instance_private (self);
+  GstTIOVXSimoClass *klass = GST_TIOVX_SIMO_GET_CLASS (self);
   gboolean ret = FALSE;
   guint num_pads = 0;
   guint i = 0;
 
-  g_return_val_if_fail (self, ret);
-
   GST_DEBUG_OBJECT (self, "gst_tiovx_simo_modules_deinit");
-
-  priv = gst_tiovx_simo_get_instance_private (self);
-  klass = GST_TIOVX_SIMO_GET_CLASS (self);
 
   if ((NULL == priv->graph)
       || (VX_SUCCESS != vxGetStatus ((vx_reference) priv->graph))) {
@@ -601,14 +586,8 @@ free_common:
 static void
 gst_tiovx_simo_finalize (GObject * gobject)
 {
-  GstTIOVXSimo *self = NULL;
-  GstTIOVXSimoPrivate *priv = NULL;
-
-  g_return_if_fail (gobject);
-
-  self = GST_TIOVX_SIMO (gobject);
-
-  priv = gst_tiovx_simo_get_instance_private (self);
+  GstTIOVXSimo *self = GST_TIOVX_SIMO (gobject);
+  GstTIOVXSimoPrivate *priv = gst_tiovx_simo_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "finalize");
 
@@ -638,8 +617,6 @@ gst_tiovx_simo_change_state (GstElement * element, GstStateChange transition)
   GstTIOVXSimo *self = NULL;
   gboolean ret = FALSE;
   GstStateChangeReturn result = GST_STATE_CHANGE_FAILURE;
-
-  g_return_val_if_fail (element, result);
 
   self = GST_TIOVX_SIMO (element);
 
@@ -682,16 +659,11 @@ static GstPad *
 gst_tiovx_simo_request_new_pad (GstElement * element, GstPadTemplate * templ,
     const gchar * name_templ, const GstCaps * caps)
 {
-  GstTIOVXSimo *self = NULL;
-  GstTIOVXSimoPrivate *priv = NULL;
+  GstTIOVXSimo *self = GST_TIOVX_SIMO (element);
+  GstTIOVXSimoPrivate *priv = gst_tiovx_simo_get_instance_private (self);
   guint name_index = 0;
   GstPad *src_pad = NULL;
   gchar *name = NULL;
-
-  g_return_val_if_fail (element, NULL);
-
-  self = GST_TIOVX_SIMO (element);
-  priv = gst_tiovx_simo_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "requesting pad");
 
@@ -778,14 +750,9 @@ unlock:
 static void
 gst_tiovx_simo_release_pad (GstElement * element, GstPad * pad)
 {
-  GstTIOVXSimo *self = NULL;
-  GstTIOVXSimoPrivate *priv = NULL;
+  GstTIOVXSimo *self = GST_TIOVX_SIMO (element);
+  GstTIOVXSimoPrivate *priv = gst_tiovx_simo_get_instance_private (self);
   GList *node = NULL;
-
-  g_return_if_fail (element);
-
-  self = GST_TIOVX_SIMO (element);
-  priv = gst_tiovx_simo_get_instance_private (self);
 
   GST_OBJECT_LOCK (self);
 
@@ -904,19 +871,11 @@ gst_tiovx_simo_default_get_src_caps (GstTIOVXSimo * self,
 static gboolean
 gst_tiovx_simo_sink_query (GstPad * pad, GstObject * parent, GstQuery * query)
 {
-  GstTIOVXSimo *self = NULL;
-  GstTIOVXSimoClass *klass = NULL;
-  GstTIOVXSimoPrivate *priv = NULL;
+  GstTIOVXSimo *self = GST_TIOVX_SIMO (parent);
+  GstTIOVXSimoClass *klass = GST_TIOVX_SIMO_GET_CLASS (self);
+  GstTIOVXSimoPrivate *priv = gst_tiovx_simo_get_instance_private (self);
   GstCaps *sink_caps = NULL;
   gboolean ret = FALSE;
-
-  g_return_val_if_fail (pad, FALSE);
-  g_return_val_if_fail (parent, FALSE);
-  g_return_val_if_fail (query, FALSE);
-
-  self = GST_TIOVX_SIMO (parent);
-  klass = GST_TIOVX_SIMO_GET_CLASS (self);
-  priv = gst_tiovx_simo_get_instance_private (self);
 
   switch (GST_QUERY_TYPE (query)) {
     case GST_QUERY_CAPS:
@@ -968,18 +927,10 @@ gst_tiovx_simo_sink_query (GstPad * pad, GstObject * parent, GstQuery * query)
 static gboolean
 gst_tiovx_simo_src_query (GstPad * pad, GstObject * parent, GstQuery * query)
 {
-  GstTIOVXSimo *self = NULL;
-  GstTIOVXSimoClass *klass = NULL;
-  GstTIOVXSimoPrivate *priv = NULL;
+  GstTIOVXSimo *self = GST_TIOVX_SIMO (parent);
+  GstTIOVXSimoClass *klass = GST_TIOVX_SIMO_GET_CLASS (self);
+  GstTIOVXSimoPrivate *priv = gst_tiovx_simo_get_instance_private (self);
   gboolean ret = FALSE;
-
-  g_return_val_if_fail (pad, FALSE);
-  g_return_val_if_fail (parent, FALSE);
-  g_return_val_if_fail (query, FALSE);
-
-  self = GST_TIOVX_SIMO (parent);
-  klass = GST_TIOVX_SIMO_GET_CLASS (self);
-  priv = gst_tiovx_simo_get_instance_private (self);
 
   switch (GST_QUERY_TYPE (query)) {
     case GST_QUERY_CAPS:
@@ -1201,10 +1152,6 @@ gst_tiovx_simo_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)
   gint num_pads = 0;
   gint i = 0;
 
-  g_return_val_if_fail (pad, FALSE);
-  g_return_val_if_fail (parent, FALSE);
-  g_return_val_if_fail (buffer, FALSE);
-
   self = GST_TIOVX_SIMO (parent);
   priv = gst_tiovx_simo_get_instance_private (self);
 
@@ -1296,20 +1243,12 @@ exit:
 static gboolean
 gst_tiovx_simo_sink_event (GstPad * pad, GstObject * parent, GstEvent * event)
 {
-  GstTIOVXSimo *self = NULL;
-  GstTIOVXSimoClass *klass = NULL;
-  GstTIOVXSimoPrivate *priv = NULL;
+  GstTIOVXSimo *self = GST_TIOVX_SIMO (parent);
+  GstTIOVXSimoClass *klass = GST_TIOVX_SIMO_GET_CLASS (self);
+  GstTIOVXSimoPrivate *priv = gst_tiovx_simo_get_instance_private (self);
   GList *caps_node = NULL;
   GList *pads_node = NULL;
   gboolean ret = FALSE;
-
-  g_return_val_if_fail (pad, FALSE);
-  g_return_val_if_fail (parent, FALSE);
-  g_return_val_if_fail (event, FALSE);
-
-  self = GST_TIOVX_SIMO (parent);
-  klass = GST_TIOVX_SIMO_GET_CLASS (self);
-  priv = gst_tiovx_simo_get_instance_private (self);
 
   switch (GST_EVENT_TYPE (event)) {
     case GST_EVENT_CAPS:

--- a/gst-libs/gst/tiovx/gsttiovxsimo.h
+++ b/gst-libs/gst/tiovx/gsttiovxsimo.h
@@ -70,7 +70,7 @@
 
 G_BEGIN_DECLS
 
-#define GST_TIOVX_SIMO_TYPE   (gst_tiovx_simo_get_type())
+#define GST_TYPE_TIOVX_SIMO   (gst_tiovx_simo_get_type())
 G_DECLARE_DERIVABLE_TYPE (GstTIOVXSimo, gst_tiovx_simo, GST,
 	TIOVX_SIMO, GstElement)
 

--- a/gst-libs/gst/tiovx/gsttiovxsiso.c
+++ b/gst-libs/gst/tiovx/gsttiovxsiso.c
@@ -133,13 +133,9 @@ static vx_status gst_tiovx_siso_process_graph (GstTIOVXSiso * self);
 static void
 gst_tiovx_siso_class_init (GstTIOVXSisoClass * klass)
 {
-  GstBaseTransformClass *base_transform_class = NULL;
-  GObjectClass *gobject_class = NULL;
-
-  g_return_if_fail (klass);
-
-  base_transform_class = GST_BASE_TRANSFORM_CLASS (klass);
-  gobject_class = (GObjectClass *) klass;
+  GstBaseTransformClass *base_transform_class =
+      GST_BASE_TRANSFORM_CLASS (klass);
+  GObjectClass *gobject_class = (GObjectClass *) klass;
 
   gobject_class->set_property = gst_tiovx_siso_set_property;
   gobject_class->get_property = gst_tiovx_siso_get_property;
@@ -173,11 +169,7 @@ gst_tiovx_siso_class_init (GstTIOVXSisoClass * klass)
 static void
 gst_tiovx_siso_init (GstTIOVXSiso * self)
 {
-  GstTIOVXSisoPrivate *priv = NULL;
-
-  g_return_if_fail (self);
-
-  priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
 
   priv->in_caps = NULL;
   priv->out_caps = NULL;
@@ -214,13 +206,8 @@ static void
 gst_tiovx_siso_set_property (GObject * object, guint property_id,
     const GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXSiso *self = NULL;
-  GstTIOVXSisoPrivate *priv = NULL;
-
-  g_return_if_fail (object);
-
-  self = GST_TIOVX_SISO (object);
-  priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = GST_TIOVX_SISO (object);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "set_property");
 
@@ -243,13 +230,8 @@ static void
 gst_tiovx_siso_get_property (GObject * object, guint property_id,
     GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXSiso *self = NULL;
-  GstTIOVXSisoPrivate *priv = NULL;
-
-  g_return_if_fail (object);
-
-  self = GST_TIOVX_SISO (object);
-  priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = GST_TIOVX_SISO (object);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "get_property");
 
@@ -310,13 +292,8 @@ exit:
 static void
 gst_tiovx_siso_finalize (GObject * obj)
 {
-  GstTIOVXSiso *self = NULL;
-  GstTIOVXSisoPrivate *priv = NULL;
-
-  g_return_if_fail (obj);
-
-  self = GST_TIOVX_SISO (obj);
-  priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = GST_TIOVX_SISO (obj);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "finalize");
 
@@ -354,19 +331,12 @@ static gboolean
 gst_tiovx_siso_set_caps (GstBaseTransform * trans, GstCaps * incaps,
     GstCaps * outcaps)
 {
-  GstTIOVXSiso *self = NULL;
-  GstTIOVXSisoPrivate *priv = NULL;
-  GstTIOVXSisoClass *klass = NULL;
+  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSisoClass *klass = GST_TIOVX_SISO_GET_CLASS (self);
   gboolean ret = TRUE;
 
-  g_return_val_if_fail (trans, FALSE);
-
-  self = GST_TIOVX_SISO (trans);
-  priv = gst_tiovx_siso_get_instance_private (self);
-
   GST_LOG_OBJECT (self, "set_caps");
-
-  klass = GST_TIOVX_SISO_GET_CLASS (self);
 
   if (NULL == klass->compare_caps) {
     GST_WARNING_OBJECT (self,
@@ -419,8 +389,8 @@ static GstFlowReturn
 gst_tiovx_siso_transform (GstBaseTransform * trans, GstBuffer * inbuf,
     GstBuffer * outbuf)
 {
-  GstTIOVXSiso *self = NULL;
-  GstTIOVXSisoPrivate *priv = NULL;
+  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
   GstBuffer *original_buffer = NULL;
   vx_status status = VX_FAILURE;
   vx_object_array in_array = NULL;
@@ -430,13 +400,6 @@ gst_tiovx_siso_transform (GstBaseTransform * trans, GstBuffer * inbuf,
   vx_reference in_ref = NULL;
   vx_reference out_ref = NULL;
   GstFlowReturn ret = GST_FLOW_ERROR;
-
-  g_return_val_if_fail (trans, GST_FLOW_ERROR);
-  g_return_val_if_fail (inbuf, GST_FLOW_ERROR);
-  g_return_val_if_fail (outbuf, GST_FLOW_ERROR);
-
-  self = GST_TIOVX_SISO (trans);
-  priv = gst_tiovx_siso_get_instance_private (self);
 
   original_buffer = inbuf;
   inbuf =
@@ -529,18 +492,12 @@ exit:
 static gboolean
 gst_tiovx_siso_decide_allocation (GstBaseTransform * trans, GstQuery * query)
 {
-  GstTIOVXSiso *self = NULL;
-  GstTIOVXSisoPrivate *priv = NULL;
+  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
   GstBufferPool *pool = NULL;
   gboolean ret = TRUE;
   gint npool = 0;
   gboolean pool_needed = TRUE;
-
-  g_return_val_if_fail (trans, FALSE);
-  g_return_val_if_fail (query, FALSE);
-
-  self = GST_TIOVX_SISO (trans);
-  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "Decide allocation");
 
@@ -606,18 +563,11 @@ static gboolean
 gst_tiovx_siso_propose_allocation (GstBaseTransform * trans,
     GstQuery * decide_query, GstQuery * query)
 {
-  GstTIOVXSiso *self = NULL;
-  GstTIOVXSisoPrivate *priv = NULL;
+  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
   GstBufferPool *pool = NULL;
   gsize size = 0;
   gboolean ret = TRUE;
-
-  g_return_val_if_fail (trans, FALSE);
-  g_return_val_if_fail (decide_query, FALSE);
-  g_return_val_if_fail (query, FALSE);
-
-  self = GST_TIOVX_SISO (trans);
-  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "Propose allocation");
 

--- a/gst-libs/gst/tiovx/gsttiovxsiso.c
+++ b/gst-libs/gst/tiovx/gsttiovxsiso.c
@@ -253,14 +253,9 @@ gst_tiovx_siso_get_property (GObject * object, guint property_id,
 static gboolean
 gst_tiovx_siso_stop (GstBaseTransform * trans)
 {
-  GstTIOVXSiso *self = NULL;
-  GstTIOVXSisoPrivate *priv = NULL;
+  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
+  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
   gboolean ret = FALSE;
-
-  g_return_val_if_fail (trans, ret);
-
-  self = GST_TIOVX_SISO (trans);
-  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "stop");
 

--- a/gst-libs/gst/tiovx/gsttiovxsiso.c
+++ b/gst-libs/gst/tiovx/gsttiovxsiso.c
@@ -133,9 +133,13 @@ static vx_status gst_tiovx_siso_process_graph (GstTIOVXSiso * self);
 static void
 gst_tiovx_siso_class_init (GstTIOVXSisoClass * klass)
 {
-  GstBaseTransformClass *base_transform_class =
-      GST_BASE_TRANSFORM_CLASS (klass);
-  GObjectClass *gobject_class = (GObjectClass *) klass;
+  GstBaseTransformClass *base_transform_class = NULL;
+  GObjectClass *gobject_class = NULL;
+
+  g_return_if_fail (klass);
+
+  base_transform_class = GST_BASE_TRANSFORM_CLASS (klass);
+  gobject_class = (GObjectClass *) klass;
 
   gobject_class->set_property = gst_tiovx_siso_set_property;
   gobject_class->get_property = gst_tiovx_siso_get_property;
@@ -169,7 +173,11 @@ gst_tiovx_siso_class_init (GstTIOVXSisoClass * klass)
 static void
 gst_tiovx_siso_init (GstTIOVXSiso * self)
 {
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSisoPrivate *priv = NULL;
+
+  g_return_if_fail (self);
+
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   priv->in_caps = NULL;
   priv->out_caps = NULL;
@@ -206,8 +214,13 @@ static void
 gst_tiovx_siso_set_property (GObject * object, guint property_id,
     const GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXSiso *self = GST_TIOVX_SISO (object);
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = NULL;
+  GstTIOVXSisoPrivate *priv = NULL;
+
+  g_return_if_fail (object);
+
+  self = GST_TIOVX_SISO (object);
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "set_property");
 
@@ -230,8 +243,13 @@ static void
 gst_tiovx_siso_get_property (GObject * object, guint property_id,
     GValue * value, GParamSpec * pspec)
 {
-  GstTIOVXSiso *self = GST_TIOVX_SISO (object);
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = NULL;
+  GstTIOVXSisoPrivate *priv = NULL;
+
+  g_return_if_fail (object);
+
+  self = GST_TIOVX_SISO (object);
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_DEBUG_OBJECT (self, "get_property");
 
@@ -253,13 +271,18 @@ gst_tiovx_siso_get_property (GObject * object, guint property_id,
 static gboolean
 gst_tiovx_siso_stop (GstBaseTransform * trans)
 {
-  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = NULL;
+  GstTIOVXSisoPrivate *priv = NULL;
   gboolean ret = FALSE;
+
+  g_return_val_if_fail (trans, ret);
+
+  self = GST_TIOVX_SISO (trans);
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "stop");
 
-  if (!priv->graph) {
+  if (NULL == priv->graph) {
     GST_WARNING_OBJECT (self,
         "Trying to deinit modules but initialization was not completed, ignoring...");
     ret = TRUE;
@@ -287,8 +310,13 @@ exit:
 static void
 gst_tiovx_siso_finalize (GObject * obj)
 {
-  GstTIOVXSiso *self = GST_TIOVX_SISO (obj);
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = NULL;
+  GstTIOVXSisoPrivate *priv = NULL;
+
+  g_return_if_fail (obj);
+
+  self = GST_TIOVX_SISO (obj);
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "finalize");
 
@@ -326,16 +354,21 @@ static gboolean
 gst_tiovx_siso_set_caps (GstBaseTransform * trans, GstCaps * incaps,
     GstCaps * outcaps)
 {
-  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
+  GstTIOVXSiso *self = NULL;
+  GstTIOVXSisoPrivate *priv = NULL;
   GstTIOVXSisoClass *klass = NULL;
   gboolean ret = TRUE;
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+
+  g_return_val_if_fail (trans, FALSE);
+
+  self = GST_TIOVX_SISO (trans);
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "set_caps");
 
   klass = GST_TIOVX_SISO_GET_CLASS (self);
 
-  if (!klass->compare_caps) {
+  if (NULL == klass->compare_caps) {
     GST_WARNING_OBJECT (self,
         "Subclass did not implement compare_caps method.");
   } else {
@@ -386,9 +419,9 @@ static GstFlowReturn
 gst_tiovx_siso_transform (GstBaseTransform * trans, GstBuffer * inbuf,
     GstBuffer * outbuf)
 {
-  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
+  GstTIOVXSiso *self = NULL;
+  GstTIOVXSisoPrivate *priv = NULL;
   GstBuffer *original_buffer = NULL;
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
   vx_status status = VX_FAILURE;
   vx_object_array in_array = NULL;
   vx_object_array out_array = NULL;
@@ -397,6 +430,13 @@ gst_tiovx_siso_transform (GstBaseTransform * trans, GstBuffer * inbuf,
   vx_reference in_ref = NULL;
   vx_reference out_ref = NULL;
   GstFlowReturn ret = GST_FLOW_ERROR;
+
+  g_return_val_if_fail (trans, GST_FLOW_ERROR);
+  g_return_val_if_fail (inbuf, GST_FLOW_ERROR);
+  g_return_val_if_fail (outbuf, GST_FLOW_ERROR);
+
+  self = GST_TIOVX_SISO (trans);
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   original_buffer = inbuf;
   inbuf =
@@ -489,12 +529,18 @@ exit:
 static gboolean
 gst_tiovx_siso_decide_allocation (GstBaseTransform * trans, GstQuery * query)
 {
-  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = NULL;
+  GstTIOVXSisoPrivate *priv = NULL;
   GstBufferPool *pool = NULL;
   gboolean ret = TRUE;
   gint npool = 0;
   gboolean pool_needed = TRUE;
+
+  g_return_val_if_fail (trans, FALSE);
+  g_return_val_if_fail (query, FALSE);
+
+  self = GST_TIOVX_SISO (trans);
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "Decide allocation");
 
@@ -560,11 +606,18 @@ static gboolean
 gst_tiovx_siso_propose_allocation (GstBaseTransform * trans,
     GstQuery * decide_query, GstQuery * query)
 {
-  GstTIOVXSiso *self = GST_TIOVX_SISO (trans);
-  GstTIOVXSisoPrivate *priv = gst_tiovx_siso_get_instance_private (self);
+  GstTIOVXSiso *self = NULL;
+  GstTIOVXSisoPrivate *priv = NULL;
   GstBufferPool *pool = NULL;
   gsize size = 0;
   gboolean ret = TRUE;
+
+  g_return_val_if_fail (trans, FALSE);
+  g_return_val_if_fail (decide_query, FALSE);
+  g_return_val_if_fail (query, FALSE);
+
+  self = GST_TIOVX_SISO (trans);
+  priv = gst_tiovx_siso_get_instance_private (self);
 
   GST_LOG_OBJECT (self, "Propose allocation");
 
@@ -652,28 +705,28 @@ gst_tiovx_siso_is_subclass_complete (GstTIOVXSiso * self)
 
   klass = GST_TIOVX_SISO_GET_CLASS (self);
 
-  if (!klass->init_module) {
+  if (NULL == klass->init_module) {
     GST_ERROR_OBJECT (self, "Subclass did not implement init_module method.");
     goto exit;
   }
 
-  if (!klass->create_graph) {
+  if (NULL == klass->create_graph) {
     GST_ERROR_OBJECT (self, "Subclass did not implement create_graph method.");
     goto exit;
   }
 
-  if (!klass->get_node_info) {
+  if (NULL == klass->get_node_info) {
     GST_ERROR_OBJECT (self, "Subclass did not implement get_node_info method");
     goto exit;
   }
 
-  if (!klass->release_buffer) {
+  if (NULL == klass->release_buffer) {
     GST_ERROR_OBJECT (self,
         "Subclass did not implement release_buffer method.");
     goto exit;
   }
 
-  if (!klass->deinit_module) {
+  if (NULL == klass->deinit_module) {
     GST_ERROR_OBJECT (self, "Subclass did not implement deinit_module method.");
     goto exit;
   }
@@ -746,15 +799,15 @@ gst_tiovx_siso_modules_init (GstTIOVXSiso * self)
     goto free_graph;
   }
 
-  if (!priv->input) {
+  if (NULL == priv->input) {
     GST_ERROR_OBJECT (self, "Incomplete info from subclass: input missing");
     goto free_graph;
   }
-  if (!priv->output) {
+  if (NULL == priv->output) {
     GST_ERROR_OBJECT (self, "Incomplete info from subclass: output missing");
     goto free_graph;
   }
-  if (!priv->node) {
+  if (NULL == priv->node) {
     GST_ERROR_OBJECT (self, "Incomplete info from subclass: node missing");
     goto free_graph;
   }

--- a/gst-libs/gst/tiovx/gsttiovxsiso.h
+++ b/gst-libs/gst/tiovx/gsttiovxsiso.h
@@ -69,7 +69,7 @@
 
 G_BEGIN_DECLS
 
-#define GST_TIOVX_SISO_TYPE   (gst_tiovx_siso_get_type())
+#define GST_TYPE_TIOVX_SISO   (gst_tiovx_siso_get_type())
 G_DECLARE_DERIVABLE_TYPE (GstTIOVXSiso, gst_tiovx_siso, GST,
 	TIOVX_SISO, GstBaseTransform)
 

--- a/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c
@@ -243,7 +243,7 @@ gst_tiovx_tensor_buffer_pool_set_config (GstBufferPool * pool,
 
   gst_buffer_pool_config_get_allocator (config, &allocator, NULL);
   if (NULL == allocator) {
-    allocator = g_object_new (GST_TIOVX_TYPE_ALLOCATOR, NULL);
+    allocator = g_object_new (GST_TYPE_TIOVX_ALLOCATOR, NULL);
     gst_buffer_pool_config_set_allocator (config,
         GST_ALLOCATOR (allocator), NULL);
   } else if (!GST_TIOVX_IS_ALLOCATOR (allocator)) {

--- a/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c
@@ -364,7 +364,7 @@ gst_tiovx_tensor_buffer_pool_free_buffer (GstBufferPool * pool,
 
   tiovxmeta =
       (GstTIOVXTensorMeta *) gst_buffer_get_meta (buffer,
-      GST_TIOVX_TENSOR_META_API_TYPE);
+      GST_TYPE_TIOVX_TENSOR_META_API);
   if (NULL != tiovxmeta) {
     if (NULL != tiovxmeta->array) {
       /* We currently support a single channel */

--- a/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c
@@ -166,8 +166,13 @@ out:
 static void
 gst_tiovx_tensor_buffer_pool_class_init (GstTIOVXTensorBufferPoolClass * klass)
 {
-  GObjectClass *o_class = G_OBJECT_CLASS (klass);
-  GstBufferPoolClass *bp_class = GST_BUFFER_POOL_CLASS (klass);
+  GObjectClass *o_class = NULL;
+  GstBufferPoolClass *bp_class = NULL;
+
+  g_return_if_fail (klass);
+
+  o_class = G_OBJECT_CLASS (klass);
+  bp_class = GST_BUFFER_POOL_CLASS (klass);
 
   o_class->finalize = gst_tiovx_tensor_buffer_pool_finalize;
 
@@ -194,7 +199,7 @@ static gboolean
 gst_tiovx_tensor_buffer_pool_set_config (GstBufferPool * pool,
     GstStructure * config)
 {
-  GstTIOVXTensorBufferPool *self = GST_TIOVX_TENSOR_BUFFER_POOL (pool);
+  GstTIOVXTensorBufferPool *self = NULL;
   GstAllocator *allocator = NULL;
   vx_reference exemplar = NULL;
   vx_status status = VX_SUCCESS;
@@ -202,6 +207,11 @@ gst_tiovx_tensor_buffer_pool_set_config (GstBufferPool * pool,
   guint min_buffers = 0;
   guint max_buffers = 0;
   guint size = 0;
+
+  g_return_val_if_fail (pool, FALSE);
+  g_return_val_if_fail (config, FALSE);
+
+  self = GST_TIOVX_TENSOR_BUFFER_POOL (pool);
 
   if (!gst_buffer_pool_config_get_params (config, &caps, &size, &min_buffers,
           &max_buffers)) {
@@ -283,9 +293,13 @@ gst_tiovx_tensor_buffer_pool_alloc_buffer (GstBufferPool * pool,
   GstTIOVXTensorMeta *tiovxmeta = NULL;
   guint i = 0;
 
-  GST_DEBUG_OBJECT (self, "Allocating TIOVX tensor buffer");
+  g_return_val_if_fail (pool, GST_FLOW_ERROR);
+
+  self = GST_TIOVX_TENSOR_BUFFER_POOL (pool);
 
   g_return_val_if_fail (self->exemplar, GST_FLOW_ERROR);
+
+  GST_DEBUG_OBJECT (self, "Allocating TIOVX tensor buffer");
 
   /* Calculate tensor size */
   vxQueryTensor ((vx_tensor) self->exemplar, VX_TENSOR_NUMBER_OF_DIMS,
@@ -362,6 +376,9 @@ gst_tiovx_tensor_buffer_pool_free_buffer (GstBufferPool * pool,
   GstTIOVXTensorMeta *tiovxmeta = NULL;
   vx_reference ref = NULL;
 
+  g_return_if_fail (pool);
+  g_return_if_fail (buffer);
+
   tiovxmeta =
       (GstTIOVXTensorMeta *) gst_buffer_get_meta (buffer,
       GST_TYPE_TIOVX_TENSOR_META_API);
@@ -383,7 +400,11 @@ gst_tiovx_tensor_buffer_pool_free_buffer (GstBufferPool * pool,
 static void
 gst_tiovx_tensor_buffer_pool_finalize (GObject * object)
 {
-  GstTIOVXTensorBufferPool *self = GST_TIOVX_TENSOR_BUFFER_POOL (object);
+  GstTIOVXTensorBufferPool *self = NULL;
+
+  g_return_if_fail (object);
+
+  self = GST_TIOVX_TENSOR_BUFFER_POOL (object);
 
   GST_DEBUG_OBJECT (self, "Finalizing TIOVX tensor buffer pool");
 

--- a/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c
@@ -166,13 +166,8 @@ out:
 static void
 gst_tiovx_tensor_buffer_pool_class_init (GstTIOVXTensorBufferPoolClass * klass)
 {
-  GObjectClass *o_class = NULL;
-  GstBufferPoolClass *bp_class = NULL;
-
-  g_return_if_fail (klass);
-
-  o_class = G_OBJECT_CLASS (klass);
-  bp_class = GST_BUFFER_POOL_CLASS (klass);
+  GObjectClass *o_class = G_OBJECT_CLASS (klass);
+  GstBufferPoolClass *bp_class = GST_BUFFER_POOL_CLASS (klass);
 
   o_class->finalize = gst_tiovx_tensor_buffer_pool_finalize;
 
@@ -199,7 +194,7 @@ static gboolean
 gst_tiovx_tensor_buffer_pool_set_config (GstBufferPool * pool,
     GstStructure * config)
 {
-  GstTIOVXTensorBufferPool *self = NULL;
+  GstTIOVXTensorBufferPool *self = GST_TIOVX_TENSOR_BUFFER_POOL (pool);
   GstAllocator *allocator = NULL;
   vx_reference exemplar = NULL;
   vx_status status = VX_SUCCESS;
@@ -207,11 +202,6 @@ gst_tiovx_tensor_buffer_pool_set_config (GstBufferPool * pool,
   guint min_buffers = 0;
   guint max_buffers = 0;
   guint size = 0;
-
-  g_return_val_if_fail (pool, FALSE);
-  g_return_val_if_fail (config, FALSE);
-
-  self = GST_TIOVX_TENSOR_BUFFER_POOL (pool);
 
   if (!gst_buffer_pool_config_get_params (config, &caps, &size, &min_buffers,
           &max_buffers)) {
@@ -293,11 +283,11 @@ gst_tiovx_tensor_buffer_pool_alloc_buffer (GstBufferPool * pool,
   GstTIOVXTensorMeta *tiovxmeta = NULL;
   guint i = 0;
 
-  g_return_val_if_fail (pool, GST_FLOW_ERROR);
-
-  self = GST_TIOVX_TENSOR_BUFFER_POOL (pool);
-
-  g_return_val_if_fail (self->exemplar, GST_FLOW_ERROR);
+  if (NULL == self->exemplar) {
+    GST_ERROR_OBJECT (self,
+        "Failed to alloc tensor buffer, invalid exemplar reference");
+    return ret;
+  }
 
   GST_DEBUG_OBJECT (self, "Allocating TIOVX tensor buffer");
 
@@ -305,7 +295,11 @@ gst_tiovx_tensor_buffer_pool_alloc_buffer (GstBufferPool * pool,
   vxQueryTensor ((vx_tensor) self->exemplar, VX_TENSOR_NUMBER_OF_DIMS,
       &num_dims, sizeof (num_dims));
 
-  g_return_val_if_fail (0 < num_dims, GST_FLOW_ERROR);
+  if (0 > num_dims) {
+    GST_ERROR_OBJECT (self,
+        "Failed to alloc tensor buffer, invalid number of tensor dimensions");
+    return ret;
+  }
 
   vxQueryTensor ((vx_tensor) self->exemplar, VX_TENSOR_DIMS, &dims,
       num_dims * sizeof (num_dims));
@@ -376,9 +370,6 @@ gst_tiovx_tensor_buffer_pool_free_buffer (GstBufferPool * pool,
   GstTIOVXTensorMeta *tiovxmeta = NULL;
   vx_reference ref = NULL;
 
-  g_return_if_fail (pool);
-  g_return_if_fail (buffer);
-
   tiovxmeta =
       (GstTIOVXTensorMeta *) gst_buffer_get_meta (buffer,
       GST_TYPE_TIOVX_TENSOR_META_API);
@@ -400,11 +391,7 @@ gst_tiovx_tensor_buffer_pool_free_buffer (GstBufferPool * pool,
 static void
 gst_tiovx_tensor_buffer_pool_finalize (GObject * object)
 {
-  GstTIOVXTensorBufferPool *self = NULL;
-
-  g_return_if_fail (object);
-
-  self = GST_TIOVX_TENSOR_BUFFER_POOL (object);
+  GstTIOVXTensorBufferPool *self = GST_TIOVX_TENSOR_BUFFER_POOL (object);
 
   GST_DEBUG_OBJECT (self, "Finalizing TIOVX tensor buffer pool");
 

--- a/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.h
+++ b/gst-libs/gst/tiovx/gsttiovxtensorbufferpool.h
@@ -69,7 +69,7 @@
 
 G_BEGIN_DECLS 
 
-#define GST_TIOVX_TYPE_TENSOR_BUFFER_POOL gst_tiovx_tensor_buffer_pool_get_type ()
+#define GST_TYPE_TIOVX_TENSOR_BUFFER_POOL gst_tiovx_tensor_buffer_pool_get_type ()
 
 /**
  * GST_TIOVX_IS_TENSOR_BUFFER_POOL:

--- a/gst-libs/gst/tiovx/gsttiovxtensormeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensormeta.c
@@ -65,7 +65,7 @@
 
 #include <TI/tivx.h>
 
-static const vx_size k_tiovx_array_lenght = 1;
+static const vx_size tiovx_array_lenght = 1;
 
 static gboolean gst_tiovx_tensor_meta_init (GstMeta * meta,
     gpointer params, GstBuffer * buffer);
@@ -166,7 +166,7 @@ gst_buffer_add_tiovx_tensor_meta (GstBuffer * buffer,
   /* Create new array based on exemplar */
   array =
       vxCreateObjectArray (vxGetContext (exemplar), exemplar,
-      k_tiovx_array_lenght);
+      tiovx_array_lenght);
 
   /* Import memory into the meta's vx reference */
   ref = (vx_tensor) vxGetObjectArrayItem (array, 0);

--- a/gst-libs/gst/tiovx/gsttiovxtensormeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensormeta.c
@@ -175,7 +175,7 @@ gst_buffer_add_tiovx_tensor_meta (GstBuffer * buffer,
       tivxReferenceImportHandle ((vx_reference) ref, (const void **) addr,
       tensor_size, num_tensors);
 
-  if (ref != NULL) {
+  if (NULL != ref) {
     vxReleaseReference ((vx_reference *) & ref);
   }
   if (status != VX_SUCCESS) {

--- a/gst-libs/gst/tiovx/gsttiovxtensormeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensormeta.c
@@ -91,7 +91,7 @@ gst_tiovx_tensor_meta_get_info (void)
   static const GstMetaInfo *info = NULL;
 
   if (g_once_init_enter (&info)) {
-    const GstMetaInfo *meta = gst_meta_register (GST_TIOVX_TENSOR_META_API_TYPE,
+    const GstMetaInfo *meta = gst_meta_register (GST_TYPE_TIOVX_TENSOR_META_API,
         "GstTIOVXTensorMeta",
         sizeof (GstTIOVXTensorMeta),
         gst_tiovx_tensor_meta_init,

--- a/gst-libs/gst/tiovx/gsttiovxtensormeta.h
+++ b/gst-libs/gst/tiovx/gsttiovxtensormeta.h
@@ -70,7 +70,7 @@
 
 G_BEGIN_DECLS 
 
-#define GST_TIOVX_TENSOR_META_API_TYPE (gst_tiovx_tensor_meta_api_get_type())
+#define GST_TYPE_TIOVX_TENSOR_META_API (gst_tiovx_tensor_meta_api_get_type())
 #define GST_TIOVX_TENSOR_META_INFO  (gst_tiovx_tensor_meta_get_info())
 
 /**

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -328,7 +328,7 @@ gst_tiovx_create_new_pool (GstDebugCategory * category, vx_reference * exemplar)
 
   if (VX_TYPE_IMAGE == type) {
     GST_CAT_INFO (category, "Creating Image buffer pool");
-    pool = g_object_new (GST_TIOVX_TYPE_BUFFER_POOL, NULL);
+    pool = g_object_new (GST_TYPE_TIOVX_BUFFER_POOL, NULL);
   } else if (VX_TYPE_TENSOR == type) {
     GST_CAT_INFO (category, "Creating Tensor buffer pool");
     pool = g_object_new (GST_TIOVX_TYPE_TENSOR_BUFFER_POOL, NULL);

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -331,7 +331,7 @@ gst_tiovx_create_new_pool (GstDebugCategory * category, vx_reference * exemplar)
     pool = g_object_new (GST_TYPE_TIOVX_BUFFER_POOL, NULL);
   } else if (VX_TYPE_TENSOR == type) {
     GST_CAT_INFO (category, "Creating Tensor buffer pool");
-    pool = g_object_new (GST_TIOVX_TYPE_TENSOR_BUFFER_POOL, NULL);
+    pool = g_object_new (GST_TYPE_TIOVX_TENSOR_BUFFER_POOL, NULL);
   } else {
     GST_CAT_ERROR (category,
         "Type %d not supported, buffer pool was not created", type);

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -619,7 +619,7 @@ gst_tiovx_get_vx_array_from_buffer (GstDebugCategory * category,
   if (VX_TYPE_IMAGE == type) {
     GstTIOVXMeta *meta = NULL;
     meta =
-        (GstTIOVXMeta *) gst_buffer_get_meta (buffer, GST_TIOVX_META_API_TYPE);
+        (GstTIOVXMeta *) gst_buffer_get_meta (buffer, GST_TYPE_TIOVX_META_API);
     if (!meta) {
       GST_CAT_ERROR (category, "TIOVX Meta was not found in buffer");
       goto exit;

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -630,7 +630,7 @@ gst_tiovx_get_vx_array_from_buffer (GstDebugCategory * category,
     GstTIOVXTensorMeta *meta = NULL;
     meta =
         (GstTIOVXTensorMeta *) gst_buffer_get_meta (buffer,
-        GST_TIOVX_TENSOR_META_API_TYPE);
+        GST_TYPE_TIOVX_TENSOR_META_API);
     if (!meta) {
       GST_CAT_ERROR (category, "TIOVX Tensor Meta was not found in buffer");
       goto exit;

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -260,12 +260,13 @@ gst_tiovx_configure_pool (GstDebugCategory * category, GstBufferPool * pool,
   GstStructure *config = NULL;
   gboolean ret = FALSE;
 
-  g_return_val_if_fail (category, FALSE);
-  g_return_val_if_fail (pool, FALSE);
-  g_return_val_if_fail (exemplar, FALSE);
-  g_return_val_if_fail (caps, FALSE);
-  g_return_val_if_fail (size > 0, FALSE);
-  g_return_val_if_fail (num_buffers > 0, FALSE);
+  g_return_val_if_fail (category, ret);
+  g_return_val_if_fail (pool, ret);
+  g_return_val_if_fail (exemplar, ret);
+  g_return_val_if_fail (VX_SUCCESS == vxGetStatus (*exemplar), VX_FAILURE);
+  g_return_val_if_fail (caps, ret);
+  g_return_val_if_fail (size > 0, ret);
+  g_return_val_if_fail (num_buffers > 0, ret);
 
   config = gst_buffer_pool_get_config (pool);
 
@@ -300,6 +301,7 @@ gst_tiovx_get_exemplar_type (vx_reference * exemplar)
   vx_status status = VX_FAILURE;
 
   g_return_val_if_fail (exemplar, -1);
+  g_return_val_if_fail (VX_SUCCESS == vxGetStatus (*exemplar), -1);
 
   status =
       vxQueryReference ((vx_reference) * exemplar, (vx_enum) VX_REFERENCE_TYPE,
@@ -320,6 +322,7 @@ gst_tiovx_create_new_pool (GstDebugCategory * category, vx_reference * exemplar)
 
   g_return_val_if_fail (category, NULL);
   g_return_val_if_fail (exemplar, NULL);
+  g_return_val_if_fail (VX_SUCCESS == vxGetStatus (*exemplar), NULL);
 
   GST_CAT_INFO (category, "Creating new pool");
 
@@ -352,13 +355,14 @@ gst_tiovx_add_new_pool (GstDebugCategory * category, GstQuery * query,
   g_return_val_if_fail (category, FALSE);
   g_return_val_if_fail (query, FALSE);
   g_return_val_if_fail (exemplar, FALSE);
+  g_return_val_if_fail (VX_SUCCESS == vxGetStatus (*exemplar), FALSE);
   g_return_val_if_fail (size > 0, FALSE);
 
   GST_CAT_DEBUG (category, "Adding new pool");
 
   pool = gst_tiovx_create_new_pool (category, exemplar);
 
-  if (!pool) {
+  if (NULL == pool) {
     GST_CAT_ERROR (category, "Create TIOVX pool failed");
     return FALSE;
   }
@@ -497,7 +501,7 @@ gst_tiovx_empty_exemplar (vx_reference ref)
   vx_uint32 sizes[MODULE_MAX_NUM_ADDRS];
   uint32_t num_addrs;
 
-  g_return_val_if_fail (ref, VX_FAILURE);
+  g_return_val_if_fail (VX_SUCCESS == vxGetStatus (ref), VX_FAILURE);
 
   tivxReferenceExportHandle (ref,
       addr, sizes, MODULE_MAX_NUM_ADDRS, &num_addrs);
@@ -544,6 +548,7 @@ gst_tiovx_validate_tiovx_buffer (GstDebugCategory * category,
   g_return_val_if_fail (category, NULL);
   g_return_val_if_fail (pool, NULL);
   g_return_val_if_fail (buffer, NULL);
+
 
   /* Propose allocation did not happen, there is no upstream pool therefore
    * the element has to create one */
@@ -593,7 +598,7 @@ gst_tiovx_validate_tiovx_buffer (GstDebugCategory * category,
 
       buffer =
           gst_tiovx_buffer_copy (category, GST_BUFFER_POOL (*pool), buffer);
-      if (!buffer) {
+      if (NULL == buffer) {
         GST_CAT_ERROR (category, "Failure when copying input buffer from pool");
       }
     }
@@ -612,6 +617,7 @@ gst_tiovx_get_vx_array_from_buffer (GstDebugCategory * category,
 
   g_return_val_if_fail (category, NULL);
   g_return_val_if_fail (exemplar, NULL);
+  g_return_val_if_fail (VX_SUCCESS == vxGetStatus (*exemplar), NULL);
   g_return_val_if_fail (buffer, NULL);
 
   type = gst_tiovx_get_exemplar_type (exemplar);
@@ -620,7 +626,7 @@ gst_tiovx_get_vx_array_from_buffer (GstDebugCategory * category,
     GstTIOVXMeta *meta = NULL;
     meta =
         (GstTIOVXMeta *) gst_buffer_get_meta (buffer, GST_TYPE_TIOVX_META_API);
-    if (!meta) {
+    if (NULL == meta) {
       GST_CAT_ERROR (category, "TIOVX Meta was not found in buffer");
       goto exit;
     }
@@ -631,7 +637,7 @@ gst_tiovx_get_vx_array_from_buffer (GstDebugCategory * category,
     meta =
         (GstTIOVXTensorMeta *) gst_buffer_get_meta (buffer,
         GST_TYPE_TIOVX_TENSOR_META_API);
-    if (!meta) {
+    if (NULL == meta) {
       GST_CAT_ERROR (category, "TIOVX Tensor Meta was not found in buffer");
       goto exit;
     }
@@ -653,6 +659,7 @@ gst_tiovx_get_size_from_exemplar (vx_reference * exemplar, GstCaps * caps)
   vx_enum type = VX_TYPE_INVALID;
 
   g_return_val_if_fail (exemplar, 0);
+  g_return_val_if_fail (VX_SUCCESS == vxGetStatus (*exemplar), 0);
   g_return_val_if_fail (caps, 0);
 
   type = gst_tiovx_get_exemplar_type (exemplar);

--- a/tests/check/libs/gsttiovxallocator.c
+++ b/tests/check/libs/gsttiovxallocator.c
@@ -95,7 +95,7 @@ GST_START_TEST (test_dmabuf)
 
   init ();
 
-  alloc = g_object_new (GST_TIOVX_TYPE_ALLOCATOR, NULL);
+  alloc = g_object_new (GST_TYPE_TIOVX_ALLOCATOR, NULL);
 
   mem = gst_allocator_alloc (GST_ALLOCATOR (alloc), MEM_SIZE, NULL);
 

--- a/tests/check/libs/gsttiovxbufferpool.c
+++ b/tests/check/libs/gsttiovxbufferpool.c
@@ -274,7 +274,7 @@ GST_END_TEST;
 GST_START_TEST (test_external_allocator)
 {
   GstBufferPool *pool = get_pool ();
-  GstAllocator *allocator = g_object_new (GST_TIOVX_TYPE_ALLOCATOR, NULL);
+  GstAllocator *allocator = g_object_new (GST_TYPE_TIOVX_ALLOCATOR, NULL);
   GstBuffer *buf = NULL;
   GstTIOVXMeta *meta = NULL;
   vx_image image = NULL;

--- a/tests/check/libs/gsttiovxbufferpool.c
+++ b/tests/check/libs/gsttiovxbufferpool.c
@@ -93,7 +93,7 @@ get_pool (void)
   tivxInit ();
   tivxHostInit ();
 
-  tiovx_pool = g_object_new (GST_TIOVX_TYPE_BUFFER_POOL, NULL);
+  tiovx_pool = g_object_new (GST_TYPE_TIOVX_BUFFER_POOL, NULL);
 
   return GST_BUFFER_POOL (tiovx_pool);
 

--- a/tests/check/libs/gsttiovxbufferpool.c
+++ b/tests/check/libs/gsttiovxbufferpool.c
@@ -141,7 +141,7 @@ GST_START_TEST (test_new_buffer)
   fail_if (NULL == buf, "No buffer has been returned");
 
   /* Check for a valid vx_image */
-  meta = (GstTIOVXMeta *) gst_buffer_get_meta (buf, GST_TIOVX_META_API_TYPE);
+  meta = (GstTIOVXMeta *) gst_buffer_get_meta (buf, GST_TYPE_TIOVX_META_API);
   image = (vx_image) vxGetObjectArrayItem (meta->array, 0);
 
   vxQueryImage (image, VX_IMAGE_WIDTH, &img_width, sizeof (img_width));
@@ -316,7 +316,7 @@ GST_START_TEST (test_external_allocator)
   fail_if (NULL == buf, "No buffer has been returned");
 
   /* Check for a valid vx_image */
-  meta = (GstTIOVXMeta *) gst_buffer_get_meta (buf, GST_TIOVX_META_API_TYPE);
+  meta = (GstTIOVXMeta *) gst_buffer_get_meta (buf, GST_TYPE_TIOVX_META_API);
   image = (vx_image) vxGetObjectArrayItem (meta->array, 0);
 
   vxQueryImage (image, VX_IMAGE_WIDTH, &img_width, sizeof (img_width));

--- a/tests/check/libs/gsttiovxmiso.c
+++ b/tests/check/libs/gsttiovxmiso.c
@@ -105,7 +105,7 @@ struct _GstTestTIOVXMisoClass
 };
 
 #define gst_test_tiovx_miso_parent_class parent_class
-G_DEFINE_TYPE (GstTestTIOVXMiso, gst_test_tiovx_miso, GST_TIOVX_MISO_TYPE);
+G_DEFINE_TYPE (GstTestTIOVXMiso, gst_test_tiovx_miso, GST_TYPE_TIOVX_MISO);
 
 static void
 gst_test_tiovx_miso_create_vx_reference (GstTestTIOVXMiso * agg,

--- a/tests/check/libs/gsttiovxpad.c
+++ b/tests/check/libs/gsttiovxpad.c
@@ -173,7 +173,7 @@ initialize_tiovx_buffer_pool (GstBufferPool ** buffer_pool)
   vx_status status;
   vx_reference reference;
 
-  *buffer_pool = g_object_new (GST_TIOVX_TYPE_BUFFER_POOL, NULL);
+  *buffer_pool = g_object_new (GST_TYPE_TIOVX_BUFFER_POOL, NULL);
 
   conf = gst_buffer_pool_get_config (*buffer_pool);
   caps = gst_caps_new_simple ("video/x-raw",

--- a/tests/check/libs/gsttiovxpad.c
+++ b/tests/check/libs/gsttiovxpad.c
@@ -106,7 +106,7 @@ init (GstTIOVXPad ** pad, vx_context * context, vx_reference * reference)
 {
   vx_status status;
 
-  *pad = g_object_new (GST_TIOVX_TYPE_PAD, NULL);
+  *pad = g_object_new (GST_TYPE_TIOVX_PAD, NULL);
   fail_if (!*pad, "Unable to create a TIOVX pad");
 
   *context = vxCreateContext ();

--- a/tests/check/libs/gsttiovxtensorbufferpool.c
+++ b/tests/check/libs/gsttiovxtensorbufferpool.c
@@ -92,7 +92,7 @@ get_pool (void)
   tivxInit ();
   tivxHostInit ();
 
-  tiovx_pool = g_object_new (GST_TIOVX_TYPE_TENSOR_BUFFER_POOL, NULL);
+  tiovx_pool = g_object_new (GST_TYPE_TIOVX_TENSOR_BUFFER_POOL, NULL);
 
   return GST_BUFFER_POOL (tiovx_pool);
 

--- a/tests/check/libs/gsttiovxtensorbufferpool.c
+++ b/tests/check/libs/gsttiovxtensorbufferpool.c
@@ -156,7 +156,7 @@ test_new_buffer (vx_enum data_type, vx_size expected_size)
   /* Check for a valid vx_tensor */
   meta =
       (GstTIOVXTensorMeta *) gst_buffer_get_meta (buf,
-      GST_TIOVX_TENSOR_META_API_TYPE);
+      GST_TYPE_TIOVX_TENSOR_META_API);
   fail_if (NULL == meta, "No Tensor meta in buffer");
   tensor = (vx_tensor) vxGetObjectArrayItem (meta->array, 0);
 
@@ -482,7 +482,7 @@ GST_START_TEST (test_external_allocator)
   /* Check for a valid vx_tensor */
   meta =
       (GstTIOVXTensorMeta *) gst_buffer_get_meta (buf,
-      GST_TIOVX_TENSOR_META_API_TYPE);
+      GST_TYPE_TIOVX_TENSOR_META_API);
   fail_if (NULL == meta, "No Tensor meta in buffer");
   tensor = (vx_tensor) vxGetObjectArrayItem (meta->array, 0);
 

--- a/tests/check/libs/gsttiovxtensorbufferpool.c
+++ b/tests/check/libs/gsttiovxtensorbufferpool.c
@@ -431,7 +431,7 @@ GST_END_TEST;
 GST_START_TEST (test_external_allocator)
 {
   GstBufferPool *pool = get_pool ();
-  GstAllocator *allocator = g_object_new (GST_TIOVX_TYPE_ALLOCATOR, NULL);
+  GstAllocator *allocator = g_object_new (GST_TYPE_TIOVX_ALLOCATOR, NULL);
   GstBuffer *buf = NULL;
   GstTIOVXTensorMeta *meta = NULL;
   gboolean ret = FALSE;


### PR DESCRIPTION
This PR takes care of:

- #79 .
- Change GST_TIOVX_TYPE to GST_TYPE_TIOVX (standarize names).
- Makes pointer guards consistent across base class implementations.