### PR TITLE
mosaic: setting default target to VPAC_MSC2

### DIFF
--- a/ext/tiovx/gsttiovxmosaic.c
+++ b/ext/tiovx/gsttiovxmosaic.c
@@ -265,7 +265,7 @@ gst_tiovx_mosaic_target_get_type (void)
   return target_type;
 }
 
-#define DEFAULT_TIOVX_MOSAIC_TARGET TIVX_TARGET_VPAC_MSC1_AND_2_ID
+#define DEFAULT_TIOVX_MOSAIC_TARGET TIVX_TARGET_VPAC_MSC2_ID
 
 /* Properties definition */
 enum


### PR DESCRIPTION
- This helps prevent a race-around condition when two processess
  creates the same MSC target instance. It is typical that atleast
  two instances of MSC will be running in separate processes. So
  by default let us not enable both MSC instance in mosaic element.

  The proper fix is however in the OpenVx driver, this will be fixed
  post 8.1

Signed-off-by: Shyam Jagannathan <shyam.jagannathan@ti.com>