### PR TITLE
TI/j7.h is deprecated in PSDKR 8.4 align to the same

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovx.h
+++ b/gst-libs/gst/tiovx/gsttiovx.h
@@ -69,7 +69,7 @@
 #include <gst/gst.h>
 
 #include <app_init.h>
-#include <TI/j7.h>
+#include <TI/tivx.h>
 #include <TI/tivx_img_proc.h>
 
 G_BEGIN_DECLS

--- a/pkgconfig/ti_vision_apps.pc
+++ b/pkgconfig/ti_vision_apps.pc
@@ -1,7 +1,6 @@
 prefix=/usr
 exec_prefix=${prefix}
 libdir=${prefix}/lib/
-libdir1=${prefix}/lib/python3.8/site-packages/dlr/
 
 includedir=${prefix}/include/processor_sdk/vision_apps/
 includedirs_app_utils=${prefix}/include/processor_sdk/vision_apps/utils/app_init/include/
@@ -23,5 +22,5 @@ Description: TI Vision Apps library
 Version: 0.1.0
 Requires:
 Requires.private:
-Libs: -L${libdir} -L${libdir1} -ldlr
+Libs: -L${libdir}
 Cflags: -DSOC_J721E -I${includedir} -I${includedirs_app_utils} -I${includedirs_kernels_img} -I${includedirs_fileio} -I${includedirs_dl} -I${includedirs_ivision} -I${includedirs_stereo} -I${includedirs_perception}

--- a/tests/check/libs/gsttiovxmiso.c
+++ b/tests/check/libs/gsttiovxmiso.c
@@ -71,7 +71,6 @@
 #include <gst-libs/gst/tiovx/gsttiovxutils.h>
 
 #include <TI/tivx.h>
-#include <TI/j7.h>
 
 #define TEST_MISO_INPUT 1
 #define TEST_MISO_NUM_CHANNELS 1

--- a/tests/check/libs/gsttiovxsimo.c
+++ b/tests/check/libs/gsttiovxsimo.c
@@ -71,7 +71,6 @@
 #include <gst-libs/gst/tiovx/gsttiovxutils.h>
 
 #include <TI/tivx.h>
-#include <TI/j7.h>
 
 #define TEST_SIMO_OUTPUT 1
 #define TEST_SIMO_NUM_CHANNELS 1

--- a/tests/check/libs/gsttiovxsiso.c
+++ b/tests/check/libs/gsttiovxsiso.c
@@ -71,7 +71,6 @@
 #include <gst-libs/gst/tiovx/gsttiovxutils.h>
 
 #include <TI/tivx.h>
-#include <TI/j7.h>
 
 /* Start of Dummy SISO element */
 


### PR DESCRIPTION
TI/j7.h is deprecated and merged in TI/tivx.h
fix the same. Also remove the dlr dependency for
vision apps

Signed-off-by: Rahul T R <r-ravikumar@ti.com>