### PR TITLE
gst-libs: meta: Fix mem leak while Mapping buffers

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovximagemeta.c
+++ b/gst-libs/gst/tiovx/gsttiovximagemeta.c
@@ -175,6 +175,8 @@ gst_buffer_add_tiovx_image_meta (GstBuffer * buffer,
   vx_image ref = NULL;
   vx_df_image vx_format = VX_DF_IMAGE_VIRT;
   vx_status status;
+  vx_image image_exemplar;
+  vx_bool release_image_exemplar = FALSE;
 
   g_return_val_if_fail (buffer, NULL);
   g_return_val_if_fail (VX_SUCCESS == vxGetStatus ((vx_reference) exemplar),
@@ -195,6 +197,16 @@ gst_buffer_add_tiovx_image_meta (GstBuffer * buffer,
   tivxReferenceExportHandle ((vx_reference) exemplar,
       plane_addr, plane_sizes, MODULE_MAX_NUM_PLANES, &num_planes);
 
+  if (NULL == plane_addr[0]) {
+    /* Copying the image exemplar when memory is not allocated,
+     * since vxMapImagePatch allocates memory which nees to be freed using
+     * vxReleaseImage*/
+    image_exemplar = gst_tiovx_copy_image_exemplar ((vx_image) exemplar);
+    release_image_exemplar = TRUE;
+  } else {
+    image_exemplar = (vx_image) exemplar;
+  }
+
   array = vxCreateObjectArray (vxGetContext (exemplar), exemplar, array_length);
 
   for (i = 0; i < array_length; i++) {
@@ -202,7 +214,7 @@ gst_buffer_add_tiovx_image_meta (GstBuffer * buffer,
       addr[plane_idx] = (void *) (mem_start + prev_size);
       plane_offset[plane_idx] = prev_size;
 
-      gst_tiovx_image_meta_get_plane_info ((vx_image) exemplar, plane_idx,
+      gst_tiovx_image_meta_get_plane_info (image_exemplar, plane_idx,
           &plane_stride_x[plane_idx], &plane_stride_y[plane_idx],
           &plane_steps_x[plane_idx], &plane_steps_y[plane_idx],
           &plane_widths[plane_idx], &plane_heights[plane_idx]);
@@ -250,13 +262,16 @@ gst_buffer_add_tiovx_image_meta (GstBuffer * buffer,
   }
 
   /* Retrieve width, height and format from exemplar */
-  vxQueryImage ((vx_image) exemplar, VX_IMAGE_WIDTH,
+  vxQueryImage (image_exemplar, VX_IMAGE_WIDTH,
       &tiovx_meta->image_info.width, sizeof (tiovx_meta->image_info.width));
-  vxQueryImage ((vx_image) exemplar, VX_IMAGE_HEIGHT,
+  vxQueryImage (image_exemplar, VX_IMAGE_HEIGHT,
       &tiovx_meta->image_info.height, sizeof (tiovx_meta->image_info.height));
-  vxQueryImage ((vx_image) exemplar, VX_IMAGE_FORMAT, &vx_format,
+  vxQueryImage (image_exemplar, VX_IMAGE_FORMAT, &vx_format,
       sizeof (vx_format));
   tiovx_meta->image_info.format = vx_format_to_gst_format (vx_format);
+
+  if (release_image_exemplar)
+    vxReleaseImage (&image_exemplar);
 
   goto out;
 

--- a/gst-libs/gst/tiovx/gsttiovxrawimagemeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxrawimagemeta.c
@@ -178,6 +178,8 @@ gst_buffer_add_tiovx_raw_image_meta (GstBuffer * buffer,
   vx_object_array array;
   vx_image ref = NULL;
   vx_status status;
+  tivx_raw_image image_exemplar;
+  vx_bool release_image_exemplar = FALSE;
 
   g_return_val_if_fail (buffer, NULL);
   g_return_val_if_fail (VX_SUCCESS == vxGetStatus ((vx_reference) exemplar),
@@ -187,11 +189,19 @@ gst_buffer_add_tiovx_raw_image_meta (GstBuffer * buffer,
   tivxReferenceExportHandle ((vx_reference) exemplar,
       addr, sizes, MODULE_MAX_NUM_EXPOSURES, &num_exposures);
 
+  if (NULL == addr[0]) {
+    image_exemplar =
+        gst_tiovx_copy_raw_image_exemplar ((tivx_raw_image) exemplar);
+    release_image_exemplar = TRUE;
+  } else {
+    image_exemplar = (tivx_raw_image) exemplar;
+  }
+
   for (exposure_idx = 0; exposure_idx < num_exposures; exposure_idx++) {
     addr[exposure_idx] = (void *) (mem_start + prev_size);
     offset[exposure_idx] = prev_size;
 
-    gst_tiovx_raw_meta_extract_image_params ((tivx_raw_image) exemplar,
+    gst_tiovx_raw_meta_extract_image_params (image_exemplar,
         exposure_idx, &stride_x[exposure_idx], &stride_y[exposure_idx],
         &steps_x[exposure_idx], &steps_y[exposure_idx], &widths[exposure_idx],
         &heights[exposure_idx]);
@@ -241,6 +251,8 @@ gst_buffer_add_tiovx_raw_image_meta (GstBuffer * buffer,
         heights[exposure_idx];
   }
 
+  if (release_image_exemplar)
+    tivxReleaseRawImage (&image_exemplar);
   goto out;
 
 err_out:

--- a/gst-libs/gst/tiovx/gsttiovxtensormeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensormeta.c
@@ -65,6 +65,8 @@
 
 #include <TI/tivx.h>
 
+#include "gsttiovxutils.h"
+
 static gboolean gst_tiovx_tensor_meta_init (GstMeta * meta,
     gpointer params, GstBuffer * buffer);
 
@@ -152,6 +154,8 @@ gst_buffer_add_tiovx_tensor_meta (GstBuffer * buffer,
   vx_size last_offset = 0;
   gint prev_size = 0;
   gint i = 0;
+  vx_tensor tensor_exemplar;
+  vx_bool release_tensor_exemplar = FALSE;
 
   g_return_val_if_fail (buffer, NULL);
   g_return_val_if_fail (VX_SUCCESS == vxGetStatus ((vx_reference) exemplar),
@@ -161,6 +165,13 @@ gst_buffer_add_tiovx_tensor_meta (GstBuffer * buffer,
   /* Get addr and size information */
   tivxReferenceExportHandle ((vx_reference) exemplar,
       tensor_addr, tensor_size, MODULE_MAX_NUM_DIMS, &num_tensors);
+
+  if (NULL == tensor_addr[0]) {
+    tensor_exemplar = gst_tiovx_copy_tensor_exemplar ((vx_tensor) exemplar);
+    release_tensor_exemplar = TRUE;
+  } else {
+    tensor_exemplar = (vx_tensor) exemplar;
+  }
 
   g_return_val_if_fail (MODULE_MAX_NUM_TENSORS == num_tensors, NULL);
 
@@ -197,16 +208,16 @@ gst_buffer_add_tiovx_tensor_meta (GstBuffer * buffer,
       gst_tiovx_tensor_meta_get_info (), NULL);
 
   /* Retrieve tensor info from exemplar */
-  vxQueryTensor ((vx_tensor) exemplar, VX_TENSOR_NUMBER_OF_DIMS,
+  vxQueryTensor (tensor_exemplar, VX_TENSOR_NUMBER_OF_DIMS,
       &num_dims, sizeof (vx_size));
-  vxQueryTensor ((vx_tensor) exemplar, VX_TENSOR_DIMS, dim_sizes,
+  vxQueryTensor (tensor_exemplar, VX_TENSOR_DIMS, dim_sizes,
       num_dims * sizeof (vx_size));
-  vxQueryTensor ((vx_tensor) exemplar, VX_TENSOR_DATA_TYPE, &data_type,
+  vxQueryTensor (tensor_exemplar, VX_TENSOR_DATA_TYPE, &data_type,
       sizeof (vx_enum));
 
   for (dim_idx = 0; dim_idx < num_dims; dim_idx++) {
     dim_strides[dim_idx] =
-        gst_tiovx_tensor_meta_get_dim_stride ((vx_tensor) exemplar, dim_idx,
+        gst_tiovx_tensor_meta_get_dim_stride (tensor_exemplar, dim_idx,
         num_dims, dim_sizes);
   }
 
@@ -222,6 +233,9 @@ gst_buffer_add_tiovx_tensor_meta (GstBuffer * buffer,
 
     last_offset += dim_sizes[dim_idx];
   }
+
+  if (release_tensor_exemplar)
+    vxReleaseTensor (&tensor_exemplar);
 
   goto out;
 

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -903,3 +903,58 @@ gst_tioxv_get_pyramid_caps_info (GObject * object, GstDebugCategory * category,
 exit:
   return ret;
 }
+
+vx_image
+gst_tiovx_copy_image_exemplar (vx_image exemplar)
+{
+  guint img_width = 0, img_height = 0;
+  vx_df_image vx_format = VX_DF_IMAGE_VIRT;
+
+  vxQueryImage (exemplar, VX_IMAGE_WIDTH, &img_width, sizeof (img_width));
+  vxQueryImage (exemplar, VX_IMAGE_HEIGHT, &img_height, sizeof (img_height));
+  vxQueryImage (exemplar, VX_IMAGE_FORMAT, &vx_format, sizeof (vx_format));
+
+  return vxCreateImage (vxGetContext ((vx_reference) exemplar), img_width,
+      img_height, vx_format);
+}
+
+vx_tensor
+gst_tiovx_copy_tensor_exemplar (vx_tensor exemplar)
+{
+  vx_enum data_type = 0;
+  vx_size dim_sizes[TENSOR_NUM_DIMS_SUPPORTED];
+  vx_size num_dims = 0;
+
+  vxQueryTensor (exemplar, VX_TENSOR_NUMBER_OF_DIMS, &num_dims,
+      sizeof (vx_size));
+  vxQueryTensor (exemplar, VX_TENSOR_DIMS, dim_sizes,
+      num_dims * sizeof (vx_size));
+  vxQueryTensor (exemplar, VX_TENSOR_DATA_TYPE, &data_type, sizeof (vx_enum));
+
+  return vxCreateTensor (vxGetContext ((vx_reference) exemplar), num_dims,
+      dim_sizes, data_type, 0);
+}
+
+tivx_raw_image
+gst_tiovx_copy_raw_image_exemplar (tivx_raw_image exemplar)
+{
+  tivx_raw_image_create_params_t raw_image_params = { };
+
+  tivxQueryRawImage (exemplar, TIVX_RAW_IMAGE_WIDTH, &raw_image_params.width,
+      sizeof (vx_uint32));
+  tivxQueryRawImage (exemplar, TIVX_RAW_IMAGE_HEIGHT, &raw_image_params.height,
+      sizeof (vx_uint32));
+  tivxQueryRawImage (exemplar, TIVX_RAW_IMAGE_NUM_EXPOSURES,
+      &raw_image_params.num_exposures, sizeof (vx_uint32));
+  tivxQueryRawImage (exemplar, TIVX_RAW_IMAGE_LINE_INTERLEAVED,
+      &raw_image_params.line_interleaved, sizeof (vx_bool));
+  tivxQueryRawImage (exemplar, TIVX_RAW_IMAGE_FORMAT, raw_image_params.format,
+      raw_image_params.num_exposures * sizeof (tivx_raw_image_format_t));
+  tivxQueryRawImage (exemplar, TIVX_RAW_IMAGE_META_HEIGHT_BEFORE,
+      &raw_image_params.meta_height_before, sizeof (vx_uint32));
+  tivxQueryRawImage (exemplar, TIVX_RAW_IMAGE_META_HEIGHT_AFTER,
+      &raw_image_params.meta_height_after, sizeof (vx_uint32));
+
+  return tivxCreateRawImage (vxGetContext ((vx_reference) exemplar),
+      &raw_image_params);
+}

--- a/gst-libs/gst/tiovx/gsttiovxutils.h
+++ b/gst-libs/gst/tiovx/gsttiovxutils.h
@@ -265,4 +265,27 @@ gst_tioxv_get_pyramid_caps_info (GObject * object, GstDebugCategory * category,
     const GstCaps * caps, gint * levels, gdouble * scale, gint * width, gint * height,
     GstVideoFormat * format);
 
+/**
+ * gst_tiovx_copy_image_exemplar:
+ * @exemplar: vx_image to create a copy
+ * 
+ * Returns a copy of the image exemplar
+ */
+vx_image gst_tiovx_copy_image_exemplar (vx_image exemplar);
+
+/**
+ * gst_tiovx_copy_tensor_exemplar:
+ * @exemplar: vx_tensor to create a copy
+ * 
+ * Returns a copy of the tensor exemplar
+ */
+vx_tensor gst_tiovx_copy_tensor_exemplar (vx_tensor exemplar);
+
+/**
+ * gst_tiovx_copy_raw_image_exemplar:
+ * @exemplar: tivx_raw_image to create a copy
+ * 
+ * Returns a copy of the raw image exemplar
+ */
+tivx_raw_image gst_tiovx_copy_raw_image_exemplar (tivx_raw_image exemplar);
 #endif /* __GST_TIOVX_UTILS_H__ */


### PR DESCRIPTION
Create a copy of exemplars before vxMapping buffers and release the copy after unmap, this is required to free any memory allocated while Mapping

Signed-off-by: Rahul T R <r-ravikumar@ti.com>