### PR TITLE
ext: tiovx: ldc: Add properties to configure crop params

### DIFF
--- a/ext/tiovx/gsttiovxldc.c
+++ b/ext/tiovx/gsttiovxldc.c
@@ -80,6 +80,8 @@
 #define DEFAULT_LDC_TABLE_WIDTH 1920
 #define DEFAULT_LDC_TABLE_HEIGHT 1080
 #define DEFAULT_LDC_DS_FACTOR 2
+#define DEFAULT_LDC_INIT_X 0
+#define DEFAULT_LDC_INIT_Y 0
 
 /* Properties definition */
 enum
@@ -91,6 +93,8 @@ enum
   PROP_LDC_TABLE_WIDTH,
   PROP_LDC_TABLE_HEIGHT,
   PROP_LDC_DS_FACTOR,
+  PROP_LDC_INIT_X,
+  PROP_LDC_INIT_Y,
   PROP_TARGET,
 };
 
@@ -158,6 +162,8 @@ struct _GstTIOVXLDC
   guint ldc_table_width;
   guint ldc_table_height;
   guint ldc_ds_factor;
+  guint ldc_init_x;
+  guint ldc_init_y;
   TIOVXLDCModuleObj obj;
   SensorObj sensorObj;
   gint num_src_pads;
@@ -284,6 +290,16 @@ gst_tiovx_ldc_class_init (GstTIOVXLDCClass * klass)
           "LDC Downscaling factor to used for LUT, power of 2", 0, 7,
           DEFAULT_LDC_DS_FACTOR, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_LDC_INIT_X,
+      g_param_spec_uint ("ldc-init-x", "LDC start x coordinate",
+          "LDC Output starting x-coordinate (must be multiple of 8)", 0, 8191,
+          DEFAULT_LDC_INIT_X, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_LDC_INIT_Y,
+      g_param_spec_uint ("ldc-init-y", "LDC start y coordinate",
+          "LDC Output starting y-coordinate (must be multiple of 8)", 0, 8191,
+          DEFAULT_LDC_INIT_X, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   g_object_class_install_property (gobject_class, PROP_TARGET,
       g_param_spec_enum ("target", "Target",
           "TIOVX target to use by this element",
@@ -327,6 +343,8 @@ gst_tiovx_ldc_init (GstTIOVXLDC * self)
   self->ldc_table_width = DEFAULT_LDC_TABLE_WIDTH;
   self->ldc_table_height = DEFAULT_LDC_TABLE_HEIGHT;
   self->ldc_ds_factor = DEFAULT_LDC_DS_FACTOR;
+  self->ldc_init_x = DEFAULT_LDC_INIT_X;
+  self->ldc_init_y = DEFAULT_LDC_INIT_Y;
   self->target_id = 0;
   self->num_src_pads = 0;
   memset (&self->obj, 0, sizeof (self->obj));
@@ -363,6 +381,12 @@ gst_tiovx_ldc_set_property (GObject * object, guint prop_id,
       break;
     case PROP_LDC_DS_FACTOR:
       self->ldc_ds_factor = g_value_get_uint (value);
+      break;
+    case PROP_LDC_INIT_X:
+      self->ldc_init_x = g_value_get_uint (value);
+      break;
+    case PROP_LDC_INIT_Y:
+      self->ldc_init_y = g_value_get_uint (value);
       break;
     case PROP_TARGET:
       self->target_id = g_value_get_enum (value);
@@ -401,6 +425,12 @@ gst_tiovx_ldc_get_property (GObject * object, guint prop_id,
       break;
     case PROP_LDC_DS_FACTOR:
       g_value_set_uint (value, self->ldc_ds_factor);
+      break;
+    case PROP_LDC_INIT_X:
+      g_value_set_uint (value, self->ldc_init_x);
+      break;
+    case PROP_LDC_INIT_Y:
+      g_value_set_uint (value, self->ldc_init_y);
       break;
     case PROP_TARGET:
       g_value_set_enum (value, self->target_id);
@@ -442,6 +472,8 @@ gst_tiovx_ldc_init_module (GstTIOVXSimo * simo,
   ldc->table_width = self->ldc_table_width;
   ldc->table_height = self->ldc_table_height;
   ldc->ds_factor = self->ldc_ds_factor;
+  ldc->init_x = self->ldc_init_x;
+  ldc->init_y = self->ldc_init_y;
 
   status = tiovx_querry_sensor (sensorObj);
   if (VX_SUCCESS != status) {


### PR DESCRIPTION
Add properties to configure crop start x and y coordinate when output resolution is configured less than input

Signed-off-by: Rahul T R <r-ravikumar@ti.com>