### PR TITLE
mesom: Add option to enable or disable DL inferer plugins

### DIFF
--- a/ext/tiovx/gsttiovx.c
+++ b/ext/tiovx/gsttiovx.c
@@ -74,9 +74,12 @@
 #include "gsttiovxmultiscaler.h"
 #include "gsttiovxmux.h"
 #include "gsttiovxpyramid.h"
+
+#if defined(DL_PLUGINS)
 #include "gsttidlinferer.h"
 #include "gsttidlpostproc.h"
 #include "gsttiperfoverlay.h"
+#endif
 
 #if defined(SOC_J721E) || defined(SOC_J721S2) || defined(SOC_J784S4)
 #include "gsttiovxcolorconvert.h"
@@ -162,7 +165,7 @@ ti_ovx_init (GstPlugin * plugin)
     GST_ERROR ("Failed to register the tiovxmemalloc element");
     goto out;
   }
-
+#if defined(DL_PLUGINS)
   ret = gst_element_register (plugin, "tidlinferer", GST_RANK_NONE,
       GST_TYPE_TI_DL_INFERER);
   if (!ret) {
@@ -183,6 +186,8 @@ ti_ovx_init (GstPlugin * plugin)
     GST_ERROR ("Failed to register the tiperfoverlay element");
     goto out;
   }
+#endif
+
 #if defined(SOC_J721E) || defined(SOC_J721S2) || defined(SOC_J784S4)
   ret = gst_element_register (plugin, "tiovxcolorconvert", GST_RANK_NONE,
       GST_TYPE_TIOVX_COLOR_CONVERT);

--- a/ext/tiovx/meson.build
+++ b/ext/tiovx/meson.build
@@ -11,9 +11,6 @@ gst_plugin_sources = [
   'gsttiovxmultiscalerpad.c',
   'gsttiovxmux.c',
   'gsttiovxpyramid.c',
-  'gsttidlinferer.cpp',
-  'gsttidlpostproc.cpp',
-  'gsttiperfoverlay.cpp',
 ]
 
 if SOC == 'j721e' or SOC == 'j721s2' or SOC == 'j784s4'
@@ -29,6 +26,14 @@ if SOC == 'j721e' or SOC == 'j721s2' or SOC == 'j784s4'
   ]
 endif
 
+if get_option('dl-plugins').enabled()
+  gst_plugin_sources = [
+    'gsttidlinferer.cpp',
+    'gsttidlpostproc.cpp',
+    'gsttiperfoverlay.cpp',
+  ]
+endif
+
 gst_plugin_headers = [
   'gsttiovxdelay.h',
   'gsttiovxdemux.h',
@@ -40,9 +45,6 @@ gst_plugin_headers = [
   'gsttiovxmultiscalerpad.h',
   'gsttiovxmux.h',
   'gsttiovxpyramid.h',
-  'gsttidlinferer.h',
-  'gsttidlpostproc.h',
-  'gsttiperfoverlay.h',
 ]
 
 if SOC == 'j721e' or SOC == 'j721s2' or SOC == 'j784s4'
@@ -55,6 +57,14 @@ if SOC == 'j721e' or SOC == 'j721s2' or SOC == 'j784s4'
     'gsttiovxdofviz.h',
     'gsttiovxsde.h',
     'gsttiovxsdeviz.h'
+  ]
+endif
+
+if get_option('dl-plugins').enabled()
+  gst_plugin_sources = [
+    'gsttidlinferer.h',
+    'gsttidlpostproc.h',
+    'gsttiperfoverlay.h',
   ]
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -59,9 +59,14 @@ plugin_deps = [
  tiovx_deps,
  ti_vision_apps_dep,
  edgeai_tiovx_modules_dep,
- edgeai_dl_inferer_dep,
  math_dep
  ]
+
+if get_option('dl-plugins').enabled()
+  plugin_deps += [
+   edgeai_dl_inferer_dep,
+   ]
+endif
 
 if SOC == 'j721e' or SOC == 'j721s2' or SOC == 'j784s4'
   plugin_deps += [
@@ -135,6 +140,10 @@ elif SOC == 'am62a'
   c_args += ['-DSOC_AM62A']
 else
   error('MESON_FAIL SOC =', SOC, 'Not supported')
+endif
+
+if get_option('dl-plugins').enabled()
+  c_args += ['-DDL_PLUGINS']
 endif
 
 cpp_args = c_args

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,6 +3,7 @@ option('tests', type : 'feature', value : 'auto', yield : true, description : 'B
 option('examples', type : 'feature', value : 'auto', yield : true, description : 'Build examples')
 option('doc', type : 'feature', value : 'disabled', yield : true, description : 'Enable hotdoc documentation')
 option('profiling', type : 'feature', value : 'disabled', yield : true, description: 'Enable profiling building')
+option('dl-plugins', type : 'feature', value : 'enabled', yield : true, description: 'Enable DL Plugins')
 
 # Common options
 option('package-name', type : 'string', yield : true,


### PR DESCRIPTION
Add option to enable or disable DL inferer plugins, this is useful to build other plugins without dl inferer dependency

Signed-off-by: Rahul T R <r-ravikumar@ti.com>