### PR TITLE
ext: tiovx: tiperfoverlay: Add support to dump stats on terminal

### DIFF
--- a/tags
+++ b/tags
@@ -1,0 +1,2400 @@
+!_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
+!_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
+!_TAG_PROGRAM_AUTHOR	Darren Hiebert	/dhiebert@users.sourceforge.net/
+!_TAG_PROGRAM_NAME	Exuberant Ctags	//
+!_TAG_PROGRAM_URL	http://ctags.sourceforge.net	/official site/
+!_TAG_PROGRAM_VERSION	5.9~svn20110310	//
+ALPHA_DEFAULT	ext/tiovx/gsttidlpostproc.cpp	95;"	d	file:
+ALPHA_MAX	ext/tiovx/gsttidlpostproc.cpp	94;"	d	file:
+ALPHA_MIN	ext/tiovx/gsttidlpostproc.cpp	93;"	d	file:
+AppendFormatFunc	ext/tiovx/gsttiovxcolorconvert.c	/^typedef gboolean (*AppendFormatFunc) (GstVideoFormat, GValue *);$/;"	t	file:
+AppendFormatFunc	ext/tiovx/gsttiovxdlcolorconvert.c	/^typedef gboolean (*AppendFormatFunc) (GstVideoFormat, GValue *);$/;"	t	file:
+BufferCounter	tests/check/test_utils.h	/^typedef struct _BufferCounter BufferCounter;$/;"	t	typeref:struct:_BufferCounter
+COLORCONVERT_INPUT_PARAM_INDEX	ext/tiovx/gsttiovxcolorconvert.c	74;"	d	file:
+COLORCONVERT_OUTPUT_PARAM_INDEX	ext/tiovx/gsttiovxcolorconvert.c	75;"	d	file:
+COLOR_BLEND_SUPPORTED_CHANNELS	gst-libs/gst/tiovx/gsttiovxutils.c	82;"	d	file:
+CONFIDENCE_THRESHOLD	ext/tiovx/gsttiovxdofviz.c	/^  CONFIDENCE_THRESHOLD,$/;"	e	enum:__anon6	file:
+DCC	tests/check/gsttiovxisp.c	/^} DCC;$/;"	t	typeref:struct:__anon47	file:
+DCC_FILE	tests/check/gsttiovxldc.c	72;"	d	file:
+DCC_IMX219_2A_FILE	tests/check/gsttiovxisp.c	75;"	d	file:
+DCC_IMX219_ID	tests/check/gsttiovxisp.c	73;"	d	file:
+DCC_IMX219_ISP_FILE	tests/check/gsttiovxisp.c	74;"	d	file:
+DEFAULT_BUFFER_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxpad.c	74;"	d	file:
+DEFAULT_DELAY_SIZE	ext/tiovx/gsttiovxdelay.c	68;"	d	file:
+DEFAULT_DISPARITY_ONLY	ext/tiovx/gsttiovxsdeviz.c	78;"	d	file:
+DEFAULT_IMAGE_HEIGHT	tests/check/gsttiovxldc.c	81;"	d	file:
+DEFAULT_IMAGE_WIDTH	tests/check/gsttiovxldc.c	80;"	d	file:
+DEFAULT_LDC_BLOCK_HEIGHT	ext/tiovx/gsttiovxldc.c	84;"	d	file:
+DEFAULT_LDC_BLOCK_WIDTH	ext/tiovx/gsttiovxldc.c	83;"	d	file:
+DEFAULT_LDC_DS_FACTOR	ext/tiovx/gsttiovxldc.c	82;"	d	file:
+DEFAULT_LDC_INIT_X	ext/tiovx/gsttiovxldc.c	86;"	d	file:
+DEFAULT_LDC_INIT_Y	ext/tiovx/gsttiovxldc.c	87;"	d	file:
+DEFAULT_LDC_PIXEL_PAD	ext/tiovx/gsttiovxldc.c	85;"	d	file:
+DEFAULT_LDC_TABLE_HEIGHT	ext/tiovx/gsttiovxldc.c	81;"	d	file:
+DEFAULT_LDC_TABLE_WIDTH	ext/tiovx/gsttiovxldc.c	80;"	d	file:
+DEFAULT_MEAN	ext/tiovx/gsttiovxdlpreproc.c	89;"	d	file:
+DEFAULT_NUM_CHANNELS	ext/tiovx/gsttiovxmultiscaler.c	77;"	d	file:
+DEFAULT_NUM_CHANNELS	gst-libs/gst/tiovx/gsttiovxmiso.c	84;"	d	file:
+DEFAULT_NUM_CHANNELS	gst-libs/gst/tiovx/gsttiovxpad.c	71;"	d	file:
+DEFAULT_NUM_CHANNELS	gst-libs/gst/tiovx/gsttiovxsimo.c	77;"	d	file:
+DEFAULT_NUM_CHANNELS	gst-libs/gst/tiovx/gsttiovxsiso.h	89;"	d
+DEFAULT_NUM_CLASSES	ext/tiovx/gsttiovxdlcolorblend.c	91;"	d	file:
+DEFAULT_PARAM_INDEX	gst-libs/gst/tiovx/gsttiovxsiso.c	77;"	d	file:
+DEFAULT_POOL_SIZE	ext/tiovx/gsttidlinferer.cpp	87;"	d	file:
+DEFAULT_POOL_SIZE	ext/tiovx/gsttiovxmemalloc.c	75;"	d	file:
+DEFAULT_POOL_SIZE	ext/tiovx/gsttiovxmux.c	82;"	d	file:
+DEFAULT_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxmiso.c	80;"	d	file:
+DEFAULT_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxsiso.c	76;"	d	file:
+DEFAULT_REPEAT_AFTER_EOS	gst-libs/gst/tiovx/gsttiovxmiso.c	78;"	d	file:
+DEFAULT_ROI_VALUE	ext/tiovx/gsttiovxmultiscalerpad.c	68;"	d	file:
+DEFAULT_SCALE	ext/tiovx/gsttiovxdlpreproc.c	88;"	d	file:
+DEFAULT_THRESHOLD	ext/tiovx/gsttiovxdofviz.c	76;"	d	file:
+DEFAULT_TIOVX_COLOR_CONVERT_TARGET	ext/tiovx/gsttiovxcolorconvert.c	104;"	d	file:
+DEFAULT_TIOVX_DL_COLOR_BLEND_DATA_TYPE	ext/tiovx/gsttiovxdlcolorblend.c	99;"	d	file:
+DEFAULT_TIOVX_DL_COLOR_BLEND_TARGET	ext/tiovx/gsttiovxdlcolorblend.c	95;"	d	file:
+DEFAULT_TIOVX_DL_COLOR_CONVERT_TARGET	ext/tiovx/gsttiovxdlcolorconvert.c	104;"	d	file:
+DEFAULT_TIOVX_DL_PRE_PROC_CHANNEL_ORDER	ext/tiovx/gsttiovxdlpreproc.c	100;"	d	file:
+DEFAULT_TIOVX_DL_PRE_PROC_DATA_TYPE	ext/tiovx/gsttiovxdlpreproc.c	104;"	d	file:
+DEFAULT_TIOVX_DL_PRE_PROC_TARGET	ext/tiovx/gsttiovxdlpreproc.c	96;"	d	file:
+DEFAULT_TIOVX_DL_PRE_PROC_TENSOR_FORMAT	ext/tiovx/gsttiovxdlpreproc.c	108;"	d	file:
+DEFAULT_TIOVX_DOF_MOTION_DIRECTION	ext/tiovx/gsttiovxdof.c	156;"	d	file:
+DEFAULT_TIOVX_DOF_TARGET	ext/tiovx/gsttiovxdof.c	119;"	d	file:
+DEFAULT_TIOVX_DOF_VIZ_TARGET	ext/tiovx/gsttiovxdofviz.c	107;"	d	file:
+DEFAULT_TIOVX_ISP_TARGET	ext/tiovx/gsttiovxisp.c	87;"	d	file:
+DEFAULT_TIOVX_LDC_TARGET	ext/tiovx/gsttiovxldc.c	76;"	d	file:
+DEFAULT_TIOVX_MOSAIC_TARGET	ext/tiovx/gsttiovxmosaic.c	461;"	d	file:
+DEFAULT_TIOVX_MULTI_SCALER_INTERPOLATION_METHOD	ext/tiovx/gsttiovxmultiscaler.c	132;"	d	file:
+DEFAULT_TIOVX_MULTI_SCALER_TARGET	ext/tiovx/gsttiovxmultiscaler.c	107;"	d	file:
+DEFAULT_TIOVX_PYRAMID_TARGET	ext/tiovx/gsttiovxpyramid.c	104;"	d	file:
+DEFAULT_TIOVX_SDE_MAX_DISPARITY	ext/tiovx/gsttiovxsde.c	191;"	d	file:
+DEFAULT_TIOVX_SDE_MIN_DISPARITY	ext/tiovx/gsttiovxsde.c	161;"	d	file:
+DEFAULT_TIOVX_SDE_TARGET	ext/tiovx/gsttiovxsde.c	132;"	d	file:
+DEFAULT_TIOVX_SDE_VIZ_MAX_DISPARITY	ext/tiovx/gsttiovxsdeviz.c	168;"	d	file:
+DEFAULT_TIOVX_SDE_VIZ_MIN_DISPARITY	ext/tiovx/gsttiovxsdeviz.c	138;"	d	file:
+DEFAULT_TIOVX_SDE_VIZ_TARGET	ext/tiovx/gsttiovxsdeviz.c	109;"	d	file:
+DEFAULT_UPDATE_FPS_INTERVAL	ext/tiovx/gsttiperfoverlay.cpp	99;"	d	file:
+DEFAULT_UPDATE_STATS_INTERVAL	ext/tiovx/gsttiperfoverlay.cpp	98;"	d	file:
+DEFAULT_USE_COLOR_MAP	ext/tiovx/gsttiovxdlcolorblend.c	90;"	d	file:
+DEFAULT_VIZ_CONFIDENCE	ext/tiovx/gsttiovxsdeviz.c	76;"	d	file:
+DLCOLORBLEND_INPUT_IMAGE_GRAPH_PARAM_INDEX	ext/tiovx/gsttiovxdlcolorblend.c	81;"	d	file:
+DLCOLORBLEND_INPUT_IMAGE_NODE_PARAM_INDEX	ext/tiovx/gsttiovxdlcolorblend.c	77;"	d	file:
+DLCOLORBLEND_INPUT_TENSOR_GRAPH_PARAM_INDEX	ext/tiovx/gsttiovxdlcolorblend.c	82;"	d	file:
+DLCOLORBLEND_INPUT_TENSOR_NODE_PARAM_INDEX	ext/tiovx/gsttiovxdlcolorblend.c	78;"	d	file:
+DLCOLORBLEND_OUTPUT_IMAGE_GRAPH_PARAM_INDEX	ext/tiovx/gsttiovxdlcolorblend.c	83;"	d	file:
+DLCOLORBLEND_OUTPUT_IMAGE_NODE_PARAM_INDEX	ext/tiovx/gsttiovxdlcolorblend.c	79;"	d	file:
+DLPREPROC_INPUT_PARAM_INDEX	ext/tiovx/gsttiovxdlpreproc.c	76;"	d	file:
+DLPREPROC_OUTPUT_PARAM_INDEX	ext/tiovx/gsttiovxdlpreproc.c	77;"	d	file:
+DL_COLOR_CONVERT_INPUT_PARAM_INDEX	ext/tiovx/gsttiovxdlcolorconvert.c	74;"	d	file:
+DL_COLOR_CONVERT_OUTPUT_PARAM_INDEX	ext/tiovx/gsttiovxdlcolorconvert.c	75;"	d	file:
+DL_PRE_PROC_SUPPORTED_CHANNELS	gst-libs/gst/tiovx/gsttiovxutils.c	83;"	d	file:
+DOFVIZ_INPUT_PARAM_INDEX	ext/tiovx/gsttiovxdofviz.c	78;"	d	file:
+DOFVIZ_OUTPUT_PARAM_INDEX	ext/tiovx/gsttiovxdofviz.c	79;"	d	file:
+GRAPH_BG_COLOR	ext/tiovx/gsttiperfoverlay.cpp	105;"	d	file:
+GST_BUFFER_OFFSET_END_FIXED_VALUE	gst-libs/gst/tiovx/gsttiovxmiso.c	83;"	d	file:
+GST_BUFFER_OFFSET_FIXED_VALUE	gst-libs/gst/tiovx/gsttiovxmiso.c	82;"	d	file:
+GST_CAPS_FEATURE_BATCHED_MEMORY	gst-libs/gst/tiovx/gsttiovxutils.h	79;"	d
+GST_CAT_DEFAULT	ext/tiovx/gsttidlinferer.cpp	179;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttidlpostproc.cpp	215;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxcolorconvert.c	167;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxdelay.c	87;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxdemux.c	187;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxdlcolorblend.c	229;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxdlcolorconvert.c	167;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxdlpreproc.c	281;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxdof.c	245;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxdofviz.c	169;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxisp.c	585;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxldc.c	182;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxmemalloc.c	94;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxmosaic.c	535;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxmultiscaler.c	185;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxmultiscalerpad.c	79;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxmux.c	282;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxpyramid.c	172;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxsde.c	291;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiovxsdeviz.c	239;"	d	file:
+GST_CAT_DEFAULT	ext/tiovx/gsttiperfoverlay.cpp	240;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxallocator.c	79;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxbufferpool.c	82;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxcontext.c	70;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	78;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxmiso.c	87;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxpad.c	90;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	81;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	84;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxsimo.c	80;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxsiso.c	87;"	d	file:
+GST_CAT_DEFAULT	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	79;"	d	file:
+GST_START_TEST	tests/check/gsttiovx_multiple_transitions.c	/^GST_START_TEST (test_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxcolorconvert.c	/^GST_START_TEST (test_caps_negotiation_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxcolorconvert.c	/^GST_START_TEST (test_caps_negotiation_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxcolorconvert.c	/^GST_START_TEST (test_caps_renegotiation)$/;"	f
+GST_START_TEST	tests/check/gsttiovxcolorconvert.c	/^GST_START_TEST (test_pad_creation_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxcolorconvert.c	/^GST_START_TEST (test_state_change_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdemux.c	/^GST_START_TEST (test_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_foreach_data_type)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_foreach_format)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_foreach_format_convertion_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_foreach_format_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_foreach_target)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_num_classes)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_resolutions)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_resolutions_with_downscale_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_resolutions_with_upscale_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_sink_pool_size)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_src_pool_size)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorblend.c	/^GST_START_TEST (test_tensor_pool_size)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorconvert.c	/^GST_START_TEST (test_caps_negotiation_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorconvert.c	/^GST_START_TEST (test_caps_negotiation_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorconvert.c	/^GST_START_TEST (test_caps_renegotiation)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorconvert.c	/^GST_START_TEST (test_pad_creation_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlcolorconvert.c	/^GST_START_TEST (test_state_change_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_foreach_channel_order)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_foreach_data_type)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_foreach_tensor_format)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_foreach_upstream_format)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_foreach_upstream_format_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_mean0)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_mean1)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_mean2)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_resolutions)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_resolutions_with_downscale_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_resolutions_with_upscale_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_scale0)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_scale1)$/;"	f
+GST_START_TEST	tests/check/gsttiovxdlpreproc.c	/^GST_START_TEST (test_scale2)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_ae_disabled)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_ae_num_skip_frames)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_analog_gain)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_awb_disabled)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_awb_num_skip_frames)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_color_temperature)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_exposure_time)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_foreach_format)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_format_msb)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_input_format_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_lines_interleaved)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_meta_height_after)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_meta_height_before)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_num_exposures)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_output_format_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_resolutions_with_downscale_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_resolutions_with_upscale_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_sink_pool_size)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_src_pool_size)$/;"	f
+GST_START_TEST	tests/check/gsttiovxisp.c	/^GST_START_TEST (test_target)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_caps_negotiation_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_caps_negotiation_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_formats)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_invalid_dcc_file_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_max_resolution)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_min_resolution)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_no_dcc_file_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_pad_addition_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_resolutions)$/;"	f
+GST_START_TEST	tests/check/gsttiovxldc.c	/^GST_START_TEST (test_resolutions_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_background_pad)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_background_pad_downscaling_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_background_pad_upscaling_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_foreach_upstream_format)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_foreach_upstream_format_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_property_target)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_resolutions)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_resolutions_downscaled_input)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_resolutions_downscaled_input_more_than_4x_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_resolutions_larger_input_into_background)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_resolutions_random_startx_starty)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_resolutions_random_startx_starty_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_resolutions_with_larger_output)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_resolutions_with_smaller_output)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_sink_pad_different_format_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmosaic.c	/^GST_START_TEST (test_sink_pad_same_format)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmultiscaler.c	/^GST_START_TEST (test_caps_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmultiscaler.c	/^GST_START_TEST (test_pads_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmultiscaler.c	/^GST_START_TEST (test_pads_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmultiscaler.c	/^GST_START_TEST (test_state_transitions)$/;"	f
+GST_START_TEST	tests/check/gsttiovxmux.c	/^GST_START_TEST (test_success)$/;"	f
+GST_START_TEST	tests/check/gsttiovxpyramid.c	/^GST_START_TEST (test_caps_negotiation_fail)$/;"	f
+GST_START_TEST	tests/check/gsttiovxpyramid.c	/^GST_START_TEST (test_caps_negotiation_success)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxallocator.c	/^GST_START_TEST (test_dmabuf)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovximagebufferpool.c	/^GST_START_TEST (test_external_allocator)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovximagebufferpool.c	/^GST_START_TEST (test_new_buffer_empty_caps)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovximagebufferpool.c	/^GST_START_TEST (test_new_buffer_empty_exemplar)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovximagebufferpool.c	/^GST_START_TEST (test_new_buffer_invalid_caps)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovximagebufferpool.c	/^GST_START_TEST (test_new_buffer_no_set_params)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovximagebufferpool.c	/^GST_START_TEST (test_new_dof_buffer)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovximagebufferpool.c	/^GST_START_TEST (test_new_image_buffer)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxmiso.c	/^GST_START_TEST (test_success)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpad.c	/^GST_START_TEST (test_peer_query_allocation)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpad.c	/^GST_START_TEST (test_push_non_tiovx_buffer)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpad.c	/^GST_START_TEST (test_push_tiovx_buffer)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpad.c	/^GST_START_TEST (test_push_tiovx_buffer_external_pool)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpad.c	/^GST_START_TEST (test_query_sink_allocation)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpyramidbufferpool.c	/^GST_START_TEST (test_create_new_pool)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpyramidbufferpool.c	/^GST_START_TEST (test_new_buffer)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpyramidbufferpool.c	/^GST_START_TEST (test_new_buffer_empty_caps)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpyramidbufferpool.c	/^GST_START_TEST (test_new_buffer_empty_exemplar)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpyramidbufferpool.c	/^GST_START_TEST (test_new_buffer_invalid_caps)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxpyramidbufferpool.c	/^GST_START_TEST (test_new_buffer_no_set_params)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxrawimagebufferpool.c	/^GST_START_TEST (test_external_allocator)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxrawimagebufferpool.c	/^GST_START_TEST (test_new_buffer)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxrawimagebufferpool.c	/^GST_START_TEST (test_new_buffer_empty_caps)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxrawimagebufferpool.c	/^GST_START_TEST (test_new_buffer_empty_exemplar)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxrawimagebufferpool.c	/^GST_START_TEST (test_new_buffer_invalid_caps)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxrawimagebufferpool.c	/^GST_START_TEST (test_new_buffer_no_set_params)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxsimo.c	/^GST_START_TEST (test_success)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxsiso.c	/^GST_START_TEST (test_success)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_external_allocator)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_empty_caps)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_empty_exemplar)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_float32)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_int16)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_int32)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_int8)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_invalid_caps)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_invalid_caps_no_data_type)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_invalid_caps_no_num_dims)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_no_set_params)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_uint16)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_uint32)$/;"	f
+GST_START_TEST	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_START_TEST (test_new_buffer_uint8)$/;"	f
+GST_TEST_TIOVX_MISO	tests/check/libs/gsttiovxmiso.c	81;"	d	file:
+GST_TEST_TIOVX_MISO_CLASS	tests/check/libs/gsttiovxmiso.c	82;"	d	file:
+GST_TEST_TIOVX_MISO_GET_CLASS	tests/check/libs/gsttiovxmiso.c	83;"	d	file:
+GST_TEST_TIOVX_SISO	tests/check/libs/gsttiovxsiso.c	84;"	d	file:
+GST_TEST_TIOVX_SISO_CLASS	tests/check/libs/gsttiovxsiso.c	85;"	d	file:
+GST_TEST_TIOVX_SISO_GET_CLASS	tests/check/libs/gsttiovxsiso.c	86;"	d	file:
+GST_TIDL_OUT_META_INFO	gst-libs/gst/tiovx/gsttidloutmeta.h	71;"	d
+GST_TIOVX_DEMUX_DEFINE_CUSTOM_CODE	ext/tiovx/gsttiovxdemux.c	215;"	d	file:
+GST_TIOVX_DEMUX_GET_CLASS	ext/tiovx/gsttiovxdemux.c	77;"	d	file:
+GST_TIOVX_IMAGE_META_INFO	gst-libs/gst/tiovx/gsttiovximagemeta.h	74;"	d
+GST_TIOVX_MISO_DEFINE_CUSTOM_CODE	gst-libs/gst/tiovx/gsttiovxmiso.c	259;"	d	file:
+GST_TIOVX_MUX_DEFINE_CUSTOM_CODE	ext/tiovx/gsttiovxmux.c	310;"	d	file:
+GST_TIOVX_MUX_META_INFO	gst-libs/gst/tiovx/gsttiovxmuxmeta.h	71;"	d
+GST_TIOVX_PYRAMID_META_INFO	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	74;"	d
+GST_TIOVX_RAW_IMAGE_META_INFO	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	74;"	d
+GST_TIOVX_SENSOR_META_INFO	gst-libs/gst/tiovx/gsttiovxsensormeta.h	70;"	d
+GST_TIOVX_TENSOR_META_INFO	gst-libs/gst/tiovx/gsttiovxtensormeta.h	74;"	d
+GST_TIOVX_TEST_SIMO	tests/check/libs/gsttiovxsimo.c	81;"	d	file:
+GST_TIOVX_TEST_SIMO_CLASS	tests/check/libs/gsttiovxsimo.c	82;"	d	file:
+GST_TIOVX_TEST_SIMO_GET_CLASS	tests/check/libs/gsttiovxsimo.c	83;"	d	file:
+GST_TI_DL_POST_PROC_GET_CLASS	ext/tiovx/gsttidlpostproc.cpp	85;"	d	file:
+GST_TYPE_GST_TIOVX_ISP	ext/tiovx/gsttiovxisp.h	83;"	d
+GST_TYPE_TEST_TIOVX_MISO	tests/check/libs/gsttiovxmiso.c	80;"	d	file:
+GST_TYPE_TEST_TIOVX_SIMO	tests/check/libs/gsttiovxsimo.c	80;"	d	file:
+GST_TYPE_TEST_TIOVX_SISO	tests/check/libs/gsttiovxsiso.c	83;"	d	file:
+GST_TYPE_TIDL_OUT_META_API	gst-libs/gst/tiovx/gsttidloutmeta.h	70;"	d
+GST_TYPE_TIOVX_ALLOCATOR	gst-libs/gst/tiovx/gsttiovxallocator.h	71;"	d
+GST_TYPE_TIOVX_BUFFER_POOL	gst-libs/gst/tiovx/gsttiovxbufferpool.h	76;"	d
+GST_TYPE_TIOVX_COLOR_CONVERT	ext/tiovx/gsttiovxcolorconvert.h	82;"	d
+GST_TYPE_TIOVX_COLOR_CONVERT_TARGET	ext/tiovx/gsttiovxcolorconvert.c	78;"	d	file:
+GST_TYPE_TIOVX_CONTEXT	gst-libs/gst/tiovx/gsttiovxcontext.h	69;"	d
+GST_TYPE_TIOVX_DELAY	ext/tiovx/gsttiovxdelay.h	71;"	d
+GST_TYPE_TIOVX_DEMUX	ext/tiovx/gsttiovxdemux.h	81;"	d
+GST_TYPE_TIOVX_DL_COLOR_BLEND	ext/tiovx/gsttiovxdlcolorblend.h	82;"	d
+GST_TYPE_TIOVX_DL_COLOR_BLEND_DATA_TYPE	ext/tiovx/gsttiovxdlcolorblend.c	98;"	d	file:
+GST_TYPE_TIOVX_DL_COLOR_BLEND_TARGET	ext/tiovx/gsttiovxdlcolorblend.c	94;"	d	file:
+GST_TYPE_TIOVX_DL_COLOR_CONVERT	ext/tiovx/gsttiovxdlcolorconvert.h	82;"	d
+GST_TYPE_TIOVX_DL_COLOR_CONVERT_TARGET	ext/tiovx/gsttiovxdlcolorconvert.c	78;"	d	file:
+GST_TYPE_TIOVX_DL_PRE_PROC	ext/tiovx/gsttiovxdlpreproc.h	82;"	d
+GST_TYPE_TIOVX_DL_PRE_PROC_CHANNEL_ORDER	ext/tiovx/gsttiovxdlpreproc.c	99;"	d	file:
+GST_TYPE_TIOVX_DL_PRE_PROC_DATA_TYPE	ext/tiovx/gsttiovxdlpreproc.c	103;"	d	file:
+GST_TYPE_TIOVX_DL_PRE_PROC_TARGET	ext/tiovx/gsttiovxdlpreproc.c	95;"	d	file:
+GST_TYPE_TIOVX_DL_PRE_PROC_TENSOR_FORMAT	ext/tiovx/gsttiovxdlpreproc.c	107;"	d	file:
+GST_TYPE_TIOVX_DOF	ext/tiovx/gsttiovxdof.h	84;"	d
+GST_TYPE_TIOVX_DOF_MOTION_DIRECTION	ext/tiovx/gsttiovxdof.c	130;"	d	file:
+GST_TYPE_TIOVX_DOF_TARGET	ext/tiovx/gsttiovxdof.c	102;"	d	file:
+GST_TYPE_TIOVX_DOF_VIZ	ext/tiovx/gsttiovxdofviz.h	81;"	d
+GST_TYPE_TIOVX_DOF_VIZ_TARGET	ext/tiovx/gsttiovxdofviz.c	82;"	d	file:
+GST_TYPE_TIOVX_IMAGE_BUFFER_POOL	gst-libs/gst/tiovx/gsttiovximagebufferpool.h	73;"	d
+GST_TYPE_TIOVX_IMAGE_META_API	gst-libs/gst/tiovx/gsttiovximagemeta.h	73;"	d
+GST_TYPE_TIOVX_ISP_PAD	ext/tiovx/gsttiovxisp.c	205;"	d	file:
+GST_TYPE_TIOVX_ISP_TARGET	ext/tiovx/gsttiovxisp.c	86;"	d	file:
+GST_TYPE_TIOVX_LDC	ext/tiovx/gsttiovxldc.h	83;"	d
+GST_TYPE_TIOVX_LDC_TARGET	ext/tiovx/gsttiovxldc.c	75;"	d	file:
+GST_TYPE_TIOVX_MEM_ALLOC	ext/tiovx/gsttiovxmemalloc.h	71;"	d
+GST_TYPE_TIOVX_MISO	gst-libs/gst/tiovx/gsttiovxmiso.h	72;"	d
+GST_TYPE_TIOVX_MISO_PAD	gst-libs/gst/tiovx/gsttiovxmiso.h	145;"	d
+GST_TYPE_TIOVX_MOSAIC	ext/tiovx/gsttiovxmosaic.h	84;"	d
+GST_TYPE_TIOVX_MOSAIC_PAD	ext/tiovx/gsttiovxmosaic.c	87;"	d	file:
+GST_TYPE_TIOVX_MOSAIC_TARGET	ext/tiovx/gsttiovxmosaic.c	441;"	d	file:
+GST_TYPE_TIOVX_MULTISCALER_PAD	ext/tiovx/gsttiovxmultiscalerpad.h	82;"	d
+GST_TYPE_TIOVX_MULTI_SCALER	ext/tiovx/gsttiovxmultiscaler.h	84;"	d
+GST_TYPE_TIOVX_MULTI_SCALER_INTERPOLATION_METHOD	ext/tiovx/gsttiovxmultiscaler.c	110;"	d	file:
+GST_TYPE_TIOVX_MULTI_SCALER_TARGET	ext/tiovx/gsttiovxmultiscaler.c	89;"	d	file:
+GST_TYPE_TIOVX_MUX	ext/tiovx/gsttiovxmux.h	81;"	d
+GST_TYPE_TIOVX_MUX_META_API	gst-libs/gst/tiovx/gsttiovxmuxmeta.h	70;"	d
+GST_TYPE_TIOVX_MUX_PAD	ext/tiovx/gsttiovxmux.c	90;"	d	file:
+GST_TYPE_TIOVX_PAD	gst-libs/gst/tiovx/gsttiovxpad.h	73;"	d
+GST_TYPE_TIOVX_PYRAMID	ext/tiovx/gsttiovxpyramid.h	82;"	d
+GST_TYPE_TIOVX_PYRAMID_BUFFER_POOL	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.h	72;"	d
+GST_TYPE_TIOVX_PYRAMID_META_API	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	73;"	d
+GST_TYPE_TIOVX_PYRAMID_TARGET	ext/tiovx/gsttiovxpyramid.c	86;"	d	file:
+GST_TYPE_TIOVX_QUEUEABLE	gst-libs/gst/tiovx/gsttiovxqueueableobject.h	71;"	d
+GST_TYPE_TIOVX_RAW_IMAGE_BUFFER_POOL	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.h	74;"	d
+GST_TYPE_TIOVX_RAW_IMAGE_META_API	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	73;"	d
+GST_TYPE_TIOVX_SDE	ext/tiovx/gsttiovxsde.h	83;"	d
+GST_TYPE_TIOVX_SDE_MAX_DISPARITY	ext/tiovx/gsttiovxsde.c	171;"	d	file:
+GST_TYPE_TIOVX_SDE_MIN_DISPARITY	ext/tiovx/gsttiovxsde.c	141;"	d	file:
+GST_TYPE_TIOVX_SDE_TARGET	ext/tiovx/gsttiovxsde.c	115;"	d	file:
+GST_TYPE_TIOVX_SDE_VIZ	ext/tiovx/gsttiovxsdeviz.h	81;"	d
+GST_TYPE_TIOVX_SDE_VIZ_MAX_DISPARITY	ext/tiovx/gsttiovxsdeviz.c	148;"	d	file:
+GST_TYPE_TIOVX_SDE_VIZ_MIN_DISPARITY	ext/tiovx/gsttiovxsdeviz.c	118;"	d	file:
+GST_TYPE_TIOVX_SDE_VIZ_TARGET	ext/tiovx/gsttiovxsdeviz.c	84;"	d	file:
+GST_TYPE_TIOVX_SENSOR_META_API	gst-libs/gst/tiovx/gsttiovxsensormeta.h	69;"	d
+GST_TYPE_TIOVX_SIMO	gst-libs/gst/tiovx/gsttiovxsimo.h	73;"	d
+GST_TYPE_TIOVX_SISO	gst-libs/gst/tiovx/gsttiovxsiso.h	72;"	d
+GST_TYPE_TIOVX_TENSOR_BUFFER_POOL	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.h	72;"	d
+GST_TYPE_TIOVX_TENSOR_META_API	gst-libs/gst/tiovx/gsttiovxtensormeta.h	73;"	d
+GST_TYPE_TI_DL_INFERER	ext/tiovx/gsttidlinferer.h	81;"	d
+GST_TYPE_TI_DL_POST_PROC	ext/tiovx/gsttidlpostproc.h	80;"	d
+GST_TYPE_TI_PERF_OVERLAY	ext/tiovx/gsttiperfoverlay.h	80;"	d
+GstTIOVXBufferPoolPrivate	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^} GstTIOVXBufferPoolPrivate;$/;"	t	typeref:struct:_GstTIOVXBufferPoolPrivate	file:
+GstTIOVXDelay	ext/tiovx/gsttiovxdelay.c	/^} GstTIOVXDelay;$/;"	t	typeref:struct:_GstTIOVXDelay	file:
+GstTIOVXDemux	ext/tiovx/gsttiovxdemux.c	/^} GstTIOVXDemux;$/;"	t	typeref:struct:_GstTIOVXDemux	file:
+GstTIOVXDimFunc	ext/tiovx/gsttiovxmultiscaler.c	/^typedef void (*GstTIOVXDimFunc) (GstTIOVXSimo * simo,$/;"	t	file:
+GstTIOVXImageInfo	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^typedef struct _GstTIOVXImageInfo GstTIOVXImageInfo;$/;"	t	typeref:struct:_GstTIOVXImageInfo
+GstTIOVXImageMeta	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^typedef struct _GstTIOVXImageMeta GstTIOVXImageMeta;$/;"	t	typeref:struct:_GstTIOVXImageMeta
+GstTIOVXMemAlloc	ext/tiovx/gsttiovxmemalloc.c	/^} GstTIOVXMemAlloc;$/;"	t	typeref:struct:_GstTIOVXMemAlloc	file:
+GstTIOVXMemoryData	gst-libs/gst/tiovx/gsttiovxallocator.h	/^typedef struct _GstTIOVXMemoryData GstTIOVXMemoryData;$/;"	t	typeref:struct:_GstTIOVXMemoryData
+GstTIOVXMisoPadPrivate	gst-libs/gst/tiovx/gsttiovxmiso.c	/^} GstTIOVXMisoPadPrivate;$/;"	t	typeref:struct:_GstTIOVXMisoPadPrivate	file:
+GstTIOVXMisoPrivate	gst-libs/gst/tiovx/gsttiovxmiso.c	/^} GstTIOVXMisoPrivate;$/;"	t	typeref:struct:_GstTIOVXMisoPrivate	file:
+GstTIOVXMux	ext/tiovx/gsttiovxmux.c	/^} GstTIOVXMux;$/;"	t	typeref:struct:_GstTIOVXMux	file:
+GstTIOVXMuxMeta	gst-libs/gst/tiovx/gsttiovxmuxmeta.h	/^typedef struct _GstTIOVXMuxMeta GstTIOVXMuxMeta;$/;"	t	typeref:struct:_GstTIOVXMuxMeta
+GstTIOVXMuxPadPrivate	ext/tiovx/gsttiovxmux.c	/^} GstTIOVXMuxPadPrivate;$/;"	t	typeref:struct:_GstTIOVXMuxPad	file:
+GstTIOVXPadPrivate	gst-libs/gst/tiovx/gsttiovxpad.c	/^} GstTIOVXPadPrivate;$/;"	t	typeref:struct:_GstTIOVXPadPrivate	file:
+GstTIOVXPyramidInfo	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^typedef struct _GstTIOVXPyramidInfo GstTIOVXPyramidInfo;$/;"	t	typeref:struct:_GstTIOVXPyramidInfo
+GstTIOVXPyramidMeta	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^typedef struct _GstTIOVXPyramidMeta GstTIOVXPyramidMeta;$/;"	t	typeref:struct:_GstTIOVXPyramidMeta
+GstTIOVXRawImageInfo	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^typedef struct _GstTIOVXRawImageInfo GstTIOVXRawImageInfo;$/;"	t	typeref:struct:_GstTIOVXRawImageInfo
+GstTIOVXRawImageMeta	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^typedef struct _GstTIOVXRawImageMeta GstTIOVXRawImageMeta;$/;"	t	typeref:struct:_GstTIOVXRawImageMeta
+GstTIOVXSensorMeta	gst-libs/gst/tiovx/gsttiovxsensormeta.h	/^typedef struct _GstTIOVXSensorMeta GstTIOVXSensorMeta;$/;"	t	typeref:struct:_GstTIOVXSensorMeta
+GstTIOVXSimoPrivate	gst-libs/gst/tiovx/gsttiovxsimo.c	/^} GstTIOVXSimoPrivate;$/;"	t	typeref:struct:_GstTIOVXSimoPrivate	file:
+GstTIOVXSisoPrivate	gst-libs/gst/tiovx/gsttiovxsiso.c	/^} GstTIOVXSisoPrivate;$/;"	t	typeref:struct:_GstTIOVXSisoPrivate	file:
+GstTIOVXTensorInfo	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^typedef struct _GstTIOVXTensorInfo GstTIOVXTensorInfo;$/;"	t	typeref:struct:_GstTIOVXTensorInfo
+GstTIOVXTensorMeta	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^typedef struct _GstTIOVXTensorMeta GstTIOVXTensorMeta;$/;"	t	typeref:struct:_GstTIOVXTensorMeta
+GstTestTIOVXMiso	tests/check/libs/gsttiovxmiso.c	/^typedef struct _GstTestTIOVXMiso GstTestTIOVXMiso;$/;"	t	typeref:struct:_GstTestTIOVXMiso	file:
+GstTestTIOVXMisoClass	tests/check/libs/gsttiovxmiso.c	/^typedef struct _GstTestTIOVXMisoClass GstTestTIOVXMisoClass;$/;"	t	typeref:struct:_GstTestTIOVXMisoClass	file:
+GstTestTIOVXSimo	tests/check/libs/gsttiovxsimo.c	/^typedef struct _GstTestTIOVXSimo GstTestTIOVXSimo;$/;"	t	typeref:struct:_GstTestTIOVXSimo	file:
+GstTestTIOVXSimoClass	tests/check/libs/gsttiovxsimo.c	/^typedef struct _GstTestTIOVXSimoClass GstTestTIOVXSimoClass;$/;"	t	typeref:struct:_GstTestTIOVXSimoClass	file:
+GstTestTIOVXSiso	tests/check/libs/gsttiovxsiso.c	/^typedef struct _GstTestTIOVXSiso GstTestTIOVXSiso;$/;"	t	typeref:struct:_GstTestTIOVXSiso	file:
+GstTestTIOVXSisoClass	tests/check/libs/gsttiovxsiso.c	/^typedef struct _GstTestTIOVXSisoClass GstTestTIOVXSisoClass;$/;"	t	typeref:struct:_GstTestTIOVXSisoClass	file:
+GstTiDlOutMeta	gst-libs/gst/tiovx/gsttidloutmeta.h	/^typedef struct _GstTiDlOutMeta GstTiDlOutMeta;$/;"	t	typeref:struct:_GstTiDlOutMeta
+HOST_EMULATION	gst-libs/gst/tiovx/gsttiovx.h	66;"	d
+INPUT_PARAMETER_INDEX	gst-libs/gst/tiovx/gsttiovxmiso.h	77;"	d
+INPUT_PARAMETER_INDEX	gst-libs/gst/tiovx/gsttiovxsiso.h	77;"	d
+INPUT_PARAM_ID	ext/tiovx/gsttiovxldc.c	78;"	d	file:
+ISS_IMX390_GAIN_TBL_SIZE	ext/tiovx/gsttiovxisp.c	127;"	d	file:
+KDATATYPE	tests/check/libs/gsttiovxtensorbufferpool.c	79;"	d	file:
+KDIMSSIZE	tests/check/libs/gsttiovxtensorbufferpool.c	78;"	d	file:
+KNUMDIMS	tests/check/libs/gsttiovxtensorbufferpool.c	77;"	d	file:
+KSIZE	tests/check/libs/gsttiovxtensorbufferpool.c	80;"	d	file:
+MAX_BUFFER_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxpad.c	73;"	d	file:
+MAX_GRAPH	ext/tiovx/gsttiperfoverlay.cpp	110;"	d	file:
+MAX_MEAN	ext/tiovx/gsttiovxdlpreproc.c	86;"	d	file:
+MAX_NUMBER_OF_PLANES	gst-libs/gst/tiovx/gsttiovxmiso.c	81;"	d	file:
+MAX_NUM_CHANNELS	gst-libs/gst/tiovx/gsttiovxsiso.h	83;"	d
+MAX_NUM_CHANNELS	gst-libs/gst/tiovx/gsttiovxutils.h	74;"	d
+MAX_OVERLAY_HEIGHT	ext/tiovx/gsttiperfoverlay.cpp	107;"	d	file:
+MAX_PIPELINE_SIZE	tests/check/gsttiovxcolorconvert.c	73;"	d	file:
+MAX_PIPELINE_SIZE	tests/check/gsttiovxdlcolorconvert.c	73;"	d	file:
+MAX_PIPELINE_SIZE	tests/check/gsttiovxldc.c	71;"	d	file:
+MAX_POOL_SIZE	ext/tiovx/gsttidlinferer.cpp	86;"	d	file:
+MAX_POOL_SIZE	ext/tiovx/gsttiovxmemalloc.c	74;"	d	file:
+MAX_POOL_SIZE	ext/tiovx/gsttiovxmux.c	81;"	d	file:
+MAX_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxmiso.h	83;"	d
+MAX_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxsiso.h	87;"	d
+MAX_RESOLUTION	tests/check/gsttiovxldc.c	78;"	d	file:
+MAX_ROI_VALUE	ext/tiovx/gsttiovxmultiscalerpad.c	67;"	d	file:
+MAX_SCALE	ext/tiovx/gsttiovxdlpreproc.c	83;"	d	file:
+MAX_SINK_PADS	ext/tiovx/gsttiovxdlcolorblend.c	85;"	d	file:
+MAX_SRC_PADS	ext/tiovx/gsttiovxldc.c	77;"	d	file:
+MAX_THRESHOLD	ext/tiovx/gsttiovxdofviz.c	75;"	d	file:
+MAX_TIDL_OUTPUTS	gst-libs/gst/tiovx/gsttidloutmeta.h	67;"	d
+MAX_VIZ_CONFIDENCE	ext/tiovx/gsttiovxsdeviz.c	75;"	d	file:
+MEAN_DIM	ext/tiovx/gsttiovxdlpreproc.c	80;"	d	file:
+MEM_SIZE	tests/check/libs/gsttiovxallocator.c	76;"	d	file:
+MIN_BUFFER_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxpad.c	72;"	d	file:
+MIN_MEAN	ext/tiovx/gsttiovxdlpreproc.c	85;"	d	file:
+MIN_NUM_CHANNELS	gst-libs/gst/tiovx/gsttiovxsiso.h	82;"	d
+MIN_NUM_CHANNELS	gst-libs/gst/tiovx/gsttiovxutils.h	73;"	d
+MIN_OVERLAY_HEIGHT	ext/tiovx/gsttiperfoverlay.cpp	108;"	d	file:
+MIN_POOL_SIZE	ext/tiovx/gsttidlinferer.cpp	85;"	d	file:
+MIN_POOL_SIZE	ext/tiovx/gsttiovxmemalloc.c	73;"	d	file:
+MIN_POOL_SIZE	ext/tiovx/gsttiovxmux.c	80;"	d	file:
+MIN_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxmiso.h	82;"	d
+MIN_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxsiso.h	86;"	d
+MIN_RESOLUTION	tests/check/gsttiovxldc.c	77;"	d	file:
+MIN_ROI_VALUE	ext/tiovx/gsttiovxmultiscalerpad.c	66;"	d	file:
+MIN_SCALE	ext/tiovx/gsttiovxdlpreproc.c	82;"	d	file:
+MIN_THRESHOLD	ext/tiovx/gsttiovxdofviz.c	74;"	d	file:
+MIN_VIZ_CONFIDENCE	ext/tiovx/gsttiovxsdeviz.c	74;"	d	file:
+MODULE_MAX_NUM_ADDRS	gst-libs/gst/tiovx/gsttiovxutils.h	76;"	d
+MODULE_MAX_NUM_DIMS	gst-libs/gst/tiovx/gsttiovxtensormeta.h	68;"	d
+MODULE_MAX_NUM_EXPOSURES	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	69;"	d
+MODULE_MAX_NUM_PLANES	ext/tiovx/gsttiovxdof.c	92;"	d	file:
+MODULE_MAX_NUM_PLANES	ext/tiovx/gsttiovxmosaic.c	82;"	d	file:
+MODULE_MAX_NUM_PLANES	gst-libs/gst/tiovx/gsttiovximagemeta.h	69;"	d
+MODULE_MAX_NUM_PYRAMIDS	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	69;"	d
+MODULE_MAX_NUM_TENSORS	gst-libs/gst/tiovx/gsttiovxtensormeta.h	69;"	d
+MODULE_MAX_NUM_TENSORS	gst-libs/gst/tiovx/gsttiovxutils.h	77;"	d
+MODULE_MAX_NUM_USER_DATA_PLANES	ext/tiovx/gsttiovxisp.c	88;"	d	file:
+NUM_BUFFERS_BEFORE_RENEGOTIATION	tests/check/gsttiovxcolorconvert.c	70;"	d	file:
+NUM_BUFFERS_BEFORE_RENEGOTIATION	tests/check/gsttiovxdlcolorconvert.c	70;"	d	file:
+NUM_CHANNELS_SUPPORTED	ext/tiovx/gsttiovxdlpreproc.c	92;"	d	file:
+NUM_DIMS_SUPPORTED	ext/tiovx/gsttiovxdlcolorblend.c	87;"	d	file:
+NUM_DIMS_SUPPORTED	ext/tiovx/gsttiovxdlpreproc.c	91;"	d	file:
+NUM_PARAMETERS	gst-libs/gst/tiovx/gsttiovxmiso.h	79;"	d
+NUM_PARAMETERS	gst-libs/gst/tiovx/gsttiovxsiso.h	79;"	d
+NUM_RENEGOTIATION_ATTEMPTS	tests/check/gsttiovxcolorconvert.c	71;"	d	file:
+NUM_RENEGOTIATION_ATTEMPTS	tests/check/gsttiovxdlcolorconvert.c	71;"	d	file:
+NUM_STATE_TRANSITIONS	tests/check/gsttiovxcolorconvert.c	77;"	d	file:
+NUM_STATE_TRANSITIONS	tests/check/gsttiovxdlcolorconvert.c	77;"	d	file:
+NUM_STATE_TRANSITIONS	tests/check/gsttiovxmultiscaler.c	131;"	d	file:
+NUM_TENSOR_DIMS	ext/tiovx/gsttidlinferer.cpp	89;"	d	file:
+OUTPUT_PARAMETER_INDEX	gst-libs/gst/tiovx/gsttiovxmiso.h	78;"	d
+OUTPUT_PARAMETER_INDEX	gst-libs/gst/tiovx/gsttiovxsiso.h	78;"	d
+OUTPUT_PARAM_ID_START	ext/tiovx/gsttiovxldc.c	79;"	d	file:
+OVERLAY_COLOR	ext/tiovx/gsttiperfoverlay.cpp	103;"	d	file:
+OVERLAY_TEXT_COLOR	ext/tiovx/gsttiperfoverlay.cpp	104;"	d	file:
+PROP_0	ext/tiovx/gsttidlinferer.cpp	/^  PROP_0,$/;"	e	enum:__anon20	file:
+PROP_0	ext/tiovx/gsttidlpostproc.cpp	/^  PROP_0,$/;"	e	enum:__anon35	file:
+PROP_0	ext/tiovx/gsttiovxcolorconvert.c	/^  PROP_0,$/;"	e	enum:__anon38	file:
+PROP_0	ext/tiovx/gsttiovxdelay.c	/^  PROP_0,$/;"	e	enum:__anon12	file:
+PROP_0	ext/tiovx/gsttiovxdlcolorblend.c	/^  PROP_0,$/;"	e	enum:__anon37	file:
+PROP_0	ext/tiovx/gsttiovxdlcolorconvert.c	/^  PROP_0,$/;"	e	enum:__anon17	file:
+PROP_0	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_0,$/;"	e	enum:__anon27	file:
+PROP_0	ext/tiovx/gsttiovxdof.c	/^  PROP_0,$/;"	e	enum:__anon9	file:
+PROP_0	ext/tiovx/gsttiovxdofviz.c	/^  PROP_0,$/;"	e	enum:__anon6	file:
+PROP_0	ext/tiovx/gsttiovxisp.c	/^  PROP_0,$/;"	e	enum:__anon33	file:
+PROP_0	ext/tiovx/gsttiovxldc.c	/^  PROP_0,$/;"	e	enum:__anon22	file:
+PROP_0	ext/tiovx/gsttiovxmemalloc.c	/^  PROP_0,$/;"	e	enum:__anon11	file:
+PROP_0	ext/tiovx/gsttiovxmosaic.c	/^  PROP_0,$/;"	e	enum:__anon26	file:
+PROP_0	ext/tiovx/gsttiovxmultiscaler.c	/^  PROP_0,$/;"	e	enum:__anon19	file:
+PROP_0	ext/tiovx/gsttiovxpyramid.c	/^  PROP_0,$/;"	e	enum:__anon5	file:
+PROP_0	ext/tiovx/gsttiovxsde.c	/^  PROP_0,$/;"	e	enum:__anon16	file:
+PROP_0	ext/tiovx/gsttiovxsdeviz.c	/^  PROP_0,$/;"	e	enum:__anon30	file:
+PROP_0	ext/tiovx/gsttiperfoverlay.cpp	/^  PROP_0,$/;"	e	enum:__anon10	file:
+PROP_0	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  PROP_0,$/;"	e	enum:__anon1	file:
+PROP_AE_MODE	ext/tiovx/gsttiovxisp.c	/^  PROP_AE_MODE,$/;"	e	enum:__anon31	file:
+PROP_AE_NUM_SKIP_FRAMES	ext/tiovx/gsttiovxisp.c	/^  PROP_AE_NUM_SKIP_FRAMES,$/;"	e	enum:__anon31	file:
+PROP_AGGREGATION_PENALTY_P1	ext/tiovx/gsttiovxsde.c	/^  PROP_AGGREGATION_PENALTY_P1,$/;"	e	enum:__anon16	file:
+PROP_AGGREGATION_PENALTY_P2	ext/tiovx/gsttiovxsde.c	/^  PROP_AGGREGATION_PENALTY_P2,$/;"	e	enum:__anon16	file:
+PROP_ALPHA	ext/tiovx/gsttidlpostproc.cpp	/^  PROP_ALPHA,$/;"	e	enum:__anon35	file:
+PROP_AWB_MODE	ext/tiovx/gsttiovxisp.c	/^  PROP_AWB_MODE,$/;"	e	enum:__anon31	file:
+PROP_AWB_NUM_SKIP_FRAMES	ext/tiovx/gsttiovxisp.c	/^  PROP_AWB_NUM_SKIP_FRAMES,$/;"	e	enum:__anon31	file:
+PROP_BACKGROUND	ext/tiovx/gsttiovxmosaic.c	/^  PROP_BACKGROUND,$/;"	e	enum:__anon26	file:
+PROP_BUFFER_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxpad.c	/^  PROP_BUFFER_POOL_SIZE = 1,$/;"	e	enum:__anon2	file:
+PROP_CHANNELS	ext/tiovx/gsttiovxmosaic.c	/^  PROP_CHANNELS,$/;"	e	enum:__anon24	file:
+PROP_CHANNEL_ORDER	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_CHANNEL_ORDER,$/;"	e	enum:__anon27	file:
+PROP_CONFIDENCE_SCORE_MAP_0	ext/tiovx/gsttiovxsde.c	/^  PROP_CONFIDENCE_SCORE_MAP_0,$/;"	e	enum:__anon16	file:
+PROP_CONFIDENCE_SCORE_MAP_1	ext/tiovx/gsttiovxsde.c	/^  PROP_CONFIDENCE_SCORE_MAP_1,$/;"	e	enum:__anon16	file:
+PROP_CONFIDENCE_SCORE_MAP_2	ext/tiovx/gsttiovxsde.c	/^  PROP_CONFIDENCE_SCORE_MAP_2,$/;"	e	enum:__anon16	file:
+PROP_CONFIDENCE_SCORE_MAP_3	ext/tiovx/gsttiovxsde.c	/^  PROP_CONFIDENCE_SCORE_MAP_3,$/;"	e	enum:__anon16	file:
+PROP_CONFIDENCE_SCORE_MAP_4	ext/tiovx/gsttiovxsde.c	/^  PROP_CONFIDENCE_SCORE_MAP_4,$/;"	e	enum:__anon16	file:
+PROP_CONFIDENCE_SCORE_MAP_5	ext/tiovx/gsttiovxsde.c	/^  PROP_CONFIDENCE_SCORE_MAP_5,$/;"	e	enum:__anon16	file:
+PROP_CONFIDENCE_SCORE_MAP_6	ext/tiovx/gsttiovxsde.c	/^  PROP_CONFIDENCE_SCORE_MAP_6,$/;"	e	enum:__anon16	file:
+PROP_CONFIDENCE_SCORE_MAP_7	ext/tiovx/gsttiovxsde.c	/^  PROP_CONFIDENCE_SCORE_MAP_7,$/;"	e	enum:__anon16	file:
+PROP_DATA_TYPE	ext/tiovx/gsttiovxdlcolorblend.c	/^  PROP_DATA_TYPE,$/;"	e	enum:__anon37	file:
+PROP_DATA_TYPE	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_DATA_TYPE,$/;"	e	enum:__anon27	file:
+PROP_DCC_2A_CONFIG_FILE	ext/tiovx/gsttiovxisp.c	/^  PROP_DCC_2A_CONFIG_FILE,$/;"	e	enum:__anon31	file:
+PROP_DCC_CONFIG_FILE	ext/tiovx/gsttiovxldc.c	/^  PROP_DCC_CONFIG_FILE,$/;"	e	enum:__anon22	file:
+PROP_DCC_ISP_CONFIG_FILE	ext/tiovx/gsttiovxisp.c	/^  PROP_DCC_ISP_CONFIG_FILE,$/;"	e	enum:__anon33	file:
+PROP_DELAY_SIZE	ext/tiovx/gsttiovxdelay.c	/^  PROP_DELAY_SIZE,$/;"	e	enum:__anon12	file:
+PROP_DEVICE	ext/tiovx/gsttiovxisp.c	/^  PROP_DEVICE = 1,$/;"	e	enum:__anon31	file:
+PROP_DISPARITY_MAX	ext/tiovx/gsttiovxsde.c	/^  PROP_DISPARITY_MAX,$/;"	e	enum:__anon16	file:
+PROP_DISPARITY_MAX	ext/tiovx/gsttiovxsdeviz.c	/^  PROP_DISPARITY_MAX,$/;"	e	enum:__anon30	file:
+PROP_DISPARITY_MIN	ext/tiovx/gsttiovxsde.c	/^  PROP_DISPARITY_MIN,$/;"	e	enum:__anon16	file:
+PROP_DISPARITY_MIN	ext/tiovx/gsttiovxsdeviz.c	/^  PROP_DISPARITY_MIN,$/;"	e	enum:__anon30	file:
+PROP_DISPARITY_ONLY	ext/tiovx/gsttiovxsdeviz.c	/^  PROP_DISPARITY_ONLY,$/;"	e	enum:__anon30	file:
+PROP_DOWNWARDS_SEARCH_RANGE	ext/tiovx/gsttiovxdof.c	/^  PROP_DOWNWARDS_SEARCH_RANGE,$/;"	e	enum:__anon9	file:
+PROP_DUMP_STATS	ext/tiovx/gsttiperfoverlay.cpp	/^  PROP_DUMP_STATS,$/;"	e	enum:__anon10	file:
+PROP_FORMAT_MSB	ext/tiovx/gsttiovxisp.c	/^  PROP_FORMAT_MSB,$/;"	e	enum:__anon33	file:
+PROP_HEIGHT	ext/tiovx/gsttiovxmosaic.c	/^  PROP_HEIGHT,$/;"	e	enum:__anon24	file:
+PROP_HORIZONTAL_SEARCH_RANGE	ext/tiovx/gsttiovxdof.c	/^  PROP_HORIZONTAL_SEARCH_RANGE,$/;"	e	enum:__anon9	file:
+PROP_INTERPOLATION_METHOD	ext/tiovx/gsttiovxmultiscaler.c	/^  PROP_INTERPOLATION_METHOD,$/;"	e	enum:__anon19	file:
+PROP_IN_POOL_SIZE	ext/tiovx/gsttidlinferer.cpp	/^  PROP_IN_POOL_SIZE,$/;"	e	enum:__anon20	file:
+PROP_IN_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  PROP_IN_POOL_SIZE,$/;"	e	enum:__anon1	file:
+PROP_LDC_BLOCK_HEIGHT	ext/tiovx/gsttiovxldc.c	/^  PROP_LDC_BLOCK_HEIGHT,$/;"	e	enum:__anon22	file:
+PROP_LDC_BLOCK_WIDTH	ext/tiovx/gsttiovxldc.c	/^  PROP_LDC_BLOCK_WIDTH,$/;"	e	enum:__anon22	file:
+PROP_LDC_DS_FACTOR	ext/tiovx/gsttiovxldc.c	/^  PROP_LDC_DS_FACTOR,$/;"	e	enum:__anon22	file:
+PROP_LDC_INIT_X	ext/tiovx/gsttiovxldc.c	/^  PROP_LDC_INIT_X,$/;"	e	enum:__anon22	file:
+PROP_LDC_INIT_Y	ext/tiovx/gsttiovxldc.c	/^  PROP_LDC_INIT_Y,$/;"	e	enum:__anon22	file:
+PROP_LDC_PIXEL_PAD	ext/tiovx/gsttiovxldc.c	/^  PROP_LDC_PIXEL_PAD,$/;"	e	enum:__anon22	file:
+PROP_LDC_TABLE_HEIGHT	ext/tiovx/gsttiovxldc.c	/^  PROP_LDC_TABLE_HEIGHT,$/;"	e	enum:__anon22	file:
+PROP_LDC_TABLE_WIDTH	ext/tiovx/gsttiovxldc.c	/^  PROP_LDC_TABLE_WIDTH,$/;"	e	enum:__anon22	file:
+PROP_LINE_INTERLEAVED	ext/tiovx/gsttiovxisp.c	/^  PROP_LINE_INTERLEAVED,$/;"	e	enum:__anon33	file:
+PROP_LUT_FILE	ext/tiovx/gsttiovxldc.c	/^  PROP_LUT_FILE,$/;"	e	enum:__anon22	file:
+PROP_MEAN_0	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_MEAN_0,$/;"	e	enum:__anon27	file:
+PROP_MEAN_1	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_MEAN_1,$/;"	e	enum:__anon27	file:
+PROP_MEAN_2	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_MEAN_2,$/;"	e	enum:__anon27	file:
+PROP_MEDIAN_FILTER_ENABLE	ext/tiovx/gsttiovxdof.c	/^  PROP_MEDIAN_FILTER_ENABLE,$/;"	e	enum:__anon9	file:
+PROP_MEDIAN_FILTER_ENABLE	ext/tiovx/gsttiovxsde.c	/^  PROP_MEDIAN_FILTER_ENABLE,$/;"	e	enum:__anon16	file:
+PROP_META_HEIGHT_AFTER	ext/tiovx/gsttiovxisp.c	/^  PROP_META_HEIGHT_AFTER,$/;"	e	enum:__anon33	file:
+PROP_META_HEIGHT_BEFORE	ext/tiovx/gsttiovxisp.c	/^  PROP_META_HEIGHT_BEFORE,$/;"	e	enum:__anon33	file:
+PROP_MODEL	ext/tiovx/gsttidlinferer.cpp	/^  PROP_MODEL,$/;"	e	enum:__anon20	file:
+PROP_MODEL	ext/tiovx/gsttidlpostproc.cpp	/^  PROP_MODEL,$/;"	e	enum:__anon35	file:
+PROP_MOTION_DIRECTION	ext/tiovx/gsttiovxdof.c	/^  PROP_MOTION_DIRECTION,$/;"	e	enum:__anon9	file:
+PROP_MOTION_SMOOTHNESS_FACTOR	ext/tiovx/gsttiovxdof.c	/^  PROP_MOTION_SMOOTHNESS_FACTOR,$/;"	e	enum:__anon9	file:
+PROP_NUM_CLASSES	ext/tiovx/gsttiovxdlcolorblend.c	/^  PROP_NUM_CLASSES,$/;"	e	enum:__anon37	file:
+PROP_NUM_EXPOSURES	ext/tiovx/gsttiovxisp.c	/^  PROP_NUM_EXPOSURES,$/;"	e	enum:__anon33	file:
+PROP_OUT_POOL_SIZE	ext/tiovx/gsttidlinferer.cpp	/^  PROP_OUT_POOL_SIZE,$/;"	e	enum:__anon20	file:
+PROP_OUT_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  PROP_OUT_POOL_SIZE,$/;"	e	enum:__anon1	file:
+PROP_OVERLAY_STATS	ext/tiovx/gsttiperfoverlay.cpp	/^  PROP_OVERLAY_STATS,$/;"	e	enum:__anon10	file:
+PROP_PAD_0	ext/tiovx/gsttiovxmux.c	/^  PROP_PAD_0,$/;"	e	enum:__anon36	file:
+PROP_PAD_0	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  PROP_PAD_0,$/;"	e	enum:__anon3	file:
+PROP_PAD_POOL_SIZE	ext/tiovx/gsttiovxmux.c	/^  PROP_PAD_POOL_SIZE,$/;"	e	enum:__anon36	file:
+PROP_PAD_POOL_SIZE	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  PROP_PAD_POOL_SIZE,$/;"	e	enum:__anon3	file:
+PROP_PAD_REPEAT_AFTER_EOS	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  PROP_PAD_REPEAT_AFTER_EOS,$/;"	e	enum:__anon3	file:
+PROP_POOL_SIZE	ext/tiovx/gsttiovxmemalloc.c	/^  PROP_POOL_SIZE,$/;"	e	enum:__anon11	file:
+PROP_REDUCED_RANGE_SEARCH_ENABLE	ext/tiovx/gsttiovxsde.c	/^  PROP_REDUCED_RANGE_SEARCH_ENABLE,$/;"	e	enum:__anon16	file:
+PROP_ROI_HEIGHT	ext/tiovx/gsttiovxmultiscalerpad.c	/^  PROP_ROI_HEIGHT,$/;"	e	enum:__anon21	file:
+PROP_ROI_STARTX	ext/tiovx/gsttiovxmultiscalerpad.c	/^  PROP_ROI_STARTX = 1,$/;"	e	enum:__anon21	file:
+PROP_ROI_STARTY	ext/tiovx/gsttiovxmultiscalerpad.c	/^  PROP_ROI_STARTY,$/;"	e	enum:__anon21	file:
+PROP_ROI_WIDTH	ext/tiovx/gsttiovxmultiscalerpad.c	/^  PROP_ROI_WIDTH,$/;"	e	enum:__anon21	file:
+PROP_SCALE_0	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_SCALE_0,$/;"	e	enum:__anon27	file:
+PROP_SCALE_1	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_SCALE_1,$/;"	e	enum:__anon27	file:
+PROP_SCALE_2	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_SCALE_2,$/;"	e	enum:__anon27	file:
+PROP_SENSOR_NAME	ext/tiovx/gsttiovxisp.c	/^  PROP_SENSOR_NAME,$/;"	e	enum:__anon33	file:
+PROP_SENSOR_NAME	ext/tiovx/gsttiovxldc.c	/^  PROP_SENSOR_NAME,$/;"	e	enum:__anon22	file:
+PROP_STARTX	ext/tiovx/gsttiovxmosaic.c	/^  PROP_STARTX = 1,$/;"	e	enum:__anon24	file:
+PROP_STARTY	ext/tiovx/gsttiovxmosaic.c	/^  PROP_STARTY,$/;"	e	enum:__anon24	file:
+PROP_TARGET	ext/tiovx/gsttiovxcolorconvert.c	/^  PROP_TARGET,$/;"	e	enum:__anon38	file:
+PROP_TARGET	ext/tiovx/gsttiovxdlcolorblend.c	/^  PROP_TARGET,$/;"	e	enum:__anon37	file:
+PROP_TARGET	ext/tiovx/gsttiovxdlcolorconvert.c	/^  PROP_TARGET,$/;"	e	enum:__anon17	file:
+PROP_TARGET	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_TARGET,$/;"	e	enum:__anon27	file:
+PROP_TARGET	ext/tiovx/gsttiovxdof.c	/^  PROP_TARGET,$/;"	e	enum:__anon9	file:
+PROP_TARGET	ext/tiovx/gsttiovxdofviz.c	/^  PROP_TARGET,$/;"	e	enum:__anon6	file:
+PROP_TARGET	ext/tiovx/gsttiovxisp.c	/^  PROP_TARGET,$/;"	e	enum:__anon33	file:
+PROP_TARGET	ext/tiovx/gsttiovxldc.c	/^  PROP_TARGET,$/;"	e	enum:__anon22	file:
+PROP_TARGET	ext/tiovx/gsttiovxmosaic.c	/^  PROP_TARGET,$/;"	e	enum:__anon26	file:
+PROP_TARGET	ext/tiovx/gsttiovxmultiscaler.c	/^  PROP_TARGET,$/;"	e	enum:__anon19	file:
+PROP_TARGET	ext/tiovx/gsttiovxpyramid.c	/^  PROP_TARGET,$/;"	e	enum:__anon5	file:
+PROP_TARGET	ext/tiovx/gsttiovxsde.c	/^  PROP_TARGET,$/;"	e	enum:__anon16	file:
+PROP_TARGET	ext/tiovx/gsttiovxsdeviz.c	/^  PROP_TARGET,$/;"	e	enum:__anon30	file:
+PROP_TENSOR_FORMAT	ext/tiovx/gsttiovxdlpreproc.c	/^  PROP_TENSOR_FORMAT,$/;"	e	enum:__anon27	file:
+PROP_TEXTURE_FILTER_ENABLE	ext/tiovx/gsttiovxsde.c	/^  PROP_TEXTURE_FILTER_ENABLE,$/;"	e	enum:__anon16	file:
+PROP_THRESHOLD_LEFT_RIGHT	ext/tiovx/gsttiovxsde.c	/^  PROP_THRESHOLD_LEFT_RIGHT,$/;"	e	enum:__anon16	file:
+PROP_THRESHOLD_TEXTURE	ext/tiovx/gsttiovxsde.c	/^  PROP_THRESHOLD_TEXTURE,$/;"	e	enum:__anon16	file:
+PROP_TITLE	ext/tiovx/gsttiperfoverlay.cpp	/^  PROP_TITLE,$/;"	e	enum:__anon10	file:
+PROP_TOPN	ext/tiovx/gsttidlpostproc.cpp	/^  PROP_TOPN,$/;"	e	enum:__anon35	file:
+PROP_UPDATE_FPS_INTERVAL	ext/tiovx/gsttiperfoverlay.cpp	/^  PROP_UPDATE_FPS_INTERVAL,$/;"	e	enum:__anon10	file:
+PROP_UPDATE_STATS_INTERVAL	ext/tiovx/gsttiperfoverlay.cpp	/^  PROP_UPDATE_STATS_INTERVAL,$/;"	e	enum:__anon10	file:
+PROP_UPWARDS_SEARCH_RANGE	ext/tiovx/gsttiovxdof.c	/^  PROP_UPWARDS_SEARCH_RANGE,$/;"	e	enum:__anon9	file:
+PROP_VIZ_CONFIDENCE	ext/tiovx/gsttiovxsdeviz.c	/^  PROP_VIZ_CONFIDENCE,$/;"	e	enum:__anon30	file:
+PROP_VIZ_THRESHOLD	ext/tiovx/gsttidlpostproc.cpp	/^  PROP_VIZ_THRESHOLD,$/;"	e	enum:__anon35	file:
+PROP_WIDTH	ext/tiovx/gsttiovxmosaic.c	/^  PROP_WIDTH,$/;"	e	enum:__anon24	file:
+PYRAMID_INPUT_PARAM_INDEX	ext/tiovx/gsttiovxpyramid.c	75;"	d	file:
+PYRAMID_MIN_RESOLUTION	ext/tiovx/gsttiovxpyramid.c	77;"	d	file:
+PYRAMID_OUTPUT_PARAM_INDEX	ext/tiovx/gsttiovxpyramid.c	76;"	d	file:
+PadTemplate	tests/check/gsttiovxisp.c	/^} PadTemplate;$/;"	t	typeref:struct:__anon48	file:
+PadTemplate	tests/check/gsttiovxmosaic.c	/^} PadTemplate;$/;"	t	typeref:struct:__anon40	file:
+PadTemplateSink	tests/check/gsttiovxdlcolorblend.c	/^} PadTemplateSink;$/;"	t	typeref:struct:__anon52	file:
+PadTemplateSink	tests/check/gsttiovxdlpreproc.c	/^} PadTemplateSink;$/;"	t	typeref:struct:__anon43	file:
+PadTemplateSrc	tests/check/gsttiovxdlcolorblend.c	/^} PadTemplateSrc;$/;"	t	typeref:struct:__anon53	file:
+PadTemplateSrc	tests/check/gsttiovxdlpreproc.c	/^} PadTemplateSrc;$/;"	t	typeref:struct:__anon44	file:
+PadTemplateTensor	tests/check/gsttiovxdlcolorblend.c	/^} PadTemplateTensor;$/;"	t	typeref:struct:__anon54	file:
+Properties	tests/check/gsttiovxisp.c	/^} Properties;$/;"	t	typeref:struct:__anon49	file:
+Properties	tests/check/gsttiovxmosaic.c	/^} Properties;$/;"	t	typeref:struct:__anon41	file:
+RAW_IMAGE_NUM_EXPOSURES	gst-libs/gst/tiovx/gsttiovxutils.c	84;"	d	file:
+Range	tests/check/gsttiovxisp.c	/^} Range;$/;"	t	typeref:struct:__anon46	file:
+SCALE_DIM	ext/tiovx/gsttiovxdlpreproc.c	79;"	d	file:
+SDEVIZ_INPUT_PARAM_INDEX	ext/tiovx/gsttiovxsdeviz.c	80;"	d	file:
+SDEVIZ_OUTPUT_PARAM_INDEX	ext/tiovx/gsttiovxsdeviz.c	81;"	d	file:
+SINK_FORMATS	tests/check/gsttiovxcolorconvert.c	74;"	d	file:
+SINK_FORMATS	tests/check/gsttiovxdlcolorconvert.c	74;"	d	file:
+SRC_FORMATS_FAIL	tests/check/gsttiovxcolorconvert.c	76;"	d	file:
+SRC_FORMATS_FAIL	tests/check/gsttiovxdlcolorconvert.c	76;"	d	file:
+SRC_FORMATS_SUCCESS	tests/check/gsttiovxcolorconvert.c	75;"	d	file:
+SRC_FORMATS_SUCCESS	tests/check/gsttiovxdlcolorconvert.c	75;"	d	file:
+TENSOR_ALIGNMENT_BYTES	ext/tiovx/gsttidlinferer.cpp	90;"	d	file:
+TENSOR_CHANNELS_SUPPORTED	ext/tiovx/gsttiovxdemux.c	157;"	d	file:
+TENSOR_CHANNELS_SUPPORTED	ext/tiovx/gsttiovxdlcolorblend.c	88;"	d	file:
+TENSOR_CHANNELS_SUPPORTED	ext/tiovx/gsttiovxmux.c	266;"	d	file:
+TENSOR_NUM_DIMS_SUPPORTED	ext/tiovx/gsttiovxdemux.c	156;"	d	file:
+TENSOR_NUM_DIMS_SUPPORTED	ext/tiovx/gsttiovxmux.c	265;"	d	file:
+TENSOR_NUM_DIMS_SUPPORTED	gst-libs/gst/tiovx/gsttiovxutils.c	81;"	d	file:
+TEST_2_OUT_FORMAT_1_SRC_CAPS_GRAY8	tests/check/gsttiovxmultiscaler.c	/^  TEST_2_OUT_FORMAT_1_SRC_CAPS_GRAY8,$/;"	e	enum:__anon39	file:
+TEST_2_OUT_FORMAT_SINK_CAPS_1_SRC_CAPS_GRAY8	tests/check/gsttiovxmultiscaler.c	/^  TEST_2_OUT_FORMAT_SINK_CAPS_1_SRC_CAPS_GRAY8,$/;"	e	enum:__anon39	file:
+TEST_BUILD_PIPELINE	tests/check/gsttiovx_multiple_transitions.c	/^  TEST_BUILD_PIPELINE,$/;"	e	enum:__anon51	file:
+TEST_DIFF_FORMAT_INPUT_2_OUTPUTS	tests/check/gsttiovxmultiscaler.c	/^  TEST_DIFF_FORMAT_INPUT_2_OUTPUTS,$/;"	e	enum:__anon39	file:
+TEST_DIFF_FORMAT_INPUT_OUTPUT	tests/check/gsttiovxmultiscaler.c	/^  TEST_DIFF_FORMAT_INPUT_OUTPUT,$/;"	e	enum:__anon39	file:
+TEST_FIVE_PADS	tests/check/gsttiovxmultiscaler.c	/^  TEST_FIVE_PADS,$/;"	e	enum:__anon39	file:
+TEST_FOUR_PADS	tests/check/gsttiovxmultiscaler.c	/^  TEST_FOUR_PADS,$/;"	e	enum:__anon39	file:
+TEST_LOW_RES	tests/check/gsttiovxmultiscaler.c	/^  TEST_LOW_RES,$/;"	e	enum:__anon39	file:
+TEST_LOW_RES_HEIGHT	tests/check/gsttiovxmultiscaler.c	/^  TEST_LOW_RES_HEIGHT,$/;"	e	enum:__anon39	file:
+TEST_LOW_RES_WIDTH	tests/check/gsttiovxmultiscaler.c	/^  TEST_LOW_RES_WIDTH,$/;"	e	enum:__anon39	file:
+TEST_MISO_INPUT	tests/check/libs/gsttiovxmiso.c	75;"	d	file:
+TEST_MISO_NUM_CHANNELS	tests/check/libs/gsttiovxmiso.c	76;"	d	file:
+TEST_NO_FORMAT_SINK_CAPS_GRAY8	tests/check/gsttiovxmultiscaler.c	/^  TEST_NO_FORMAT_SINK_CAPS_GRAY8,$/;"	e	enum:__anon39	file:
+TEST_NO_FORMAT_SPECIFIED	tests/check/gsttiovxmultiscaler.c	/^  TEST_NO_FORMAT_SPECIFIED,$/;"	e	enum:__anon39	file:
+TEST_NO_FORMAT_SRC_CAPS_GRAY8	tests/check/gsttiovxmultiscaler.c	/^  TEST_NO_FORMAT_SRC_CAPS_GRAY8,$/;"	e	enum:__anon39	file:
+TEST_ONE_PAD	tests/check/gsttiovxmultiscaler.c	/^  TEST_ONE_PAD,$/;"	e	enum:__anon39	file:
+TEST_SIMO_NUM_CHANNELS	tests/check/libs/gsttiovxsimo.c	76;"	d	file:
+TEST_SIMO_OUTPUT	tests/check/libs/gsttiovxsimo.c	75;"	d	file:
+TEST_SIX_PADS	tests/check/gsttiovxmultiscaler.c	/^  TEST_SIX_PADS,$/;"	e	enum:__anon39	file:
+TEST_THREE_PADS	tests/check/gsttiovxmultiscaler.c	/^  TEST_THREE_PADS,$/;"	e	enum:__anon39	file:
+TEST_TWO_PADS	tests/check/gsttiovxmultiscaler.c	/^  TEST_TWO_PADS,$/;"	e	enum:__anon39	file:
+TEST_UPSCALING	tests/check/gsttiovxmultiscaler.c	/^  TEST_UPSCALING,$/;"	e	enum:__anon39	file:
+TEST_ZERO_PADS	tests/check/gsttiovxmultiscaler.c	/^  TEST_ZERO_PADS = 0,$/;"	e	enum:__anon39	file:
+TEXT_COLOR	ext/tiovx/gsttiperfoverlay.cpp	101;"	d	file:
+TIOVXDLCOLORBLEND_DATA_TYPE_ARRAY_SIZE	tests/check/gsttiovxdlcolorblend.c	91;"	d	file:
+TIOVXDLCOLORBLEND_DATA_TYPE_ENUM_ARRAY_SIZE	tests/check/gsttiovxdlcolorblend.c	103;"	d	file:
+TIOVXDLCOLORBLEND_FORMATS_ARRAY_SIZE	tests/check/gsttiovxdlcolorblend.c	77;"	d	file:
+TIOVXDLCOLORBLEND_NUM_DIMS_SUPPORTED	tests/check/gsttiovxdlcolorblend.c	73;"	d	file:
+TIOVXDLCOLORBLEND_STATES_CHANGE_ITERATIONS	tests/check/gsttiovxdlcolorblend.c	74;"	d	file:
+TIOVXDLCOLORBLEND_TARGETS_ARRAY_SIZE	tests/check/gsttiovxdlcolorblend.c	120;"	d	file:
+TIOVXDLColorBlendModeled	tests/check/gsttiovxdlcolorblend.c	/^} TIOVXDLColorBlendModeled;$/;"	t	typeref:struct:__anon55	file:
+TIOVXDLPREPROC_CHANNEL_ORDER_ARRAY_SIZE	tests/check/gsttiovxdlpreproc.c	104;"	d	file:
+TIOVXDLPREPROC_DATA_TYPE_ARRAY_SIZE	tests/check/gsttiovxdlpreproc.c	91;"	d	file:
+TIOVXDLPREPROC_FORMATS_ARRAY_SIZE	tests/check/gsttiovxdlpreproc.c	74;"	d	file:
+TIOVXDLPREPROC_STATES_CHANGE_ITERATIONS	tests/check/gsttiovxdlpreproc.c	71;"	d	file:
+TIOVXDLPREPROC_TENSOR_FORMAT_ARRAY_SIZE	tests/check/gsttiovxdlpreproc.c	112;"	d	file:
+TIOVXDLPreProcModeled	tests/check/gsttiovxdlpreproc.c	/^} TIOVXDLPreProcModeled;$/;"	t	typeref:struct:__anon45	file:
+TIOVXISPModeled	tests/check/gsttiovxisp.c	/^} TIOVXISPModeled;$/;"	t	typeref:struct:__anon50	file:
+TIOVXISP_DCC_ARRAY_SIZE	tests/check/gsttiovxisp.c	138;"	d	file:
+TIOVXISP_INPUT_FORMATS_ARRAY_SIZE	tests/check/gsttiovxisp.c	90;"	d	file:
+TIOVXISP_MAX_SUPPORTED_PADS	tests/check/gsttiovxisp.c	79;"	d	file:
+TIOVXISP_NUM_DIMS_SUPPORTED	tests/check/gsttiovxisp.c	77;"	d	file:
+TIOVXISP_OUTPUT_FORMATS_ARRAY_SIZE	tests/check/gsttiovxisp.c	110;"	d	file:
+TIOVXISP_STATE_CHANGE_ITERATIONS	tests/check/gsttiovxisp.c	71;"	d	file:
+TIOVXISP_TARGET_ARRAY_SIZE	tests/check/gsttiovxisp.c	178;"	d	file:
+TIOVXLDC_STATE_CHANGE_ITERATIONS	tests/check/gsttiovxldc.c	70;"	d	file:
+TIOVXMOSAIC_FORMATS_ARRAY_SIZE	tests/check/gsttiovxmosaic.c	74;"	d	file:
+TIOVXMOSAIC_STATE_CHANGE_ITERATIONS	tests/check/gsttiovxmosaic.c	71;"	d	file:
+TIOVXMOSAIC_TARGET_ARRAY_SIZE	tests/check/gsttiovxmosaic.c	89;"	d	file:
+TIOVXMosaicModeled	tests/check/gsttiovxmosaic.c	/^} TIOVXMosaicModeled;$/;"	t	typeref:struct:__anon42	file:
+TIOVX_COLOR_CONVERT_STATIC_CAPS_SINK	ext/tiovx/gsttiovxcolorconvert.c	134;"	d	file:
+TIOVX_COLOR_CONVERT_STATIC_CAPS_SRC	ext/tiovx/gsttiovxcolorconvert.c	121;"	d	file:
+TIOVX_COLOR_CONVERT_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxcolorconvert.c	118;"	d	file:
+TIOVX_COLOR_CONVERT_SUPPORTED_FORMATS_SINK	ext/tiovx/gsttiovxcolorconvert.c	115;"	d	file:
+TIOVX_COLOR_CONVERT_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxcolorconvert.c	114;"	d	file:
+TIOVX_COLOR_CONVERT_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxcolorconvert.c	117;"	d	file:
+TIOVX_COLOR_CONVERT_SUPPORTED_WIDTH	ext/tiovx/gsttiovxcolorconvert.c	116;"	d	file:
+TIOVX_DEMUX_STATIC_CAPS_SINK	ext/tiovx/gsttiovxdemux.c	127;"	d	file:
+TIOVX_DEMUX_STATIC_CAPS_SRC	ext/tiovx/gsttiovxdemux.c	101;"	d	file:
+TIOVX_DEMUX_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxdemux.c	84;"	d	file:
+TIOVX_DEMUX_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxdemux.c	83;"	d	file:
+TIOVX_DEMUX_SUPPORTED_PYRAMID_FORMAT	ext/tiovx/gsttiovxdemux.c	94;"	d	file:
+TIOVX_DEMUX_SUPPORTED_PYRAMID_HEIGHT	ext/tiovx/gsttiovxdemux.c	96;"	d	file:
+TIOVX_DEMUX_SUPPORTED_PYRAMID_LEVELS	ext/tiovx/gsttiovxdemux.c	97;"	d	file:
+TIOVX_DEMUX_SUPPORTED_PYRAMID_SCALE	ext/tiovx/gsttiovxdemux.c	98;"	d	file:
+TIOVX_DEMUX_SUPPORTED_PYRAMID_WIDTH	ext/tiovx/gsttiovxdemux.c	95;"	d	file:
+TIOVX_DEMUX_SUPPORTED_TENSOR_CHANNEL_ORDER	ext/tiovx/gsttiovxdemux.c	91;"	d	file:
+TIOVX_DEMUX_SUPPORTED_TENSOR_DATA_TYPES	ext/tiovx/gsttiovxdemux.c	90;"	d	file:
+TIOVX_DEMUX_SUPPORTED_TENSOR_DIMENSIONS	ext/tiovx/gsttiovxdemux.c	89;"	d	file:
+TIOVX_DEMUX_SUPPORTED_TENSOR_FORMAT	ext/tiovx/gsttiovxdemux.c	92;"	d	file:
+TIOVX_DEMUX_SUPPORTED_TENSOR_FORMATS	ext/tiovx/gsttiovxdemux.c	88;"	d	file:
+TIOVX_DEMUX_SUPPORTED_VIDEO_FORMATS	ext/tiovx/gsttiovxdemux.c	86;"	d	file:
+TIOVX_DEMUX_SUPPORTED_WIDTH	ext/tiovx/gsttiovxdemux.c	82;"	d	file:
+TIOVX_DL_COLOR_BLEND_STATIC_CAPS_IMAGE	ext/tiovx/gsttiovxdlcolorblend.c	111;"	d	file:
+TIOVX_DL_COLOR_BLEND_STATIC_CAPS_TENSOR_SINK	ext/tiovx/gsttiovxdlcolorblend.c	126;"	d	file:
+TIOVX_DL_COLOR_BLEND_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxdlcolorblend.c	108;"	d	file:
+TIOVX_DL_COLOR_BLEND_SUPPORTED_DATA_TYPES	ext/tiovx/gsttiovxdlcolorblend.c	107;"	d	file:
+TIOVX_DL_COLOR_BLEND_SUPPORTED_DIMENSIONS	ext/tiovx/gsttiovxdlcolorblend.c	106;"	d	file:
+TIOVX_DL_COLOR_BLEND_SUPPORTED_FORMATS_SINK	ext/tiovx/gsttiovxdlcolorblend.c	103;"	d	file:
+TIOVX_DL_COLOR_BLEND_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxdlcolorblend.c	102;"	d	file:
+TIOVX_DL_COLOR_BLEND_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxdlcolorblend.c	105;"	d	file:
+TIOVX_DL_COLOR_BLEND_SUPPORTED_WIDTH	ext/tiovx/gsttiovxdlcolorblend.c	104;"	d	file:
+TIOVX_DL_COLOR_CONVERT_STATIC_CAPS_SINK	ext/tiovx/gsttiovxdlcolorconvert.c	134;"	d	file:
+TIOVX_DL_COLOR_CONVERT_STATIC_CAPS_SRC	ext/tiovx/gsttiovxdlcolorconvert.c	121;"	d	file:
+TIOVX_DL_COLOR_CONVERT_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxdlcolorconvert.c	118;"	d	file:
+TIOVX_DL_COLOR_CONVERT_SUPPORTED_FORMATS_SINK	ext/tiovx/gsttiovxdlcolorconvert.c	115;"	d	file:
+TIOVX_DL_COLOR_CONVERT_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxdlcolorconvert.c	114;"	d	file:
+TIOVX_DL_COLOR_CONVERT_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxdlcolorconvert.c	117;"	d	file:
+TIOVX_DL_COLOR_CONVERT_SUPPORTED_WIDTH	ext/tiovx/gsttiovxdlcolorconvert.c	116;"	d	file:
+TIOVX_DL_PRE_PROC_STATIC_CAPS_SINK	ext/tiovx/gsttiovxdlpreproc.c	140;"	d	file:
+TIOVX_DL_PRE_PROC_STATIC_CAPS_SRC	ext/tiovx/gsttiovxdlpreproc.c	121;"	d	file:
+TIOVX_DL_PRE_PROC_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxdlpreproc.c	118;"	d	file:
+TIOVX_DL_PRE_PROC_SUPPORTED_CHANNEL_ORDER	ext/tiovx/gsttiovxdlpreproc.c	116;"	d	file:
+TIOVX_DL_PRE_PROC_SUPPORTED_DATA_TYPES	ext/tiovx/gsttiovxdlpreproc.c	115;"	d	file:
+TIOVX_DL_PRE_PROC_SUPPORTED_DIMENSIONS	ext/tiovx/gsttiovxdlpreproc.c	114;"	d	file:
+TIOVX_DL_PRE_PROC_SUPPORTED_FORMATS_SINK	ext/tiovx/gsttiovxdlpreproc.c	111;"	d	file:
+TIOVX_DL_PRE_PROC_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxdlpreproc.c	113;"	d	file:
+TIOVX_DL_PRE_PROC_SUPPORTED_TENSOR_FORMAT	ext/tiovx/gsttiovxdlpreproc.c	117;"	d	file:
+TIOVX_DL_PRE_PROC_SUPPORTED_WIDTH	ext/tiovx/gsttiovxdlpreproc.c	112;"	d	file:
+TIOVX_DOF_STATIC_CAPS_SINK	ext/tiovx/gsttiovxdof.c	181;"	d	file:
+TIOVX_DOF_STATIC_CAPS_SRC	ext/tiovx/gsttiovxdof.c	198;"	d	file:
+TIOVX_DOF_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxdof.c	178;"	d	file:
+TIOVX_DOF_SUPPORTED_FORMATS_PYRAMID	ext/tiovx/gsttiovxdof.c	173;"	d	file:
+TIOVX_DOF_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxdof.c	175;"	d	file:
+TIOVX_DOF_SUPPORTED_LEVELS_PYRAMID	ext/tiovx/gsttiovxdof.c	176;"	d	file:
+TIOVX_DOF_SUPPORTED_SCALE_PYRAMID	ext/tiovx/gsttiovxdof.c	177;"	d	file:
+TIOVX_DOF_SUPPORTED_WIDTH	ext/tiovx/gsttiovxdof.c	174;"	d	file:
+TIOVX_DOF_VIZ_STATIC_CAPS_SINK	ext/tiovx/gsttiovxdofviz.c	137;"	d	file:
+TIOVX_DOF_VIZ_STATIC_CAPS_SRC	ext/tiovx/gsttiovxdofviz.c	124;"	d	file:
+TIOVX_DOF_VIZ_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxdofviz.c	121;"	d	file:
+TIOVX_DOF_VIZ_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxdofviz.c	118;"	d	file:
+TIOVX_DOF_VIZ_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxdofviz.c	120;"	d	file:
+TIOVX_DOF_VIZ_SUPPORTED_WIDTH	ext/tiovx/gsttiovxdofviz.c	119;"	d	file:
+TIOVX_ISP_STATIC_CAPS_SINK	ext/tiovx/gsttiovxisp.c	531;"	d	file:
+TIOVX_ISP_STATIC_CAPS_SRC	ext/tiovx/gsttiovxisp.c	518;"	d	file:
+TIOVX_ISP_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxisp.c	515;"	d	file:
+TIOVX_ISP_SUPPORTED_FORMATS_SINK	ext/tiovx/gsttiovxisp.c	512;"	d	file:
+TIOVX_ISP_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxisp.c	508;"	d	file:
+TIOVX_ISP_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxisp.c	510;"	d	file:
+TIOVX_ISP_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxisp.c	514;"	d	file:
+TIOVX_ISP_SUPPORTED_WIDTH	ext/tiovx/gsttiovxisp.c	513;"	d	file:
+TIOVX_LDC_STATIC_SUPPORTED_CAPS	ext/tiovx/gsttiovxldc.c	136;"	d	file:
+TIOVX_LDC_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxldc.c	133;"	d	file:
+TIOVX_LDC_SUPPORTED_FORMATS	ext/tiovx/gsttiovxldc.c	130;"	d	file:
+TIOVX_LDC_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxldc.c	132;"	d	file:
+TIOVX_LDC_SUPPORTED_WIDTH	ext/tiovx/gsttiovxldc.c	131;"	d	file:
+TIOVX_MAX_CHANNELS	ext/tiovx/gsttiovxdemux.c	79;"	d	file:
+TIOVX_MOSAIC_STATIC_CAPS_SINK	ext/tiovx/gsttiovxmosaic.c	478;"	d	file:
+TIOVX_MOSAIC_STATIC_CAPS_SRC	ext/tiovx/gsttiovxmosaic.c	492;"	d	file:
+TIOVX_MOSAIC_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxmosaic.c	476;"	d	file:
+TIOVX_MOSAIC_SUPPORTED_FORMATS_SINK	ext/tiovx/gsttiovxmosaic.c	473;"	d	file:
+TIOVX_MOSAIC_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxmosaic.c	472;"	d	file:
+TIOVX_MOSAIC_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxmosaic.c	475;"	d	file:
+TIOVX_MOSAIC_SUPPORTED_WIDTH	ext/tiovx/gsttiovxmosaic.c	474;"	d	file:
+TIOVX_MULTI_SCALER_STATIC_CAPS_IMAGE	ext/tiovx/gsttiovxmultiscaler.c	149;"	d	file:
+TIOVX_MULTI_SCALER_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxmultiscaler.c	147;"	d	file:
+TIOVX_MULTI_SCALER_SUPPORTED_FORMATS_SINK	ext/tiovx/gsttiovxmultiscaler.c	144;"	d	file:
+TIOVX_MULTI_SCALER_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxmultiscaler.c	143;"	d	file:
+TIOVX_MULTI_SCALER_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxmultiscaler.c	146;"	d	file:
+TIOVX_MULTI_SCALER_SUPPORTED_WIDTH	ext/tiovx/gsttiovxmultiscaler.c	145;"	d	file:
+TIOVX_MUX_STATIC_CAPS_SINK	ext/tiovx/gsttiovxmux.c	243;"	d	file:
+TIOVX_MUX_STATIC_CAPS_SRC	ext/tiovx/gsttiovxmux.c	216;"	d	file:
+TIOVX_MUX_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxmux.c	199;"	d	file:
+TIOVX_MUX_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxmux.c	198;"	d	file:
+TIOVX_MUX_SUPPORTED_PYRAMID_FORMAT	ext/tiovx/gsttiovxmux.c	209;"	d	file:
+TIOVX_MUX_SUPPORTED_PYRAMID_HEIGHT	ext/tiovx/gsttiovxmux.c	211;"	d	file:
+TIOVX_MUX_SUPPORTED_PYRAMID_LEVELS	ext/tiovx/gsttiovxmux.c	212;"	d	file:
+TIOVX_MUX_SUPPORTED_PYRAMID_SCALE	ext/tiovx/gsttiovxmux.c	213;"	d	file:
+TIOVX_MUX_SUPPORTED_PYRAMID_WIDTH	ext/tiovx/gsttiovxmux.c	210;"	d	file:
+TIOVX_MUX_SUPPORTED_TENSOR_CHANNEL_ORDER	ext/tiovx/gsttiovxmux.c	206;"	d	file:
+TIOVX_MUX_SUPPORTED_TENSOR_DATA_TYPES	ext/tiovx/gsttiovxmux.c	205;"	d	file:
+TIOVX_MUX_SUPPORTED_TENSOR_DIMENSIONS	ext/tiovx/gsttiovxmux.c	204;"	d	file:
+TIOVX_MUX_SUPPORTED_TENSOR_FORMAT	ext/tiovx/gsttiovxmux.c	207;"	d	file:
+TIOVX_MUX_SUPPORTED_TENSOR_FORMATS	ext/tiovx/gsttiovxmux.c	203;"	d	file:
+TIOVX_MUX_SUPPORTED_VIDEO_FORMATS	ext/tiovx/gsttiovxmux.c	201;"	d	file:
+TIOVX_MUX_SUPPORTED_WIDTH	ext/tiovx/gsttiovxmux.c	197;"	d	file:
+TIOVX_PYRAMID_STATIC_CAPS_SINK	ext/tiovx/gsttiovxpyramid.c	139;"	d	file:
+TIOVX_PYRAMID_STATIC_CAPS_SRC	ext/tiovx/gsttiovxpyramid.c	122;"	d	file:
+TIOVX_PYRAMID_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxpyramid.c	119;"	d	file:
+TIOVX_PYRAMID_SUPPORTED_FORMATS	ext/tiovx/gsttiovxpyramid.c	114;"	d	file:
+TIOVX_PYRAMID_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxpyramid.c	116;"	d	file:
+TIOVX_PYRAMID_SUPPORTED_LEVELS	ext/tiovx/gsttiovxpyramid.c	117;"	d	file:
+TIOVX_PYRAMID_SUPPORTED_SCALE	ext/tiovx/gsttiovxpyramid.c	118;"	d	file:
+TIOVX_PYRAMID_SUPPORTED_WIDTH	ext/tiovx/gsttiovxpyramid.c	115;"	d	file:
+TIOVX_SDE_STATIC_CAPS_SINK	ext/tiovx/gsttiovxsde.c	225;"	d	file:
+TIOVX_SDE_STATIC_CAPS_SRC	ext/tiovx/gsttiovxsde.c	238;"	d	file:
+TIOVX_SDE_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxsde.c	222;"	d	file:
+TIOVX_SDE_SUPPORTED_FORMATS	ext/tiovx/gsttiovxsde.c	219;"	d	file:
+TIOVX_SDE_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxsde.c	221;"	d	file:
+TIOVX_SDE_SUPPORTED_WIDTH	ext/tiovx/gsttiovxsde.c	220;"	d	file:
+TIOVX_SDE_VIZ_STATIC_CAPS_SINK	ext/tiovx/gsttiovxsdeviz.c	201;"	d	file:
+TIOVX_SDE_VIZ_STATIC_CAPS_SRC	ext/tiovx/gsttiovxsdeviz.c	188;"	d	file:
+TIOVX_SDE_VIZ_SUPPORTED_CHANNELS	ext/tiovx/gsttiovxsdeviz.c	185;"	d	file:
+TIOVX_SDE_VIZ_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttiovxsdeviz.c	182;"	d	file:
+TIOVX_SDE_VIZ_SUPPORTED_HEIGHT	ext/tiovx/gsttiovxsdeviz.c	184;"	d	file:
+TIOVX_SDE_VIZ_SUPPORTED_WIDTH	ext/tiovx/gsttiovxsdeviz.c	183;"	d	file:
+TIOVX_TEST_SIMO_STATIC_CAPS_SRC	tests/check/libs/gsttiovxsimo.c	94;"	d	file:
+TIOVX_TEST_SISO_STATIC_CAPS	tests/check/libs/gsttiovxsiso.c	77;"	d	file:
+TIVX_MAX_DISPARITY_127	ext/tiovx/gsttiovxsde.c	/^  TIVX_MAX_DISPARITY_127 = 1,$/;"	e	enum:__anon15	file:
+TIVX_MAX_DISPARITY_127	ext/tiovx/gsttiovxsdeviz.c	/^  TIVX_MAX_DISPARITY_127 = 1,$/;"	e	enum:__anon29	file:
+TIVX_MAX_DISPARITY_191	ext/tiovx/gsttiovxsde.c	/^  TIVX_MAX_DISPARITY_191 = 2,$/;"	e	enum:__anon15	file:
+TIVX_MAX_DISPARITY_191	ext/tiovx/gsttiovxsdeviz.c	/^  TIVX_MAX_DISPARITY_191 = 2,$/;"	e	enum:__anon29	file:
+TIVX_MAX_DISPARITY_63	ext/tiovx/gsttiovxsde.c	/^  TIVX_MAX_DISPARITY_63 = 0,$/;"	e	enum:__anon15	file:
+TIVX_MAX_DISPARITY_63	ext/tiovx/gsttiovxsdeviz.c	/^  TIVX_MAX_DISPARITY_63 = 0,$/;"	e	enum:__anon29	file:
+TIVX_MIN_DISPARITY_MINUS_THREE	ext/tiovx/gsttiovxsde.c	/^  TIVX_MIN_DISPARITY_MINUS_THREE = 1,$/;"	e	enum:__anon14	file:
+TIVX_MIN_DISPARITY_MINUS_THREE	ext/tiovx/gsttiovxsdeviz.c	/^  TIVX_MIN_DISPARITY_MINUS_THREE = 1,$/;"	e	enum:__anon28	file:
+TIVX_MIN_DISPARITY_ZERO	ext/tiovx/gsttiovxsde.c	/^  TIVX_MIN_DISPARITY_ZERO = 0,$/;"	e	enum:__anon14	file:
+TIVX_MIN_DISPARITY_ZERO	ext/tiovx/gsttiovxsdeviz.c	/^  TIVX_MIN_DISPARITY_ZERO = 0,$/;"	e	enum:__anon28	file:
+TIVX_MOTION_DIRECTION_FORWARD_MOTION_ID	ext/tiovx/gsttiovxdof.c	/^  TIVX_MOTION_DIRECTION_FORWARD_MOTION_ID = 1,$/;"	e	enum:__anon8	file:
+TIVX_MOTION_DIRECTION_MOTION_NEUTRAL_5x5_ID	ext/tiovx/gsttiovxdof.c	/^  TIVX_MOTION_DIRECTION_MOTION_NEUTRAL_5x5_ID = 0,$/;"	e	enum:__anon8	file:
+TIVX_MOTION_DIRECTION_MOTION_NEUTRAL_7x7_ID	ext/tiovx/gsttiovxdof.c	/^  TIVX_MOTION_DIRECTION_MOTION_NEUTRAL_7x7_ID = 3,$/;"	e	enum:__anon8	file:
+TIVX_MOTION_DIRECTION_REVERSE_MOTION_ID	ext/tiovx/gsttiovxdof.c	/^  TIVX_MOTION_DIRECTION_REVERSE_MOTION_ID = 2,$/;"	e	enum:__anon8	file:
+TIVX_TARGET_DMPAC_DOF_ID	ext/tiovx/gsttiovxdof.c	/^  TIVX_TARGET_DMPAC_DOF_ID = 0,$/;"	e	enum:__anon7	file:
+TIVX_TARGET_DMPAC_SDE_ID	ext/tiovx/gsttiovxsde.c	/^  TIVX_TARGET_DMPAC_SDE_ID = 0,$/;"	e	enum:__anon13	file:
+TIVX_TARGET_VPAC_LDC_ID	ext/tiovx/gsttiovxldc.c	/^  TIVX_TARGET_VPAC_LDC_ID = 0,$/;"	e	enum:__anon23	file:
+TIVX_TARGET_VPAC_MSC1_AND_2_ID	ext/tiovx/gsttiovxmosaic.c	/^  TIVX_TARGET_VPAC_MSC1_AND_2_ID,$/;"	e	enum:__anon25	file:
+TIVX_TARGET_VPAC_MSC1_AND_MSC2	ext/tiovx/gsttiovxmosaic.c	/^static const gchar TIVX_TARGET_VPAC_MSC1_AND_MSC2[] = "VPAC_MSC1_AND_MSC2";$/;"	v	file:
+TIVX_TARGET_VPAC_MSC1_ID	ext/tiovx/gsttiovxmosaic.c	/^  TIVX_TARGET_VPAC_MSC1_ID = 0,$/;"	e	enum:__anon25	file:
+TIVX_TARGET_VPAC_MSC1_ID	ext/tiovx/gsttiovxmultiscaler.c	/^  TIVX_TARGET_VPAC_MSC1_ID = 0,$/;"	e	enum:__anon18	file:
+TIVX_TARGET_VPAC_MSC1_ID	ext/tiovx/gsttiovxpyramid.c	/^  TIVX_TARGET_VPAC_MSC1_ID = 0,$/;"	e	enum:__anon4	file:
+TIVX_TARGET_VPAC_MSC2_ID	ext/tiovx/gsttiovxmosaic.c	/^  TIVX_TARGET_VPAC_MSC2_ID,$/;"	e	enum:__anon25	file:
+TIVX_TARGET_VPAC_MSC2_ID	ext/tiovx/gsttiovxmultiscaler.c	/^  TIVX_TARGET_VPAC_MSC2_ID,$/;"	e	enum:__anon18	file:
+TIVX_TARGET_VPAC_MSC2_ID	ext/tiovx/gsttiovxpyramid.c	/^  TIVX_TARGET_VPAC_MSC2_ID,$/;"	e	enum:__anon4	file:
+TIVX_TARGET_VPAC_VISS1_ID	ext/tiovx/gsttiovxisp.c	/^  TIVX_TARGET_VPAC_VISS1_ID = 0,$/;"	e	enum:__anon34	file:
+TI_2A_WRAPPER_SENSOR_IMG_PHASE_BGGR	ext/tiovx/gsttiovxisp.c	/^  TI_2A_WRAPPER_SENSOR_IMG_PHASE_BGGR = 0,$/;"	e	enum:__anon32	file:
+TI_2A_WRAPPER_SENSOR_IMG_PHASE_GBRG	ext/tiovx/gsttiovxisp.c	/^  TI_2A_WRAPPER_SENSOR_IMG_PHASE_GBRG = 1,$/;"	e	enum:__anon32	file:
+TI_2A_WRAPPER_SENSOR_IMG_PHASE_GRBG	ext/tiovx/gsttiovxisp.c	/^  TI_2A_WRAPPER_SENSOR_IMG_PHASE_GRBG = 2,$/;"	e	enum:__anon32	file:
+TI_2A_WRAPPER_SENSOR_IMG_PHASE_RGGB	ext/tiovx/gsttiovxisp.c	/^  TI_2A_WRAPPER_SENSOR_IMG_PHASE_RGGB = 3,$/;"	e	enum:__anon32	file:
+TI_DL_INFERER_STATIC_CAPS	ext/tiovx/gsttidlinferer.cpp	113;"	d	file:
+TI_DL_INFERER_SUPPORTED_CHANNEL_ORDER	ext/tiovx/gsttidlinferer.cpp	109;"	d	file:
+TI_DL_INFERER_SUPPORTED_DATA_TYPES	ext/tiovx/gsttidlinferer.cpp	108;"	d	file:
+TI_DL_INFERER_SUPPORTED_DIMENSIONS	ext/tiovx/gsttidlinferer.cpp	107;"	d	file:
+TI_DL_INFERER_SUPPORTED_HEIGHT	ext/tiovx/gsttidlinferer.cpp	106;"	d	file:
+TI_DL_INFERER_SUPPORTED_TENSOR_FORMAT	ext/tiovx/gsttidlinferer.cpp	110;"	d	file:
+TI_DL_INFERER_SUPPORTED_WIDTH	ext/tiovx/gsttidlinferer.cpp	105;"	d	file:
+TI_DL_POST_PROC_STATIC_CAPS_IMAGE	ext/tiovx/gsttidlpostproc.cpp	125;"	d	file:
+TI_DL_POST_PROC_STATIC_CAPS_TENSOR_SINK	ext/tiovx/gsttidlpostproc.cpp	132;"	d	file:
+TI_DL_POST_PROC_SUPPORTED_DATA_TYPES	ext/tiovx/gsttidlpostproc.cpp	122;"	d	file:
+TI_DL_POST_PROC_SUPPORTED_FORMATS_SINK	ext/tiovx/gsttidlpostproc.cpp	119;"	d	file:
+TI_DL_POST_PROC_SUPPORTED_FORMATS_SRC	ext/tiovx/gsttidlpostproc.cpp	118;"	d	file:
+TI_DL_POST_PROC_SUPPORTED_HEIGHT	ext/tiovx/gsttidlpostproc.cpp	121;"	d	file:
+TI_DL_POST_PROC_SUPPORTED_WIDTH	ext/tiovx/gsttidlpostproc.cpp	120;"	d	file:
+TOP_N_DEFAULT	ext/tiovx/gsttidlpostproc.cpp	91;"	d	file:
+TOP_N_MAX	ext/tiovx/gsttidlpostproc.cpp	90;"	d	file:
+TOP_N_MIN	ext/tiovx/gsttidlpostproc.cpp	89;"	d	file:
+TOTAL_OVERLAY_HEIGHT_PCT	ext/tiovx/gsttiperfoverlay.cpp	109;"	d	file:
+VIZ_THRESHOLD_DEFAULT	ext/tiovx/gsttidlpostproc.cpp	99;"	d	file:
+VIZ_THRESHOLD_MAX	ext/tiovx/gsttidlpostproc.cpp	98;"	d	file:
+VIZ_THRESHOLD_MIN	ext/tiovx/gsttidlpostproc.cpp	97;"	d	file:
+_BufferCounter	tests/check/test_utils.h	/^struct _BufferCounter$/;"	s
+_GST_TIOVX_DELAY_H_	ext/tiovx/gsttiovxdelay.h	63;"	d
+_GST_TIOVX_MEMALLOC_H_	ext/tiovx/gsttiovxmemalloc.h	63;"	d
+_GST_TIOVX_MISO_H_	gst-libs/gst/tiovx/gsttiovxmiso.h	63;"	d
+_GST_TIOVX_QUEUEABLE_OBJECT_H_	gst-libs/gst/tiovx/gsttiovxqueueableobject.h	63;"	d
+_GST_TIOVX_SIMO_H_	gst-libs/gst/tiovx/gsttiovxsimo.h	63;"	d
+_GST_TIOVX_SISO_H_	gst-libs/gst/tiovx/gsttiovxsiso.h	63;"	d
+_GstTIDLInferer	ext/tiovx/gsttidlinferer.cpp	/^struct _GstTIDLInferer$/;"	s	file:
+_GstTIDLPostProc	ext/tiovx/gsttidlpostproc.cpp	/^struct _GstTIDLPostProc$/;"	s	file:
+_GstTIOVXAllocator	gst-libs/gst/tiovx/gsttiovxallocator.c	/^struct _GstTIOVXAllocator$/;"	s	file:
+_GstTIOVXBufferPoolClass	gst-libs/gst/tiovx/gsttiovxbufferpool.h	/^struct _GstTIOVXBufferPoolClass$/;"	s
+_GstTIOVXBufferPoolPrivate	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^typedef struct _GstTIOVXBufferPoolPrivate$/;"	s	file:
+_GstTIOVXColorconvert	ext/tiovx/gsttiovxcolorconvert.c	/^struct _GstTIOVXColorconvert$/;"	s	file:
+_GstTIOVXContext	gst-libs/gst/tiovx/gsttiovxcontext.c	/^struct _GstTIOVXContext$/;"	s	file:
+_GstTIOVXDLColorBlend	ext/tiovx/gsttiovxdlcolorblend.c	/^struct _GstTIOVXDLColorBlend$/;"	s	file:
+_GstTIOVXDLColorconvert	ext/tiovx/gsttiovxdlcolorconvert.c	/^struct _GstTIOVXDLColorconvert$/;"	s	file:
+_GstTIOVXDLPreProc	ext/tiovx/gsttiovxdlpreproc.c	/^struct _GstTIOVXDLPreProc$/;"	s	file:
+_GstTIOVXDOF	ext/tiovx/gsttiovxdof.c	/^struct _GstTIOVXDOF$/;"	s	file:
+_GstTIOVXDelay	ext/tiovx/gsttiovxdelay.c	/^typedef struct _GstTIOVXDelay$/;"	s	file:
+_GstTIOVXDemux	ext/tiovx/gsttiovxdemux.c	/^typedef struct _GstTIOVXDemux$/;"	s	file:
+_GstTIOVXDofViz	ext/tiovx/gsttiovxdofviz.c	/^struct _GstTIOVXDofViz$/;"	s	file:
+_GstTIOVXISP	ext/tiovx/gsttiovxisp.c	/^struct _GstTIOVXISP$/;"	s	file:
+_GstTIOVXImageBufferPool	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	/^struct _GstTIOVXImageBufferPool$/;"	s	file:
+_GstTIOVXImageInfo	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^struct _GstTIOVXImageInfo {$/;"	s
+_GstTIOVXImageMeta	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^struct _GstTIOVXImageMeta {$/;"	s
+_GstTIOVXIspPad	ext/tiovx/gsttiovxisp.c	/^struct _GstTIOVXIspPad$/;"	s	file:
+_GstTIOVXIspPadClass	ext/tiovx/gsttiovxisp.c	/^struct _GstTIOVXIspPadClass$/;"	s	file:
+_GstTIOVXLDC	ext/tiovx/gsttiovxldc.c	/^struct _GstTIOVXLDC$/;"	s	file:
+_GstTIOVXMemAlloc	ext/tiovx/gsttiovxmemalloc.c	/^typedef struct _GstTIOVXMemAlloc$/;"	s	file:
+_GstTIOVXMemoryData	gst-libs/gst/tiovx/gsttiovxallocator.h	/^struct _GstTIOVXMemoryData {$/;"	s
+_GstTIOVXMisoClass	gst-libs/gst/tiovx/gsttiovxmiso.h	/^struct _GstTIOVXMisoClass$/;"	s
+_GstTIOVXMisoPadClass	gst-libs/gst/tiovx/gsttiovxmiso.h	/^struct _GstTIOVXMisoPadClass$/;"	s
+_GstTIOVXMisoPadPrivate	gst-libs/gst/tiovx/gsttiovxmiso.c	/^typedef struct _GstTIOVXMisoPadPrivate$/;"	s	file:
+_GstTIOVXMisoPrivate	gst-libs/gst/tiovx/gsttiovxmiso.c	/^typedef struct _GstTIOVXMisoPrivate$/;"	s	file:
+_GstTIOVXMosaic	ext/tiovx/gsttiovxmosaic.c	/^struct _GstTIOVXMosaic$/;"	s	file:
+_GstTIOVXMosaicPad	ext/tiovx/gsttiovxmosaic.c	/^struct _GstTIOVXMosaicPad$/;"	s	file:
+_GstTIOVXMosaicPadClass	ext/tiovx/gsttiovxmosaic.c	/^struct _GstTIOVXMosaicPadClass$/;"	s	file:
+_GstTIOVXMultiScaler	ext/tiovx/gsttiovxmultiscaler.c	/^struct _GstTIOVXMultiScaler$/;"	s	file:
+_GstTIOVXMultiScalerPad	ext/tiovx/gsttiovxmultiscalerpad.h	/^struct _GstTIOVXMultiScalerPad$/;"	s
+_GstTIOVXMultiScalerPadClass	ext/tiovx/gsttiovxmultiscalerpad.h	/^struct _GstTIOVXMultiScalerPadClass$/;"	s
+_GstTIOVXMux	ext/tiovx/gsttiovxmux.c	/^typedef struct _GstTIOVXMux$/;"	s	file:
+_GstTIOVXMuxMeta	gst-libs/gst/tiovx/gsttiovxmuxmeta.h	/^struct _GstTIOVXMuxMeta {$/;"	s
+_GstTIOVXMuxPad	ext/tiovx/gsttiovxmux.c	/^typedef struct _GstTIOVXMuxPad$/;"	s	file:
+_GstTIOVXPadClass	gst-libs/gst/tiovx/gsttiovxpad.h	/^struct _GstTIOVXPadClass$/;"	s
+_GstTIOVXPadPrivate	gst-libs/gst/tiovx/gsttiovxpad.c	/^typedef struct _GstTIOVXPadPrivate$/;"	s	file:
+_GstTIOVXPyramid	ext/tiovx/gsttiovxpyramid.c	/^struct _GstTIOVXPyramid$/;"	s	file:
+_GstTIOVXPyramidBufferPool	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	/^struct _GstTIOVXPyramidBufferPool$/;"	s	file:
+_GstTIOVXPyramidInfo	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^struct _GstTIOVXPyramidInfo$/;"	s
+_GstTIOVXPyramidMeta	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^struct _GstTIOVXPyramidMeta$/;"	s
+_GstTIOVXQueueable	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^struct _GstTIOVXQueueable$/;"	s	file:
+_GstTIOVXRawImageBufferPool	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^struct _GstTIOVXRawImageBufferPool$/;"	s	file:
+_GstTIOVXRawImageInfo	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^struct _GstTIOVXRawImageInfo {$/;"	s
+_GstTIOVXRawImageMeta	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^struct _GstTIOVXRawImageMeta {$/;"	s
+_GstTIOVXSde	ext/tiovx/gsttiovxsde.c	/^struct _GstTIOVXSde$/;"	s	file:
+_GstTIOVXSdeViz	ext/tiovx/gsttiovxsdeviz.c	/^struct _GstTIOVXSdeViz$/;"	s	file:
+_GstTIOVXSensorMeta	gst-libs/gst/tiovx/gsttiovxsensormeta.h	/^struct _GstTIOVXSensorMeta$/;"	s
+_GstTIOVXSimoClass	gst-libs/gst/tiovx/gsttiovxsimo.h	/^struct _GstTIOVXSimoClass$/;"	s
+_GstTIOVXSimoPrivate	gst-libs/gst/tiovx/gsttiovxsimo.c	/^typedef struct _GstTIOVXSimoPrivate$/;"	s	file:
+_GstTIOVXSisoClass	gst-libs/gst/tiovx/gsttiovxsiso.h	/^struct _GstTIOVXSisoClass$/;"	s
+_GstTIOVXSisoPrivate	gst-libs/gst/tiovx/gsttiovxsiso.c	/^typedef struct _GstTIOVXSisoPrivate$/;"	s	file:
+_GstTIOVXTensorBufferPool	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	/^struct _GstTIOVXTensorBufferPool$/;"	s	file:
+_GstTIOVXTensorInfo	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^struct _GstTIOVXTensorInfo {$/;"	s
+_GstTIOVXTensorMeta	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^struct _GstTIOVXTensorMeta {$/;"	s
+_GstTIPerfOverlay	ext/tiovx/gsttiperfoverlay.cpp	/^struct _GstTIPerfOverlay$/;"	s	file:
+_GstTestTIOVXMiso	tests/check/libs/gsttiovxmiso.c	/^struct _GstTestTIOVXMiso$/;"	s	file:
+_GstTestTIOVXMisoClass	tests/check/libs/gsttiovxmiso.c	/^struct _GstTestTIOVXMisoClass$/;"	s	file:
+_GstTestTIOVXSimo	tests/check/libs/gsttiovxsimo.c	/^struct _GstTestTIOVXSimo$/;"	s	file:
+_GstTestTIOVXSimoClass	tests/check/libs/gsttiovxsimo.c	/^struct _GstTestTIOVXSimoClass$/;"	s	file:
+_GstTestTIOVXSiso	tests/check/libs/gsttiovxsiso.c	/^struct _GstTestTIOVXSiso$/;"	s	file:
+_GstTestTIOVXSisoClass	tests/check/libs/gsttiovxsiso.c	/^struct _GstTestTIOVXSisoClass$/;"	s	file:
+_GstTiDlOutMeta	gst-libs/gst/tiovx/gsttidloutmeta.h	/^struct _GstTiDlOutMeta$/;"	s
+__GST_TIDL_OUT_META__	gst-libs/gst/tiovx/gsttidloutmeta.h	63;"	d
+__GST_TIOVX_ALLOCATOR__	gst-libs/gst/tiovx/gsttiovxallocator.h	63;"	d
+__GST_TIOVX_BUFFER_POOL_H__	gst-libs/gst/tiovx/gsttiovxbufferpool.h	66;"	d
+__GST_TIOVX_BUFFER_POOL_UTILS_H__	gst-libs/gst/tiovx/gsttiovxbufferpoolutils.h	65;"	d
+__GST_TIOVX_BUFFER_UTILS_H__	gst-libs/gst/tiovx/gsttiovxbufferutils.h	65;"	d
+__GST_TIOVX_COLOR_CONVERT_H__	ext/tiovx/gsttiovxcolorconvert.h	65;"	d
+__GST_TIOVX_CONTEXT__	gst-libs/gst/tiovx/gsttiovxcontext.h	63;"	d
+__GST_TIOVX_DEMUX_H__	ext/tiovx/gsttiovxdemux.h	65;"	d
+__GST_TIOVX_DL_COLOR_BLEND_H__	ext/tiovx/gsttiovxdlcolorblend.h	65;"	d
+__GST_TIOVX_DL_COLOR_CONVERT_H__	ext/tiovx/gsttiovxdlcolorconvert.h	65;"	d
+__GST_TIOVX_DL_PRE_PROC_H__	ext/tiovx/gsttiovxdlpreproc.h	65;"	d
+__GST_TIOVX_DOF_H__	ext/tiovx/gsttiovxdof.h	65;"	d
+__GST_TIOVX_DOF_VIZ_H__	ext/tiovx/gsttiovxdofviz.h	65;"	d
+__GST_TIOVX_H__	gst-libs/gst/tiovx/gsttiovx.h	63;"	d
+__GST_TIOVX_IMAGE_BUFFER_POOL_H__	gst-libs/gst/tiovx/gsttiovximagebufferpool.h	66;"	d
+__GST_TIOVX_IMAGE_META__	gst-libs/gst/tiovx/gsttiovximagemeta.h	63;"	d
+__GST_TIOVX_ISP_H__	ext/tiovx/gsttiovxisp.h	65;"	d
+__GST_TIOVX_LDC_H__	ext/tiovx/gsttiovxldc.h	65;"	d
+__GST_TIOVX_MOSAIC_H__	ext/tiovx/gsttiovxmosaic.h	65;"	d
+__GST_TIOVX_MULTISCALER_PAD_H__	ext/tiovx/gsttiovxmultiscalerpad.h	65;"	d
+__GST_TIOVX_MULTI_SCALER_H__	ext/tiovx/gsttiovxmultiscaler.h	65;"	d
+__GST_TIOVX_MUX_H__	ext/tiovx/gsttiovxmux.h	65;"	d
+__GST_TIOVX_MUX_META__	gst-libs/gst/tiovx/gsttiovxmuxmeta.h	63;"	d
+__GST_TIOVX_PAD_H__	gst-libs/gst/tiovx/gsttiovxpad.h	66;"	d
+__GST_TIOVX_PYRAMID_H__	ext/tiovx/gsttiovxpyramid.h	65;"	d
+__GST_TIOVX_PYRAMID_META__	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	63;"	d
+__GST_TIOVX_PYRAMiD_BUFFER_POOL_H__	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.h	65;"	d
+__GST_TIOVX_RAW_IMAGE_BUFFER_POOL_H__	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.h	66;"	d
+__GST_TIOVX_RAW_IMAGE_META__	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	63;"	d
+__GST_TIOVX_SDE_H__	ext/tiovx/gsttiovxsde.h	65;"	d
+__GST_TIOVX_SDE_VIZ_H__	ext/tiovx/gsttiovxsdeviz.h	65;"	d
+__GST_TIOVX_SENSOR_META__	gst-libs/gst/tiovx/gsttiovxsensormeta.h	63;"	d
+__GST_TIOVX_TENSOR_BUFFER_POOL_H__	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.h	65;"	d
+__GST_TIOVX_TENSOR_META__	gst-libs/gst/tiovx/gsttiovxtensormeta.h	63;"	d
+__GST_TIOVX_UTILS_H__	gst-libs/gst/tiovx/gsttiovxutils.h	65;"	d
+__GST_TI_DL_INFERER_H__	ext/tiovx/gsttidlinferer.h	65;"	d
+__GST_TI_DL_POST_PROC_H__	ext/tiovx/gsttidlpostproc.h	65;"	d
+__GST_TI_PERF_OVERLAY_H__	ext/tiovx/gsttiperfoverlay.h	65;"	d
+__STDC_FORMAT_MACROS	ext/tiovx/gsttiperfoverlay.cpp	62;"	d	file:
+__TEST_UTILS_H__	tests/check/test_utils.h	63;"	d
+_tiovx_mem_ptr_quark	gst-libs/gst/tiovx/gsttiovxallocator.c	/^static GQuark _tiovx_mem_ptr_quark;$/;"	v	file:
+_tiovx_mem_ptr_quark_str	gst-libs/gst/tiovx/gsttiovxallocator.c	/^const char *_tiovx_mem_ptr_quark_str = "mem_ptr";$/;"	v
+add_graph_parameter_by_node_index	gst-libs/gst/tiovx/gsttiovxutils.c	/^add_graph_parameter_by_node_index (GstDebugCategory * debug_category,$/;"	f
+add_meta_to_buffer	gst-libs/gst/tiovx/gsttiovxbufferpool.h	/^  void (*add_meta_to_buffer) (GstTIOVXBufferPool * self, GstBuffer* buffer,$/;"	m	struct:_GstTIOVXBufferPoolClass
+add_outbuf_meta	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*add_outbuf_meta)          (GstTIOVXMiso * self, GstBuffer * outbuf);$/;"	m	struct:_GstTIOVXMisoClass
+ae_awb_result_param_id	ext/tiovx/gsttiovxisp.c	/^static const int ae_awb_result_param_id = 1;$/;"	v	file:
+ae_mode	ext/tiovx/gsttiovxisp.c	/^  gboolean ae_mode;$/;"	m	struct:_GstTIOVXIspPad	file:
+ae_num_skip_frames	ext/tiovx/gsttiovxisp.c	/^  guint ae_num_skip_frames;$/;"	m	struct:_GstTIOVXIspPad	file:
+ae_num_skip_frames_range	tests/check/gsttiovxisp.c	/^  const Range *ae_num_skip_frames_range;$/;"	m	struct:__anon49	file:
+aewb_config	ext/tiovx/gsttiovxisp.c	/^  tivx_aewb_config_t aewb_config;$/;"	m	struct:_GstTIOVXIspPad	file:
+aewb_memory	ext/tiovx/gsttiovxisp.c	/^  GstMemory *aewb_memory;$/;"	m	struct:_GstTIOVXISP	file:
+aggregation_penalty_p1	ext/tiovx/gsttiovxsde.c	/^  gint aggregation_penalty_p1;$/;"	m	struct:_GstTIOVXSde	file:
+aggregation_penalty_p1_default	ext/tiovx/gsttiovxsde.c	/^static const int aggregation_penalty_p1_default = 32;$/;"	v	file:
+aggregation_penalty_p1_max	ext/tiovx/gsttiovxsde.c	/^static const int aggregation_penalty_p1_max = 127;$/;"	v	file:
+aggregation_penalty_p1_min	ext/tiovx/gsttiovxsde.c	/^static const int aggregation_penalty_p1_min = 0;$/;"	v	file:
+aggregation_penalty_p2	ext/tiovx/gsttiovxsde.c	/^  gint aggregation_penalty_p2;$/;"	m	struct:_GstTIOVXSde	file:
+aggregation_penalty_p2_default	ext/tiovx/gsttiovxsde.c	/^static const int aggregation_penalty_p2_default = 192;$/;"	v	file:
+aggregation_penalty_p2_max	ext/tiovx/gsttiovxsde.c	/^static const int aggregation_penalty_p2_max = 255;$/;"	v	file:
+aggregation_penalty_p2_min	ext/tiovx/gsttiovxsde.c	/^static const int aggregation_penalty_p2_min = 0;$/;"	v	file:
+aggregator	ext/tiovx/gsttiovxmux.c	/^  GstAggregator aggregator;$/;"	m	struct:_GstTIOVXMux	file:
+allocator	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^  GstTIOVXAllocator *allocator;$/;"	m	struct:_GstTIOVXBufferPoolPrivate	file:
+allocators	tests/check/libs/gsttiovxallocator.c	/^GST_CHECK_MAIN (allocators);$/;"	v
+allocators_suite	tests/check/libs/gsttiovxallocator.c	/^allocators_suite (void)$/;"	f	file:
+alpha	ext/tiovx/gsttidlpostproc.cpp	/^      alpha;$/;"	m	struct:_GstTIDLPostProc	file:
+analog_gain_ctrl_id	ext/tiovx/gsttiovxisp.c	/^static const guint analog_gain_ctrl_id = V4L2_CID_ANALOGUE_GAIN;$/;"	v	file:
+analog_gain_range	tests/check/gsttiovxisp.c	/^  const Range *analog_gain_range;$/;"	m	struct:__anon49	file:
+append_format_to_list	ext/tiovx/gsttiovxcolorconvert.c	/^append_format_to_list (GValue * list, const gchar * format)$/;"	f	file:
+append_format_to_list	ext/tiovx/gsttiovxdlcolorconvert.c	/^append_format_to_list (GValue * list, const gchar * format)$/;"	f	file:
+append_sink_formats	ext/tiovx/gsttiovxcolorconvert.c	/^append_sink_formats (GstVideoFormat src_format, GValue * sink_formats)$/;"	f	file:
+append_sink_formats	ext/tiovx/gsttiovxdlcolorconvert.c	/^append_sink_formats (GstVideoFormat src_format, GValue * sink_formats)$/;"	f	file:
+append_src_formats	ext/tiovx/gsttiovxcolorconvert.c	/^append_src_formats (GstVideoFormat sink_format, GValue * src_formats)$/;"	f	file:
+append_src_formats	ext/tiovx/gsttiovxdlcolorconvert.c	/^append_src_formats (GstVideoFormat sink_format, GValue * src_formats)$/;"	f	file:
+array	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  vx_object_array array;$/;"	m	struct:_GstTIOVXImageMeta
+array	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  vx_object_array array;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+array	gst-libs/gst/tiovx/gsttiovxmuxmeta.h	/^  vx_object_array array;$/;"	m	struct:_GstTIOVXMuxMeta
+array	gst-libs/gst/tiovx/gsttiovxpad.c	/^  vx_object_array array;$/;"	m	struct:_GstTIOVXPadPrivate	file:
+array	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  vx_object_array array;$/;"	m	struct:_GstTIOVXPyramidMeta
+array	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^  vx_object_array array;$/;"	m	struct:_GstTIOVXQueueable	file:
+array	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  vx_object_array array;$/;"	m	struct:_GstTIOVXRawImageMeta
+array	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  vx_object_array array;$/;"	m	struct:_GstTIOVXTensorMeta
+awb_mode	ext/tiovx/gsttiovxisp.c	/^  gboolean awb_mode;$/;"	m	struct:_GstTIOVXIspPad	file:
+awb_num_skip_frames	ext/tiovx/gsttiovxisp.c	/^  guint awb_num_skip_frames;$/;"	m	struct:_GstTIOVXIspPad	file:
+awb_num_skip_frames_range	tests/check/gsttiovxisp.c	/^  const Range *awb_num_skip_frames_range;$/;"	m	struct:__anon49	file:
+background	ext/tiovx/gsttiovxmosaic.c	/^  gchar *background;$/;"	m	struct:_GstTIOVXMosaic	file:
+background_image_memory	ext/tiovx/gsttiovxmosaic.c	/^  GstMemory *background_image_memory;$/;"	m	struct:_GstTIOVXMosaic	file:
+background_pad	tests/check/gsttiovxmosaic.c	/^  PadTemplate background_pad;$/;"	m	struct:__anon42	file:
+background_template	ext/tiovx/gsttiovxmosaic.c	/^static GstStaticPadTemplate background_template =$/;"	v	file:
+bar_graphs	ext/tiovx/gsttiperfoverlay.cpp	/^      bar_graphs[MAX_GRAPH];$/;"	m	struct:_GstTIPerfOverlay	file:
+base	ext/tiovx/gsttiovxisp.c	/^  GstTIOVXMisoPad base;$/;"	m	struct:_GstTIOVXIspPad	file:
+base	ext/tiovx/gsttiovxmosaic.c	/^  GstTIOVXMisoPad base;$/;"	m	struct:_GstTIOVXMosaicPad	file:
+base	ext/tiovx/gsttiovxmultiscalerpad.h	/^  GstTIOVXPad base;$/;"	m	struct:_GstTIOVXMultiScalerPad
+base	gst-libs/gst/tiovx/gsttiovxallocator.c	/^  GstDmaBufAllocator base;$/;"	m	struct:_GstTIOVXAllocator	file:
+base	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^  GstBufferPool base;$/;"	m	struct:_GstTIOVXBufferPoolPrivate	file:
+base	gst-libs/gst/tiovx/gsttiovxcontext.c	/^  GObject base;$/;"	m	struct:_GstTIOVXContext	file:
+base	gst-libs/gst/tiovx/gsttiovxpad.c	/^  GstPad base;$/;"	m	struct:_GstTIOVXPadPrivate	file:
+big_font_property	ext/tiovx/gsttiperfoverlay.cpp	/^      big_font_property;$/;"	m	struct:_GstTIPerfOverlay	file:
+buffer_counter	tests/check/test_utils.h	/^  guint buffer_counter;$/;"	m	struct:_BufferCounter
+buffer_counter_func	tests/check/test_utils.h	/^buffer_counter_func (GstElement * element, GstBuffer * buffer, GstPad * pad,$/;"	f
+buffer_limit	tests/check/test_utils.h	/^  guint buffer_limit;$/;"	m	struct:_BufferCounter
+buffer_pool	ext/tiovx/gsttiovxmux.c	/^  GstBufferPool *buffer_pool;$/;"	m	struct:_GstTIOVXMuxPad	file:
+buffer_pool	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  GstBufferPool *buffer_pool;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+buffer_pool	gst-libs/gst/tiovx/gsttiovxpad.c	/^  GstBufferPool *buffer_pool;$/;"	m	struct:_GstTIOVXPadPrivate	file:
+c_array_to_gst_array	ext/tiovx/gsttiovxmosaic.c	/^c_array_to_gst_array (GValue * gst_array, const gint * c_array, guint length)$/;"	f	file:
+caps	ext/tiovx/gsttiovxmemalloc.c	/^  GstCaps *caps;$/;"	m	struct:_GstTIOVXMemAlloc	file:
+caps_negotiated	ext/tiovx/gsttiperfoverlay.cpp	/^      caps_negotiated;$/;"	m	struct:_GstTIPerfOverlay	file:
+channel_order	ext/tiovx/gsttiovxdlpreproc.c	/^  gint channel_order;$/;"	m	struct:_GstTIOVXDLPreProc	file:
+channel_order	tests/check/gsttiovxdlpreproc.c	/^  const gchar **channel_order;$/;"	m	struct:__anon44	file:
+color_black	ext/tiovx/gsttiperfoverlay.cpp	/^      color_black;$/;"	m	struct:_GstTIPerfOverlay	file:
+color_green	ext/tiovx/gsttiperfoverlay.cpp	/^      color_green;$/;"	m	struct:_GstTIPerfOverlay	file:
+color_orange	ext/tiovx/gsttiperfoverlay.cpp	/^      color_orange;$/;"	m	struct:_GstTIPerfOverlay	file:
+color_purple	ext/tiovx/gsttiperfoverlay.cpp	/^      color_purple;$/;"	m	struct:_GstTIPerfOverlay	file:
+color_red	ext/tiovx/gsttiperfoverlay.cpp	/^      color_red;$/;"	m	struct:_GstTIPerfOverlay	file:
+color_temperature_range	tests/check/gsttiovxisp.c	/^  const Range *color_temperature_range;$/;"	m	struct:__anon49	file:
+color_white	ext/tiovx/gsttiperfoverlay.cpp	/^      color_white;$/;"	m	struct:_GstTIPerfOverlay	file:
+color_yellow	ext/tiovx/gsttiperfoverlay.cpp	/^      color_yellow;$/;"	m	struct:_GstTIPerfOverlay	file:
+compare_caps	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  gboolean      (*compare_caps)             (GstTIOVXSimo *self, GstCaps *caps1, GstCaps *caps2, GstPadDirection direction);$/;"	m	struct:_GstTIOVXSimoClass
+compare_caps	gst-libs/gst/tiovx/gsttiovxsiso.h	/^  gboolean      (*compare_caps)             (GstTIOVXSiso *trans, GstCaps *caps1, GstCaps *caps2, GstPadDirection direction);$/;"	m	struct:_GstTIOVXSisoClass
+cond	tests/check/test_utils.h	/^  GCond cond;$/;"	m	struct:_BufferCounter
+confidence_score_map	ext/tiovx/gsttiovxsde.c	/^  gint confidence_score_map[8];$/;"	m	struct:_GstTIOVXSde	file:
+confidence_score_map_0_default	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_0_default = 0;$/;"	v	file:
+confidence_score_map_1_default	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_1_default = 1;$/;"	v	file:
+confidence_score_map_2_default	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_2_default = 2;$/;"	v	file:
+confidence_score_map_3_default	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_3_default = 3;$/;"	v	file:
+confidence_score_map_4_default	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_4_default = 5;$/;"	v	file:
+confidence_score_map_5_default	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_5_default = 9;$/;"	v	file:
+confidence_score_map_6_default	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_6_default = 14;$/;"	v	file:
+confidence_score_map_7_default	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_7_default = 127;$/;"	v	file:
+confidence_score_map_max	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_max = 127;$/;"	v	file:
+confidence_score_map_min	ext/tiovx/gsttiovxsde.c	/^static const int confidence_score_map_min = 0;$/;"	v	file:
+confidence_threshold	ext/tiovx/gsttiovxdofviz.c	/^  guint confidence_threshold;$/;"	m	struct:_GstTIOVXDofViz	file:
+configure_module	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*configure_module)         (GstTIOVXMiso *agg);$/;"	m	struct:_GstTIOVXMisoClass
+configure_module	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  gboolean      (*configure_module)         (GstTIOVXSimo *self);$/;"	m	struct:_GstTIOVXSimoClass
+context	ext/tiovx/gsttidlinferer.cpp	/^      context;$/;"	m	struct:_GstTIDLInferer	file:
+context	ext/tiovx/gsttidlpostproc.cpp	/^      context;$/;"	m	struct:_GstTIDLPostProc	file:
+context	ext/tiovx/gsttiovxdemux.c	/^  vx_context context;$/;"	m	struct:_GstTIOVXDemux	file:
+context	ext/tiovx/gsttiovxmemalloc.c	/^  vx_context context;$/;"	m	struct:_GstTIOVXMemAlloc	file:
+context	ext/tiovx/gsttiovxmux.c	/^  vx_context context;$/;"	m	struct:_GstTIOVXMux	file:
+context	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  vx_context context;$/;"	m	struct:_GstTIOVXMisoPrivate	file:
+context	gst-libs/gst/tiovx/gsttiovxsimo.c	/^  vx_context context;$/;"	m	struct:_GstTIOVXSimoPrivate	file:
+context	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  vx_context context;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+copy_all_size	gst-libs/gst/tiovx/gsttiovxbufferutils.c	/^static const gsize copy_all_size = -1;$/;"	v	file:
+cpu_loads	ext/tiovx/gsttiperfoverlay.cpp	/^      cpu_loads[APP_IPC_CPU_MAX];$/;"	m	struct:_GstTIPerfOverlay	file:
+create_graph	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*create_graph)             (GstTIOVXMiso *agg, vx_context context, vx_graph graph);$/;"	m	struct:_GstTIOVXMisoClass
+create_graph	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  gboolean      (*create_graph)             (GstTIOVXSimo *self, vx_context context, vx_graph graph);$/;"	m	struct:_GstTIOVXSimoClass
+create_graph	gst-libs/gst/tiovx/gsttiovxsiso.h	/^  gboolean      (*create_graph)             (GstTIOVXSiso *trans, vx_context context, vx_graph graph);$/;"	m	struct:_GstTIOVXSisoClass
+create_raw_image	tests/check/libs/gsttiovxrawimagebufferpool.c	/^create_raw_image (vx_context context)$/;"	f	file:
+data_type	ext/tiovx/gsttiovxdlcolorblend.c	/^  vx_enum data_type;$/;"	m	struct:_GstTIOVXDLColorBlend	file:
+data_type	ext/tiovx/gsttiovxdlpreproc.c	/^  vx_enum data_type;$/;"	m	struct:_GstTIOVXDLPreProc	file:
+data_type	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  vx_enum data_type;$/;"	m	struct:_GstTIOVXTensorInfo
+data_type	tests/check/gsttiovxdlcolorblend.c	/^  const gchar **data_type;$/;"	m	struct:__anon54	file:
+data_type	tests/check/gsttiovxdlpreproc.c	/^  const gchar **data_type;$/;"	m	struct:__anon44	file:
+data_type_enum	tests/check/gsttiovxdlcolorblend.c	/^  const enum vx_type_e *data_type_enum;$/;"	m	struct:__anon54	typeref:enum:__anon54::vx_type_e	file:
+dcc	tests/check/gsttiovxisp.c	/^  const DCC **dcc;$/;"	m	struct:__anon49	file:
+dcc_2a	tests/check/gsttiovxisp.c	/^  const gchar *dcc_2a;$/;"	m	struct:__anon47	file:
+dcc_2a_buf	ext/tiovx/gsttiovxisp.c	/^  uint8_t *dcc_2a_buf;$/;"	m	struct:_GstTIOVXIspPad	file:
+dcc_2a_buf_size	ext/tiovx/gsttiovxisp.c	/^  uint32_t dcc_2a_buf_size;$/;"	m	struct:_GstTIOVXIspPad	file:
+dcc_2a_config_file	ext/tiovx/gsttiovxisp.c	/^  gchar *dcc_2a_config_file;$/;"	m	struct:_GstTIOVXIspPad	file:
+dcc_config_file	ext/tiovx/gsttiovxldc.c	/^  gchar *dcc_config_file;$/;"	m	struct:_GstTIOVXLDC	file:
+dcc_isp_config_file	ext/tiovx/gsttiovxisp.c	/^  gchar *dcc_isp_config_file;$/;"	m	struct:_GstTIOVXISP	file:
+ddr_load	ext/tiovx/gsttiperfoverlay.cpp	/^      ddr_load;$/;"	m	struct:_GstTIPerfOverlay	file:
+default_ae_mode	ext/tiovx/gsttiovxisp.c	/^static const int default_ae_mode = ALGORITHMS_ISS_AE_AUTO;$/;"	v	file:
+default_ae_num_skip_frames	ext/tiovx/gsttiovxisp.c	/^static const guint default_ae_num_skip_frames = 0;$/;"	v	file:
+default_awb_mode	ext/tiovx/gsttiovxisp.c	/^static const int default_awb_mode = ALGORITHMS_ISS_AWB_AUTO;$/;"	v	file:
+default_awb_num_skip_frames	ext/tiovx/gsttiovxisp.c	/^static const guint default_awb_num_skip_frames = 0;$/;"	v	file:
+default_dim_value	ext/tiovx/gsttiovxmosaic.c	/^static const gint default_dim_value = 0;$/;"	v	file:
+default_enable_channel	ext/tiovx/gsttiovxmosaic.c	/^static const gint default_enable_channel = -1;$/;"	v	file:
+default_format_msb	ext/tiovx/gsttiovxisp.c	/^static const gint default_format_msb = 7;$/;"	v	file:
+default_lines_interleaved	ext/tiovx/gsttiovxisp.c	/^static const gboolean default_lines_interleaved = FALSE;$/;"	v	file:
+default_meta_height_after	ext/tiovx/gsttiovxisp.c	/^static const gint default_meta_height_after = 0;$/;"	v	file:
+default_meta_height_before	ext/tiovx/gsttiovxisp.c	/^static const gint default_meta_height_before = 0;$/;"	v	file:
+default_num_exposures	ext/tiovx/gsttiovxisp.c	/^static const gint default_num_exposures = 1;$/;"	v	file:
+default_num_exposures	tests/check/gsttiovxisp.c	/^static const gint default_num_exposures = 1;$/;"	v	file:
+default_sensor_img_format	ext/tiovx/gsttiovxisp.c	/^static const guint default_sensor_img_format = 0;       \/* BAYER = 0x0, Rest unsupported *\/$/;"	v	file:
+default_start_value	ext/tiovx/gsttiovxmosaic.c	/^static const gint default_start_value = 0;$/;"	v	file:
+default_tiovx_mosaic_background	ext/tiovx/gsttiovxmosaic.c	/^static const gchar *default_tiovx_mosaic_background = "";$/;"	v	file:
+default_tiovx_sensor_name	ext/tiovx/gsttiovxisp.c	/^static const char default_tiovx_sensor_name[] = "SENSOR_SONY_IMX219_RPI";$/;"	v	file:
+deinit	tests/check/libs/gsttiovxpad.c	/^deinit (GstTIOVXPad * pad, vx_context context, vx_reference reference)$/;"	f	file:
+deinit_module	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*deinit_module)            (GstTIOVXMiso *agg);$/;"	m	struct:_GstTIOVXMisoClass
+deinit_module	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  gboolean      (*deinit_module)            (GstTIOVXSimo *self);$/;"	m	struct:_GstTIOVXSimoClass
+deinit_module	gst-libs/gst/tiovx/gsttiovxsiso.h	/^  gboolean      (*deinit_module)            (GstTIOVXSiso *trans, vx_context context);$/;"	m	struct:_GstTIOVXSisoClass
+delay_size	ext/tiovx/gsttiovxdelay.c	/^  guint delay_size;$/;"	m	struct:_GstTIOVXDelay	file:
+delayed_sink_template	ext/tiovx/gsttiovxdof.c	/^static GstStaticPadTemplate delayed_sink_template =$/;"	v	file:
+dim_offsets	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  vx_size dim_offsets[MODULE_MAX_NUM_DIMS];$/;"	m	struct:_GstTIOVXTensorInfo
+dim_sizes	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  vx_size dim_sizes[MODULE_MAX_NUM_DIMS];$/;"	m	struct:_GstTIOVXTensorInfo
+dim_strides	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  vx_size dim_strides[MODULE_MAX_NUM_DIMS];$/;"	m	struct:_GstTIOVXTensorInfo
+disparity_max	ext/tiovx/gsttiovxsde.c	/^  gint disparity_max;$/;"	m	struct:_GstTIOVXSde	file:
+disparity_max	ext/tiovx/gsttiovxsdeviz.c	/^  gint disparity_max;$/;"	m	struct:_GstTIOVXSdeViz	file:
+disparity_min	ext/tiovx/gsttiovxsde.c	/^  gint disparity_min;$/;"	m	struct:_GstTIOVXSde	file:
+disparity_min	ext/tiovx/gsttiovxsdeviz.c	/^  gint disparity_min;$/;"	m	struct:_GstTIOVXSdeViz	file:
+disparity_only	ext/tiovx/gsttiovxsdeviz.c	/^  gboolean disparity_only;$/;"	m	struct:_GstTIOVXSdeViz	file:
+dl_tensor	ext/tiovx/gsttidlpostproc.cpp	/^      dl_tensor;$/;"	m	struct:_GstTIDLPostProc	file:
+downwards_search_range	ext/tiovx/gsttiovxdof.c	/^  gint downwards_search_range;$/;"	m	struct:_GstTIOVXDOF	file:
+dump_perf_stats	ext/tiovx/gsttiperfoverlay.cpp	/^dump_perf_stats (GstTIPerfOverlay * self)$/;"	f	file:
+dump_stats	ext/tiovx/gsttiperfoverlay.cpp	/^      dump_stats;$/;"	m	struct:_GstTIPerfOverlay	file:
+element	ext/tiovx/gsttidlinferer.cpp	/^      element;$/;"	m	struct:_GstTIDLInferer	file:
+element	ext/tiovx/gsttidlpostproc.cpp	/^      element;$/;"	m	struct:_GstTIDLPostProc	file:
+element	ext/tiovx/gsttiovxcolorconvert.c	/^  GstTIOVXSiso element;$/;"	m	struct:_GstTIOVXColorconvert	file:
+element	ext/tiovx/gsttiovxdlcolorblend.c	/^  GstTIOVXMiso element;$/;"	m	struct:_GstTIOVXDLColorBlend	file:
+element	ext/tiovx/gsttiovxdlcolorconvert.c	/^  GstTIOVXSiso element;$/;"	m	struct:_GstTIOVXDLColorconvert	file:
+element	ext/tiovx/gsttiovxdlpreproc.c	/^  GstTIOVXSiso element;$/;"	m	struct:_GstTIOVXDLPreProc	file:
+element	ext/tiovx/gsttiovxdofviz.c	/^  GstTIOVXSiso element;$/;"	m	struct:_GstTIOVXDofViz	file:
+element	ext/tiovx/gsttiovxisp.c	/^  GstTIOVXMiso element;$/;"	m	struct:_GstTIOVXISP	file:
+element	ext/tiovx/gsttiovxldc.c	/^  GstTIOVXSimo element;$/;"	m	struct:_GstTIOVXLDC	file:
+element	ext/tiovx/gsttiovxmultiscaler.c	/^  GstTIOVXSimo element;$/;"	m	struct:_GstTIOVXMultiScaler	file:
+element	ext/tiovx/gsttiovxpyramid.c	/^  GstTIOVXSiso element;$/;"	m	struct:_GstTIOVXPyramid	file:
+element	ext/tiovx/gsttiovxsdeviz.c	/^  GstTIOVXSiso element;$/;"	m	struct:_GstTIOVXSdeViz	file:
+element	ext/tiovx/gsttiperfoverlay.cpp	/^      element;$/;"	m	struct:_GstTIPerfOverlay	file:
+enabled_channels	ext/tiovx/gsttiovxmosaic.c	/^  gint enabled_channels[MAX_NUM_CHANNELS];$/;"	m	struct:_GstTIOVXMosaicPad	file:
+enabled_channels_set	ext/tiovx/gsttiovxmosaic.c	/^  gboolean enabled_channels_set;$/;"	m	struct:_GstTIOVXMosaicPad	file:
+exemplar	ext/tiovx/gsttiovxmux.c	/^  vx_reference exemplar;$/;"	m	struct:_GstTIOVXMuxPad	file:
+exemplar	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^  vx_reference exemplar;$/;"	m	struct:_GstTIOVXBufferPoolPrivate	file:
+exemplar	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  vx_reference *exemplar;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+exemplar	gst-libs/gst/tiovx/gsttiovxpad.c	/^  vx_reference exemplar;$/;"	m	struct:_GstTIOVXPadPrivate	file:
+exemplar	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^  vx_reference exemplar;$/;"	m	struct:_GstTIOVXQueueable	file:
+exposure_ctrl_id	ext/tiovx/gsttiovxisp.c	/^static const guint exposure_ctrl_id = V4L2_CID_EXPOSURE;$/;"	v	file:
+exposure_heights	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  guint exposure_heights[MODULE_MAX_NUM_EXPOSURES];$/;"	m	struct:_GstTIOVXRawImageInfo
+exposure_offset	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  gsize exposure_offset[MODULE_MAX_NUM_EXPOSURES];$/;"	m	struct:_GstTIOVXRawImageInfo
+exposure_sizes	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  guint exposure_sizes[MODULE_MAX_NUM_EXPOSURES];$/;"	m	struct:_GstTIOVXRawImageInfo
+exposure_steps_x	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  guint exposure_steps_x[MODULE_MAX_NUM_EXPOSURES];$/;"	m	struct:_GstTIOVXRawImageInfo
+exposure_steps_y	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  guint exposure_steps_y[MODULE_MAX_NUM_EXPOSURES];$/;"	m	struct:_GstTIOVXRawImageInfo
+exposure_stride_x	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  gint exposure_stride_x[MODULE_MAX_NUM_EXPOSURES];$/;"	m	struct:_GstTIOVXRawImageInfo
+exposure_stride_y	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  gint exposure_stride_y[MODULE_MAX_NUM_EXPOSURES];$/;"	m	struct:_GstTIOVXRawImageInfo
+exposure_time_range	tests/check/gsttiovxisp.c	/^  const Range *exposure_time_range;$/;"	m	struct:__anon49	file:
+exposure_widths	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  guint exposure_widths[MODULE_MAX_NUM_EXPOSURES];$/;"	m	struct:_GstTIOVXRawImageInfo
+fail_unless_equals_int_with_message	tests/check/test_utils.h	110;"	d
+fixate_caps	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  GstCaps *     (*fixate_caps)              (GstTIOVXMiso *self, GList * sink_caps_list, GstCaps *src_caps, gint *num_channels);$/;"	m	struct:_GstTIOVXMisoClass
+fixate_caps	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  GList *       (*fixate_caps)              (GstTIOVXSimo *self, GstCaps *sink_caps, GList * src_caps_list);$/;"	m	struct:_GstTIOVXSimoClass
+format	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  GstVideoFormat format;$/;"	m	struct:_GstTIOVXImageInfo
+format	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  GstVideoFormat format;$/;"	m	struct:_GstTIOVXPyramidInfo
+format_msb	ext/tiovx/gsttiovxisp.c	/^  gint format_msb;$/;"	m	struct:_GstTIOVXISP	file:
+format_msb_range	tests/check/gsttiovxisp.c	/^  const Range *format_msb_range;$/;"	m	struct:__anon49	file:
+formats	tests/check/gsttiovxdlcolorblend.c	/^  const gchar **formats;$/;"	m	struct:__anon52	file:
+formats	tests/check/gsttiovxdlcolorblend.c	/^  const gchar **formats;$/;"	m	struct:__anon53	file:
+formats	tests/check/gsttiovxdlpreproc.c	/^  const gchar **formats;$/;"	m	struct:__anon43	file:
+formats	tests/check/gsttiovxisp.c	/^  const gchar **formats;$/;"	m	struct:__anon48	file:
+formats	tests/check/gsttiovxmosaic.c	/^  const gchar **formats;$/;"	m	struct:__anon40	file:
+fps	ext/tiovx/gsttiperfoverlay.cpp	/^      fps;$/;"	m	struct:_GstTIPerfOverlay	file:
+fps_height	ext/tiovx/gsttiperfoverlay.cpp	/^      fps_height;$/;"	m	struct:_GstTIPerfOverlay	file:
+fps_width	ext/tiovx/gsttiperfoverlay.cpp	/^      fps_width;$/;"	m	struct:_GstTIPerfOverlay	file:
+fps_x_pos	ext/tiovx/gsttiperfoverlay.cpp	/^      fps_x_pos;$/;"	m	struct:_GstTIPerfOverlay	file:
+fps_y_pos	ext/tiovx/gsttiperfoverlay.cpp	/^      fps_y_pos;$/;"	m	struct:_GstTIPerfOverlay	file:
+frame_count	ext/tiovx/gsttiperfoverlay.cpp	/^      frame_count;$/;"	m	struct:_GstTIPerfOverlay	file:
+framerate	tests/check/gsttiovxdlpreproc.c	/^  const guint *framerate;$/;"	m	struct:__anon43	file:
+framerate	tests/check/gsttiovxisp.c	/^  const guint *framerate;$/;"	m	struct:__anon48	file:
+framerate	tests/check/gsttiovxmosaic.c	/^  const guint *framerate;$/;"	m	struct:__anon40	file:
+frames_rendered	ext/tiovx/gsttiperfoverlay.cpp	/^      frames_rendered;$/;"	m	struct:_GstTIPerfOverlay	file:
+free_buffer_meta	gst-libs/gst/tiovx/gsttiovxbufferpool.h	/^  void (*free_buffer_meta) (GstTIOVXBufferPool * self, GstBuffer* buffer);$/;"	m	struct:_GstTIOVXBufferPoolClass
+gIMX390GainsTable	ext/tiovx/gsttiovxisp.c	/^static const uint16_t gIMX390GainsTable[ISS_IMX390_GAIN_TBL_SIZE][2U] = {$/;"	v	file:
+get_formats	ext/tiovx/gsttiovxcolorconvert.c	/^get_formats (const GValue * input_formats, GValue * output_formats,$/;"	f	file:
+get_formats	ext/tiovx/gsttiovxdlcolorconvert.c	/^get_formats (const GValue * input_formats, GValue * output_formats,$/;"	f	file:
+get_graph_count	ext/tiovx/gsttiperfoverlay.cpp	/^get_graph_count (GstTIPerfOverlay * self)$/;"	f	file:
+get_imx219_ae_dyn_params	ext/tiovx/gsttiovxisp.c	/^get_imx219_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)$/;"	f	file:
+get_imx390_ae_dyn_params	ext/tiovx/gsttiovxisp.c	/^get_imx390_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)$/;"	f	file:
+get_node_info	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*get_node_info)            (GstTIOVXMiso *agg, GList* sink_pads_list, GstPad * src_pad, vx_node * node, GList **queueable_objects);$/;"	m	struct:_GstTIOVXMisoClass
+get_node_info	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  gboolean      (*get_node_info)            (GstTIOVXSimo *self, vx_node *node, GstTIOVXPad *sink_pad, GList *src_pads, GList **queueable_objects);$/;"	m	struct:_GstTIOVXSimoClass
+get_node_info	gst-libs/gst/tiovx/gsttiovxsiso.h	/^  gboolean      (*get_node_info)            (GstTIOVXSiso *trans, vx_object_array * input, vx_object_array * output, vx_reference * input_ref, vx_reference * output_ref,$/;"	m	struct:_GstTIOVXSisoClass
+get_ov2312_ae_dyn_params	ext/tiovx/gsttiovxisp.c	/^get_ov2312_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)$/;"	f	file:
+get_pool	tests/check/libs/gsttiovximagebufferpool.c	/^get_pool (void)$/;"	f	file:
+get_pool	tests/check/libs/gsttiovxpyramidbufferpool.c	/^get_pool (void)$/;"	f	file:
+get_pool	tests/check/libs/gsttiovxrawimagebufferpool.c	/^get_pool (void)$/;"	f	file:
+get_pool	tests/check/libs/gsttiovxtensorbufferpool.c	/^get_pool (void)$/;"	f	file:
+get_sink_caps	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  GstCaps *     (*get_sink_caps)            (GstTIOVXSimo *self, GstCaps *filter, GList *src_caps_list, GList *src_pads);$/;"	m	struct:_GstTIOVXSimoClass
+get_src_caps	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  GstCaps *     (*get_src_caps)             (GstTIOVXSimo *self, GstCaps *filter, GstCaps *sink_caps, GstTIOVXPad *src_pad);$/;"	m	struct:_GstTIOVXSimoClass
+graph	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  vx_graph graph;$/;"	m	struct:_GstTIOVXMisoPrivate	file:
+graph	gst-libs/gst/tiovx/gsttiovxsimo.c	/^  vx_graph graph;$/;"	m	struct:_GstTIOVXSimoPrivate	file:
+graph	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  vx_graph graph;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+graph_bg_color	ext/tiovx/gsttiperfoverlay.cpp	/^      graph_bg_color;$/;"	m	struct:_GstTIPerfOverlay	file:
+graph_height	ext/tiovx/gsttiperfoverlay.cpp	/^      graph_height;$/;"	m	struct:_GstTIPerfOverlay	file:
+graph_offset_x	ext/tiovx/gsttiperfoverlay.cpp	/^      graph_offset_x;$/;"	m	struct:_GstTIPerfOverlay	file:
+graph_param_id	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  gint graph_param_id;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+graph_param_id	gst-libs/gst/tiovx/gsttiovxpad.c	/^  gint graph_param_id;$/;"	m	struct:_GstTIOVXPadPrivate	file:
+graph_param_id	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^  gint graph_param_id;$/;"	m	struct:_GstTIOVXQueueable	file:
+graph_pos_x	ext/tiovx/gsttiperfoverlay.cpp	/^      graph_pos_x;$/;"	m	struct:_GstTIPerfOverlay	file:
+graph_pos_y	ext/tiovx/gsttiperfoverlay.cpp	/^      graph_pos_y;$/;"	m	struct:_GstTIPerfOverlay	file:
+graph_width	ext/tiovx/gsttiperfoverlay.cpp	/^      graph_width;$/;"	m	struct:_GstTIPerfOverlay	file:
+gst_array_to_c_array	ext/tiovx/gsttiovxmosaic.c	/^gst_array_to_c_array (const GValue * gst_array, guint * length)$/;"	f	file:
+gst_buffer_add_tidl_out_meta	gst-libs/gst/tiovx/gsttidloutmeta.c	/^gst_buffer_add_tidl_out_meta (GstBuffer * buffer,$/;"	f
+gst_buffer_add_tiovx_image_meta	gst-libs/gst/tiovx/gsttiovximagemeta.c	/^gst_buffer_add_tiovx_image_meta (GstBuffer * buffer,$/;"	f
+gst_buffer_add_tiovx_mux_meta	gst-libs/gst/tiovx/gsttiovxmuxmeta.c	/^gst_buffer_add_tiovx_mux_meta (GstBuffer * buffer, const vx_reference exemplar)$/;"	f
+gst_buffer_add_tiovx_pyramid_meta	gst-libs/gst/tiovx/gsttiovxpyramidmeta.c	/^gst_buffer_add_tiovx_pyramid_meta (GstBuffer * buffer,$/;"	f
+gst_buffer_add_tiovx_raw_image_meta	gst-libs/gst/tiovx/gsttiovxrawimagemeta.c	/^gst_buffer_add_tiovx_raw_image_meta (GstBuffer * buffer,$/;"	f
+gst_buffer_add_tiovx_sensor_meta	gst-libs/gst/tiovx/gsttiovxsensormeta.c	/^gst_buffer_add_tiovx_sensor_meta (GstBuffer * buffer,$/;"	f
+gst_buffer_add_tiovx_tensor_meta	gst-libs/gst/tiovx/gsttiovxtensormeta.c	/^gst_buffer_add_tiovx_tensor_meta (GstBuffer * buffer,$/;"	f
+gst_dl_tiovx_color_convert	tests/check/gsttiovxdlcolorconvert.c	/^GST_CHECK_MAIN (gst_dl_tiovx_color_convert);$/;"	v
+gst_dl_tiovx_color_convert_suite	tests/check/gsttiovxdlcolorconvert.c	/^gst_dl_tiovx_color_convert_suite (void)$/;"	f	file:
+gst_format	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^  const gchar *gst_format;$/;"	m	struct:_GstTIOVXRawImageBufferPool	file:
+gst_format_to_tivx_raw_format	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_format_to_tivx_raw_format (const gchar * gst_format)$/;"	f
+gst_format_to_vx_format	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_format_to_vx_format (const GstVideoFormat gst_format)$/;"	f
+gst_invalid_formats	tests/check/gsttiovxldc.c	/^static const gchar *gst_invalid_formats[] = {$/;"	v	file:
+gst_sink_formats	tests/check/gsttiovxcolorconvert.c	/^static const gchar *gst_sink_formats[] = {$/;"	v	file:
+gst_sink_formats	tests/check/gsttiovxdlcolorconvert.c	/^static const gchar *gst_sink_formats[] = {$/;"	v	file:
+gst_src_formats_fail	tests/check/gsttiovxcolorconvert.c	/^static const gchar *gst_src_formats_fail[SINK_FORMATS][SRC_FORMATS_FAIL] = {$/;"	v	file:
+gst_src_formats_fail	tests/check/gsttiovxdlcolorconvert.c	/^static const gchar *gst_src_formats_fail[SINK_FORMATS][SRC_FORMATS_FAIL] = {$/;"	v	file:
+gst_src_formats_success	tests/check/gsttiovxcolorconvert.c	/^static const gchar *gst_src_formats_success[SINK_FORMATS][SRC_FORMATS_SUCCESS] = {$/;"	v	file:
+gst_src_formats_success	tests/check/gsttiovxdlcolorconvert.c	/^static const gchar *gst_src_formats_success[SINK_FORMATS][SRC_FORMATS_SUCCESS] = {$/;"	v	file:
+gst_state	tests/check/gsttiovx_multiple_transitions.c	/^GST_CHECK_MAIN (gst_state);$/;"	v
+gst_state	tests/check/gsttiovxdlcolorblend.c	/^GST_CHECK_MAIN (gst_state);$/;"	v
+gst_state	tests/check/gsttiovxdlpreproc.c	/^GST_CHECK_MAIN (gst_state);$/;"	v
+gst_state	tests/check/gsttiovxmosaic.c	/^GST_CHECK_MAIN (gst_state);$/;"	v
+gst_state	tests/check/gsttiovxmultiscaler.c	/^GST_CHECK_MAIN (gst_state);$/;"	v
+gst_state	tests/check/libs/gsttiovxmiso.c	/^GST_CHECK_MAIN (gst_state);$/;"	v
+gst_state	tests/check/libs/gsttiovxsimo.c	/^GST_CHECK_MAIN (gst_state);$/;"	v
+gst_state	tests/check/libs/gsttiovxsiso.c	/^GST_CHECK_MAIN (gst_state);$/;"	v
+gst_state_suite	tests/check/gsttiovx_multiple_transitions.c	/^gst_state_suite (void)$/;"	f	file:
+gst_state_suite	tests/check/gsttiovxdlcolorblend.c	/^gst_state_suite (void)$/;"	f	file:
+gst_state_suite	tests/check/gsttiovxdlpreproc.c	/^gst_state_suite (void)$/;"	f	file:
+gst_state_suite	tests/check/gsttiovxmosaic.c	/^gst_state_suite (void)$/;"	f	file:
+gst_state_suite	tests/check/gsttiovxmultiscaler.c	/^gst_state_suite (void)$/;"	f	file:
+gst_state_suite	tests/check/libs/gsttiovxmiso.c	/^gst_state_suite (void)$/;"	f	file:
+gst_state_suite	tests/check/libs/gsttiovxsimo.c	/^gst_state_suite (void)$/;"	f	file:
+gst_state_suite	tests/check/libs/gsttiovxsiso.c	/^gst_state_suite (void)$/;"	f	file:
+gst_test_tiovx_miso_class_init	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_class_init (GstTestTIOVXMisoClass * klass)$/;"	f	file:
+gst_test_tiovx_miso_configure_module	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_configure_module (GstTIOVXMiso * agg)$/;"	f	file:
+gst_test_tiovx_miso_create_graph	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_create_graph (GstTIOVXMiso * agg, vx_context context,$/;"	f	file:
+gst_test_tiovx_miso_create_vx_object_array	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_create_vx_object_array (GstTestTIOVXMiso * agg,$/;"	f	file:
+gst_test_tiovx_miso_deinit_module	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_deinit_module (GstTIOVXMiso * agg)$/;"	f	file:
+gst_test_tiovx_miso_get_node_info	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_get_node_info (GstTIOVXMiso * agg, GList * sink_pads_list,$/;"	f	file:
+gst_test_tiovx_miso_init	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_init (GstTestTIOVXMiso * self)$/;"	f	file:
+gst_test_tiovx_miso_init_module	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_init_module (GstTIOVXMiso * agg, vx_context context,$/;"	f	file:
+gst_test_tiovx_miso_parent_class	tests/check/libs/gsttiovxmiso.c	110;"	d	file:
+gst_test_tiovx_miso_plugin_init	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_plugin_init (GstPlugin * plugin)$/;"	f	file:
+gst_test_tiovx_miso_plugin_register	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_plugin_register (void)$/;"	f	file:
+gst_test_tiovx_miso_release_buffer	tests/check/libs/gsttiovxmiso.c	/^gst_test_tiovx_miso_release_buffer (GstTIOVXMiso * agg)$/;"	f	file:
+gst_test_tiovx_simo_create_vx_object_array	tests/check/libs/gsttiovxsimo.c	/^gst_test_tiovx_simo_create_vx_object_array (GstTestTIOVXSimo * self,$/;"	f	file:
+gst_test_tiovx_siso_class_init	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_class_init (GstTestTIOVXSisoClass * klass)$/;"	f	file:
+gst_test_tiovx_siso_compare_caps	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_compare_caps (GstTIOVXSiso * trans, GstCaps * caps1,$/;"	f	file:
+gst_test_tiovx_siso_create_graph	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_create_graph (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_test_tiovx_siso_create_vx_object_array	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_create_vx_object_array (GstTestTIOVXSiso * trans,$/;"	f	file:
+gst_test_tiovx_siso_deinit_module	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_deinit_module (GstTIOVXSiso * trans, vx_context context)$/;"	f	file:
+gst_test_tiovx_siso_get_node_info	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_get_node_info (GstTIOVXSiso * trans,$/;"	f	file:
+gst_test_tiovx_siso_init	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_init (GstTestTIOVXSiso * self)$/;"	f	file:
+gst_test_tiovx_siso_init_module	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_init_module (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_test_tiovx_siso_parent_class	tests/check/libs/gsttiovxsiso.c	115;"	d	file:
+gst_test_tiovx_siso_plugin_init	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_plugin_init (GstPlugin * plugin)$/;"	f	file:
+gst_test_tiovx_siso_plugin_register	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_plugin_register (void)$/;"	f	file:
+gst_test_tiovx_siso_release_buffer	tests/check/libs/gsttiovxsiso.c	/^gst_test_tiovx_siso_release_buffer (GstTIOVXSiso * trans)$/;"	f	file:
+gst_ti_dl_inferer_class_init	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_class_init (GstTIDLInfererClass * klass)$/;"	f	file:
+gst_ti_dl_inferer_debug	ext/tiovx/gsttidlinferer.cpp	/^GST_DEBUG_CATEGORY_STATIC (gst_ti_dl_inferer_debug);$/;"	v
+gst_ti_dl_inferer_decide_allocation	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_decide_allocation (GstBaseTransform * trans, GstQuery * query)$/;"	f	file:
+gst_ti_dl_inferer_finalize	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_finalize (GObject * obj)$/;"	f	file:
+gst_ti_dl_inferer_get_property	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_ti_dl_inferer_init	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_init (GstTIDLInferer * self)$/;"	f	file:
+gst_ti_dl_inferer_parent_class	ext/tiovx/gsttidlinferer.cpp	181;"	d	file:
+gst_ti_dl_inferer_propose_allocation	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_propose_allocation (GstBaseTransform * trans,$/;"	f	file:
+gst_ti_dl_inferer_set_property	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_ti_dl_inferer_transform	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_transform (GstBaseTransform * trans, GstBuffer * inbuf,$/;"	f	file:
+gst_ti_dl_inferer_transform_caps	ext/tiovx/gsttidlinferer.cpp	/^gst_ti_dl_inferer_transform_caps (GstBaseTransform * base,$/;"	f	file:
+gst_ti_dl_make_post_proc	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_make_post_proc (GstTIDLPostProc * self, GstBuffer * buffer)$/;"	f	file:
+gst_ti_dl_post_proc_chain	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)$/;"	f	file:
+gst_ti_dl_post_proc_change_state	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_change_state (GstElement * element,$/;"	f	file:
+gst_ti_dl_post_proc_child_proxy_get_child_by_index	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_child_proxy_get_child_by_index (GstChildProxy *$/;"	f	file:
+gst_ti_dl_post_proc_child_proxy_get_child_by_name	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_child_proxy_get_child_by_name (GstChildProxy *$/;"	f	file:
+gst_ti_dl_post_proc_child_proxy_get_children_count	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_child_proxy_get_children_count (GstChildProxy * child_proxy)$/;"	f	file:
+gst_ti_dl_post_proc_child_proxy_init	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_child_proxy_init (gpointer g_iface, gpointer iface_data)$/;"	f	file:
+gst_ti_dl_post_proc_class_init	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_class_init (GstTIDLPostProcClass * klass)$/;"	f	file:
+gst_ti_dl_post_proc_debug	ext/tiovx/gsttidlpostproc.cpp	/^GST_DEBUG_CATEGORY_STATIC (gst_ti_dl_post_proc_debug);$/;"	v
+gst_ti_dl_post_proc_finalize	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_finalize (GObject * obj)$/;"	f	file:
+gst_ti_dl_post_proc_get_property	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_ti_dl_post_proc_init	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_init (GstTIDLPostProc * self)$/;"	f	file:
+gst_ti_dl_post_proc_parent_class	ext/tiovx/gsttidlpostproc.cpp	220;"	d	file:
+gst_ti_dl_post_proc_parse_model	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_parse_model (GstTIDLPostProc * self)$/;"	f	file:
+gst_ti_dl_post_proc_set_property	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_ti_dl_post_proc_sink_event	ext/tiovx/gsttidlpostproc.cpp	/^gst_ti_dl_post_proc_sink_event (GstPad * pad, GstObject * parent,$/;"	f	file:
+gst_ti_perf_overlay_class_init	ext/tiovx/gsttiperfoverlay.cpp	/^gst_ti_perf_overlay_class_init (GstTIPerfOverlayClass * klass)$/;"	f	file:
+gst_ti_perf_overlay_debug	ext/tiovx/gsttiperfoverlay.cpp	/^GST_DEBUG_CATEGORY_STATIC (gst_ti_perf_overlay_debug);$/;"	v
+gst_ti_perf_overlay_finalize	ext/tiovx/gsttiperfoverlay.cpp	/^gst_ti_perf_overlay_finalize (GObject * obj)$/;"	f	file:
+gst_ti_perf_overlay_get_property	ext/tiovx/gsttiperfoverlay.cpp	/^gst_ti_perf_overlay_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_ti_perf_overlay_init	ext/tiovx/gsttiperfoverlay.cpp	/^gst_ti_perf_overlay_init (GstTIPerfOverlay * self)$/;"	f	file:
+gst_ti_perf_overlay_parent_class	ext/tiovx/gsttiperfoverlay.cpp	242;"	d	file:
+gst_ti_perf_overlay_set_caps	ext/tiovx/gsttiperfoverlay.cpp	/^gst_ti_perf_overlay_set_caps (GstBaseTransform * trans, GstCaps * incaps,$/;"	f	file:
+gst_ti_perf_overlay_set_property	ext/tiovx/gsttiperfoverlay.cpp	/^gst_ti_perf_overlay_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_ti_perf_overlay_transform_ip	ext/tiovx/gsttiperfoverlay.cpp	/^gst_ti_perf_overlay_transform_ip (GstBaseTransform * trans, GstBuffer * buffer)$/;"	f	file:
+gst_tidl_out_meta_api_get_type	gst-libs/gst/tiovx/gsttidloutmeta.c	/^gst_tidl_out_meta_api_get_type (void)$/;"	f
+gst_tidl_out_meta_get_info	gst-libs/gst/tiovx/gsttidloutmeta.c	/^gst_tidl_out_meta_get_info (void)$/;"	f
+gst_tidl_out_meta_init	gst-libs/gst/tiovx/gsttidloutmeta.c	/^gst_tidl_out_meta_init (GstMeta * meta, gpointer params, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_add_new_pool	gst-libs/gst/tiovx/gsttiovxbufferpoolutils.c	/^gst_tiovx_add_new_pool (GstDebugCategory * category, GstQuery * query,$/;"	f
+gst_tiovx_allocator_alloc	gst-libs/gst/tiovx/gsttiovxallocator.c	/^gst_tiovx_allocator_alloc (GstAllocator * allocator, gsize size,$/;"	f	file:
+gst_tiovx_allocator_class_init	gst-libs/gst/tiovx/gsttiovxallocator.c	/^gst_tiovx_allocator_class_init (GstTIOVXAllocatorClass * klass)$/;"	f	file:
+gst_tiovx_allocator_debug_category	gst-libs/gst/tiovx/gsttiovxallocator.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_allocator_debug_category);$/;"	v
+gst_tiovx_allocator_free	gst-libs/gst/tiovx/gsttiovxallocator.c	/^gst_tiovx_allocator_free (GstAllocator * allocator, GstMemory * memory)$/;"	f	file:
+gst_tiovx_allocator_init	gst-libs/gst/tiovx/gsttiovxallocator.c	/^gst_tiovx_allocator_init (GstTIOVXAllocator * self)$/;"	f	file:
+gst_tiovx_allocator_mem_free	gst-libs/gst/tiovx/gsttiovxallocator.c	/^gst_tiovx_allocator_mem_free (gpointer mem)$/;"	f	file:
+gst_tiovx_bayer_get_bits_per_pixel	tests/check/test_utils.h	/^gst_tiovx_bayer_get_bits_per_pixel (const gchar * bayer_format)$/;"	f
+gst_tiovx_buffer_copy	gst-libs/gst/tiovx/gsttiovxbufferutils.c	/^gst_tiovx_buffer_copy (GstDebugCategory * category, GstBufferPool * pool,$/;"	f	file:
+gst_tiovx_buffer_performance	gst-libs/gst/tiovx/gsttiovxbufferutils.c	/^GST_DEBUG_CATEGORY (gst_tiovx_buffer_performance);$/;"	v
+gst_tiovx_buffer_pool	tests/check/libs/gsttiovximagebufferpool.c	/^GST_CHECK_MAIN (gst_tiovx_buffer_pool);$/;"	v
+gst_tiovx_buffer_pool	tests/check/libs/gsttiovxrawimagebufferpool.c	/^GST_CHECK_MAIN (gst_tiovx_buffer_pool);$/;"	v
+gst_tiovx_buffer_pool_alloc_buffer	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^gst_tiovx_buffer_pool_alloc_buffer (GstBufferPool * pool, GstBuffer ** buffer,$/;"	f	file:
+gst_tiovx_buffer_pool_class_init	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^gst_tiovx_buffer_pool_class_init (GstTIOVXBufferPoolClass * klass)$/;"	f	file:
+gst_tiovx_buffer_pool_config_get_exemplar	gst-libs/gst/tiovx/gsttiovxbufferpoolutils.c	/^gst_tiovx_buffer_pool_config_get_exemplar (GstStructure * config,$/;"	f
+gst_tiovx_buffer_pool_config_get_num_channels	gst-libs/gst/tiovx/gsttiovxbufferpoolutils.c	/^gst_tiovx_buffer_pool_config_get_num_channels (GstStructure * config,$/;"	f
+gst_tiovx_buffer_pool_config_set_exemplar	gst-libs/gst/tiovx/gsttiovxbufferpoolutils.c	/^gst_tiovx_buffer_pool_config_set_exemplar (GstStructure * config,$/;"	f
+gst_tiovx_buffer_pool_config_set_num_channels	gst-libs/gst/tiovx/gsttiovxbufferpoolutils.c	/^gst_tiovx_buffer_pool_config_set_num_channels (GstStructure * config,$/;"	f
+gst_tiovx_buffer_pool_debug_category	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_buffer_pool_debug_category);$/;"	v
+gst_tiovx_buffer_pool_finalize	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^gst_tiovx_buffer_pool_finalize (GObject * object)$/;"	f	file:
+gst_tiovx_buffer_pool_free_buffer	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^gst_tiovx_buffer_pool_free_buffer (GstBufferPool * pool, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_buffer_pool_init	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^gst_tiovx_buffer_pool_init (GstTIOVXBufferPool * self)$/;"	f	file:
+gst_tiovx_buffer_pool_set_config	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^gst_tiovx_buffer_pool_set_config (GstBufferPool * pool, GstStructure * config)$/;"	f	file:
+gst_tiovx_buffer_pool_suite	tests/check/libs/gsttiovximagebufferpool.c	/^gst_tiovx_buffer_pool_suite (void)$/;"	f	file:
+gst_tiovx_buffer_pool_suite	tests/check/libs/gsttiovxrawimagebufferpool.c	/^gst_tiovx_buffer_pool_suite (void)$/;"	f	file:
+gst_tiovx_color_convert	tests/check/gsttiovxcolorconvert.c	/^GST_CHECK_MAIN (gst_tiovx_color_convert);$/;"	v
+gst_tiovx_color_convert_class_init	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_class_init (GstTIOVXColorconvertClass * klass)$/;"	f	file:
+gst_tiovx_color_convert_compare_caps	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_compare_caps (GstTIOVXSiso * trans, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_color_convert_create_graph	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_create_graph (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_tiovx_color_convert_debug	ext/tiovx/gsttiovxcolorconvert.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_color_convert_debug);$/;"	v
+gst_tiovx_color_convert_deinit_module	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_deinit_module (GstTIOVXSiso * trans, vx_context context)$/;"	f	file:
+gst_tiovx_color_convert_get_node_info	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_get_node_info (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_color_convert_get_property	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_color_convert_init	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_init (GstTIOVXColorconvert * self)$/;"	f	file:
+gst_tiovx_color_convert_init_module	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_init_module (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_tiovx_color_convert_parent_class	ext/tiovx/gsttiovxcolorconvert.c	169;"	d	file:
+gst_tiovx_color_convert_release_buffer	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_release_buffer (GstTIOVXSiso * trans)$/;"	f	file:
+gst_tiovx_color_convert_set_property	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_color_convert_suite	tests/check/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_suite (void)$/;"	f	file:
+gst_tiovx_color_convert_target_get_type	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_target_get_type (void)$/;"	f	file:
+gst_tiovx_color_convert_transform_caps	ext/tiovx/gsttiovxcolorconvert.c	/^gst_tiovx_color_convert_transform_caps (GstBaseTransform * base,$/;"	f	file:
+gst_tiovx_configure_pool	gst-libs/gst/tiovx/gsttiovxbufferpoolutils.c	/^gst_tiovx_configure_pool (GstDebugCategory * category, GstBufferPool * pool,$/;"	f
+gst_tiovx_context_class_init	gst-libs/gst/tiovx/gsttiovxcontext.c	/^gst_tiovx_context_class_init (GstTIOVXContextClass * klass)$/;"	f	file:
+gst_tiovx_context_constructor	gst-libs/gst/tiovx/gsttiovxcontext.c	/^gst_tiovx_context_constructor (GType type, guint n_construct_properties,$/;"	f	file:
+gst_tiovx_context_debug_category	gst-libs/gst/tiovx/gsttiovxcontext.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_context_debug_category);$/;"	v
+gst_tiovx_context_finalize	gst-libs/gst/tiovx/gsttiovxcontext.c	/^gst_tiovx_context_finalize (GObject * object)$/;"	f	file:
+gst_tiovx_context_init	gst-libs/gst/tiovx/gsttiovxcontext.c	/^gst_tiovx_context_init (GstTIOVXContext * self)$/;"	f	file:
+gst_tiovx_context_new	gst-libs/gst/tiovx/gsttiovxcontext.c	/^gst_tiovx_context_new (void)$/;"	f
+gst_tiovx_copy_image_exemplar	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_copy_image_exemplar (vx_image exemplar)$/;"	f
+gst_tiovx_copy_raw_image_exemplar	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_copy_raw_image_exemplar (tivx_raw_image exemplar)$/;"	f
+gst_tiovx_copy_tensor_exemplar	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_copy_tensor_exemplar (vx_tensor exemplar)$/;"	f
+gst_tiovx_create_new_pool	gst-libs/gst/tiovx/gsttiovxbufferpoolutils.c	/^gst_tiovx_create_new_pool (GstDebugCategory * category, vx_reference exemplar)$/;"	f
+gst_tiovx_delay_class_init	ext/tiovx/gsttiovxdelay.c	/^gst_tiovx_delay_class_init (GstTIOVXDelayClass * klass)$/;"	f	file:
+gst_tiovx_delay_debug_category	ext/tiovx/gsttiovxdelay.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_delay_debug_category);$/;"	v
+gst_tiovx_delay_get_property	ext/tiovx/gsttiovxdelay.c	/^gst_tiovx_delay_get_property (GObject * object, guint property_id,$/;"	f	file:
+gst_tiovx_delay_init	ext/tiovx/gsttiovxdelay.c	/^gst_tiovx_delay_init (GstTIOVXDelay * self)$/;"	f	file:
+gst_tiovx_delay_prepare_output_buffer	ext/tiovx/gsttiovxdelay.c	/^gst_tiovx_delay_prepare_output_buffer (GstBaseTransform * trans,$/;"	f	file:
+gst_tiovx_delay_set_property	ext/tiovx/gsttiovxdelay.c	/^gst_tiovx_delay_set_property (GObject * object, guint property_id,$/;"	f	file:
+gst_tiovx_delay_stop	ext/tiovx/gsttiovxdelay.c	/^gst_tiovx_delay_stop (GstBaseTransform * trans)$/;"	f	file:
+gst_tiovx_delay_transform	ext/tiovx/gsttiovxdelay.c	/^gst_tiovx_delay_transform (GstBaseTransform * trans, GstBuffer * input,$/;"	f	file:
+gst_tiovx_demux	tests/check/gsttiovxdemux.c	/^GST_CHECK_MAIN (gst_tiovx_demux);$/;"	v
+gst_tiovx_demux_chain	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_chain (GstPad * pad, GstObject * parent, GstBuffer * in_buffer)$/;"	f	file:
+gst_tiovx_demux_child_proxy_get_child_by_index	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_child_proxy_get_child_by_index (GstChildProxy *$/;"	f	file:
+gst_tiovx_demux_child_proxy_get_child_by_name	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_child_proxy_get_child_by_name (GstChildProxy *$/;"	f	file:
+gst_tiovx_demux_child_proxy_get_children_count	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_child_proxy_get_children_count (GstChildProxy * child_proxy)$/;"	f	file:
+gst_tiovx_demux_child_proxy_init	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_child_proxy_init (gpointer g_iface, gpointer iface_data)$/;"	f	file:
+gst_tiovx_demux_class_init	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_class_init (GstTIOVXDemuxClass * klass)$/;"	f	file:
+gst_tiovx_demux_debug_category	ext/tiovx/gsttiovxdemux.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_demux_debug_category);$/;"	v
+gst_tiovx_demux_finalize	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_finalize (GObject * gobject)$/;"	f	file:
+gst_tiovx_demux_fixate_caps	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_fixate_caps (GstTIOVXDemux * self, GstCaps * sink_caps,$/;"	f	file:
+gst_tiovx_demux_get_exemplar_mem	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_demux_get_exemplar_mem (GObject * object, GstDebugCategory * category,$/;"	f
+gst_tiovx_demux_get_sink_caps	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_get_sink_caps (GstTIOVXDemux * self,$/;"	f	file:
+gst_tiovx_demux_get_src_caps	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_get_src_caps (GstTIOVXDemux * self,$/;"	f	file:
+gst_tiovx_demux_get_src_caps_list	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_get_src_caps_list (GstTIOVXDemux * self)$/;"	f	file:
+gst_tiovx_demux_init	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_init (GstTIOVXDemux * self)$/;"	f	file:
+gst_tiovx_demux_push_buffers	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_push_buffers (GstTIOVXDemux * demux, GList * pads,$/;"	f	file:
+gst_tiovx_demux_release_pad	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_release_pad (GstElement * element, GstPad * pad)$/;"	f	file:
+gst_tiovx_demux_request_new_pad	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_request_new_pad (GstElement * element, GstPadTemplate * templ,$/;"	f	file:
+gst_tiovx_demux_sink_event	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_sink_event (GstPad * pad, GstObject * parent, GstEvent * event)$/;"	f	file:
+gst_tiovx_demux_sink_query	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_sink_query (GstPad * pad, GstObject * parent, GstQuery * query)$/;"	f	file:
+gst_tiovx_demux_src_query	ext/tiovx/gsttiovxdemux.c	/^gst_tiovx_demux_src_query (GstPad * pad, GstObject * parent, GstQuery * query)$/;"	f	file:
+gst_tiovx_demux_suite	tests/check/gsttiovxdemux.c	/^gst_tiovx_demux_suite (void)$/;"	f	file:
+gst_tiovx_dl_color_blend_class_init	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_class_init (GstTIOVXDLColorBlendClass * klass)$/;"	f	file:
+gst_tiovx_dl_color_blend_configure_module	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_configure_module (GstTIOVXMiso * miso)$/;"	f	file:
+gst_tiovx_dl_color_blend_create_graph	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_create_graph (GstTIOVXMiso * miso,$/;"	f	file:
+gst_tiovx_dl_color_blend_data_type_get_type	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_data_type_get_type (void)$/;"	f	file:
+gst_tiovx_dl_color_blend_debug	ext/tiovx/gsttiovxdlcolorblend.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_dl_color_blend_debug);$/;"	v
+gst_tiovx_dl_color_blend_deinit_module	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_deinit_module (GstTIOVXMiso * miso)$/;"	f	file:
+gst_tiovx_dl_color_blend_finalize	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_dl_color_blend_fixate_caps	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_fixate_caps (GstTIOVXMiso * miso,$/;"	f	file:
+gst_tiovx_dl_color_blend_get_node_info	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_get_node_info (GstTIOVXMiso * miso,$/;"	f	file:
+gst_tiovx_dl_color_blend_get_property	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dl_color_blend_get_tensor_blocksize	tests/check/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_get_tensor_blocksize (const guint tensor_width,$/;"	f	file:
+gst_tiovx_dl_color_blend_init	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_init (GstTIOVXDLColorBlend * self)$/;"	f	file:
+gst_tiovx_dl_color_blend_init_module	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_init_module (GstTIOVXMiso * miso,$/;"	f	file:
+gst_tiovx_dl_color_blend_modeling_init	tests/check/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_modeling_init (TIOVXDLColorBlendModeled * element)$/;"	f	file:
+gst_tiovx_dl_color_blend_parent_class	ext/tiovx/gsttiovxdlcolorblend.c	231;"	d	file:
+gst_tiovx_dl_color_blend_release_buffer	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_release_buffer (GstTIOVXMiso * miso)$/;"	f	file:
+gst_tiovx_dl_color_blend_request_new_pad	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_request_new_pad (GstElement * element,$/;"	f	file:
+gst_tiovx_dl_color_blend_set_property	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dl_color_blend_target_get_type	ext/tiovx/gsttiovxdlcolorblend.c	/^gst_tiovx_dl_color_blend_target_get_type (void)$/;"	f	file:
+gst_tiovx_dl_color_convert_class_init	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_class_init (GstTIOVXDLColorconvertClass * klass)$/;"	f	file:
+gst_tiovx_dl_color_convert_compare_caps	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_compare_caps (GstTIOVXSiso * trans, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_dl_color_convert_create_graph	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_create_graph (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_dl_color_convert_debug	ext/tiovx/gsttiovxdlcolorconvert.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_dl_color_convert_debug);$/;"	v
+gst_tiovx_dl_color_convert_deinit_module	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_deinit_module (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_dl_color_convert_get_node_info	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_get_node_info (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_dl_color_convert_get_property	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dl_color_convert_init	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_init (GstTIOVXDLColorconvert * self)$/;"	f	file:
+gst_tiovx_dl_color_convert_init_module	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_init_module (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_dl_color_convert_parent_class	ext/tiovx/gsttiovxdlcolorconvert.c	169;"	d	file:
+gst_tiovx_dl_color_convert_release_buffer	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_release_buffer (GstTIOVXSiso * trans)$/;"	f	file:
+gst_tiovx_dl_color_convert_set_property	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dl_color_convert_target_get_type	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_target_get_type (void)$/;"	f	file:
+gst_tiovx_dl_color_convert_transform_caps	ext/tiovx/gsttiovxdlcolorconvert.c	/^gst_tiovx_dl_color_convert_transform_caps (GstBaseTransform * base,$/;"	f	file:
+gst_tiovx_dl_pre_proc_channel_order_get_type	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_channel_order_get_type (void)$/;"	f	file:
+gst_tiovx_dl_pre_proc_class_init	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_class_init (GstTIOVXDLPreProcClass * klass)$/;"	f	file:
+gst_tiovx_dl_pre_proc_compare_caps	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_compare_caps (GstTIOVXSiso * trans, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_dl_pre_proc_create_graph	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_create_graph (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_dl_pre_proc_data_type_get_type	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_data_type_get_type (void)$/;"	f	file:
+gst_tiovx_dl_pre_proc_debug	ext/tiovx/gsttiovxdlpreproc.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_dl_pre_proc_debug);$/;"	v
+gst_tiovx_dl_pre_proc_deinit_module	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_deinit_module (GstTIOVXSiso * trans, vx_context context)$/;"	f	file:
+gst_tiovx_dl_pre_proc_finalize	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_dl_pre_proc_get_enum_nickname	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_get_enum_nickname (GType type, gint value_id)$/;"	f	file:
+gst_tiovx_dl_pre_proc_get_node_info	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_get_node_info (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_dl_pre_proc_get_property	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dl_pre_proc_init	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_init (GstTIOVXDLPreProc * self)$/;"	f	file:
+gst_tiovx_dl_pre_proc_init_module	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_init_module (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_dl_pre_proc_modeling_init	tests/check/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_modeling_init (TIOVXDLPreProcModeled * element)$/;"	f	file:
+gst_tiovx_dl_pre_proc_parent_class	ext/tiovx/gsttiovxdlpreproc.c	283;"	d	file:
+gst_tiovx_dl_pre_proc_release_buffer	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_release_buffer (GstTIOVXSiso * trans)$/;"	f	file:
+gst_tiovx_dl_pre_proc_set_property	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dl_pre_proc_target_get_type	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_target_get_type (void)$/;"	f	file:
+gst_tiovx_dl_pre_proc_tensor_format_get_type	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_tensor_format_get_type (void)$/;"	f	file:
+gst_tiovx_dl_pre_proc_transform_caps	ext/tiovx/gsttiovxdlpreproc.c	/^gst_tiovx_dl_pre_proc_transform_caps (GstBaseTransform *$/;"	f	file:
+gst_tiovx_dof_class_init	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_class_init (GstTIOVXDOFClass * klass)$/;"	f	file:
+gst_tiovx_dof_configure_module	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_configure_module (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_dof_create_graph	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_create_graph (GstTIOVXMiso * agg, vx_context context,$/;"	f	file:
+gst_tiovx_dof_debug	ext/tiovx/gsttiovxdof.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_dof_debug);$/;"	v
+gst_tiovx_dof_deinit_module	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_deinit_module (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_dof_finalize	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_finalize (GObject * object)$/;"	f	file:
+gst_tiovx_dof_fixate_caps	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_fixate_caps (GstTIOVXMiso * miso,$/;"	f	file:
+gst_tiovx_dof_get_node_info	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_get_node_info (GstTIOVXMiso * agg,$/;"	f	file:
+gst_tiovx_dof_get_property	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dof_init	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_init (GstTIOVXDOF * self)$/;"	f	file:
+gst_tiovx_dof_init_module	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_init_module (GstTIOVXMiso * agg, vx_context context,$/;"	f	file:
+gst_tiovx_dof_motion_direction_get_type	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_motion_direction_get_type (void)$/;"	f	file:
+gst_tiovx_dof_parent_class	ext/tiovx/gsttiovxdof.c	247;"	d	file:
+gst_tiovx_dof_release_buffer	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_release_buffer (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_dof_set_property	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dof_target_get_type	ext/tiovx/gsttiovxdof.c	/^gst_tiovx_dof_target_get_type (void)$/;"	f	file:
+gst_tiovx_dof_viz_class_init	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_class_init (GstTIOVXDofVizClass * klass)$/;"	f	file:
+gst_tiovx_dof_viz_compare_caps	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_compare_caps (GstTIOVXSiso * trans, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_dof_viz_create_graph	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_create_graph (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_tiovx_dof_viz_debug	ext/tiovx/gsttiovxdofviz.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_dof_viz_debug);$/;"	v
+gst_tiovx_dof_viz_deinit_module	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_deinit_module (GstTIOVXSiso * trans, vx_context context)$/;"	f	file:
+gst_tiovx_dof_viz_get_node_info	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_get_node_info (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_dof_viz_get_property	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dof_viz_init	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_init (GstTIOVXDofViz * self)$/;"	f	file:
+gst_tiovx_dof_viz_init_module	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_init_module (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_tiovx_dof_viz_parent_class	ext/tiovx/gsttiovxdofviz.c	171;"	d	file:
+gst_tiovx_dof_viz_release_buffer	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_release_buffer (GstTIOVXSiso * trans)$/;"	f	file:
+gst_tiovx_dof_viz_set_property	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_dof_viz_target_get_type	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_target_get_type (void)$/;"	f	file:
+gst_tiovx_dof_viz_transform_caps	ext/tiovx/gsttiovxdofviz.c	/^gst_tiovx_dof_viz_transform_caps (GstBaseTransform * base,$/;"	f	file:
+gst_tiovx_empty_exemplar	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_empty_exemplar (vx_reference ref)$/;"	f
+gst_tiovx_get_batched_memory_feature	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_get_batched_memory_feature (void)$/;"	f
+gst_tiovx_get_exemplar_from_caps	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_get_exemplar_from_caps (GObject * object, GstDebugCategory * category,$/;"	f
+gst_tiovx_get_exemplar_type	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_get_exemplar_type (vx_reference exemplar)$/;"	f
+gst_tiovx_get_size_from_exemplar	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_get_size_from_exemplar (vx_reference exemplar)$/;"	f
+gst_tiovx_get_vx_array_from_buffer	gst-libs/gst/tiovx/gsttiovxbufferutils.c	/^gst_tiovx_get_vx_array_from_buffer (GstDebugCategory * category,$/;"	f
+gst_tiovx_image_buffer_pool_add_meta_to_buffer	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	/^gst_tiovx_image_buffer_pool_add_meta_to_buffer (GstTIOVXBufferPool * self,$/;"	f
+gst_tiovx_image_buffer_pool_class_init	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	/^gst_tiovx_image_buffer_pool_class_init (GstTIOVXImageBufferPoolClass * klass)$/;"	f	file:
+gst_tiovx_image_buffer_pool_debug	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_image_buffer_pool_debug);$/;"	v
+gst_tiovx_image_buffer_pool_free_buffer_meta	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	/^gst_tiovx_image_buffer_pool_free_buffer_meta (GstTIOVXBufferPool * self,$/;"	f
+gst_tiovx_image_buffer_pool_init	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	/^gst_tiovx_image_buffer_pool_init (GstTIOVXImageBufferPool * self)$/;"	f	file:
+gst_tiovx_image_buffer_pool_parent_class	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	80;"	d	file:
+gst_tiovx_image_buffer_pool_validate_caps	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	/^gst_tiovx_image_buffer_pool_validate_caps (GstTIOVXBufferPool * self,$/;"	f	file:
+gst_tiovx_image_meta_api_get_type	gst-libs/gst/tiovx/gsttiovximagemeta.c	/^gst_tiovx_image_meta_api_get_type (void)$/;"	f
+gst_tiovx_image_meta_get_info	gst-libs/gst/tiovx/gsttiovximagemeta.c	/^gst_tiovx_image_meta_get_info (void)$/;"	f
+gst_tiovx_image_meta_get_plane_info	gst-libs/gst/tiovx/gsttiovximagemeta.c	/^gst_tiovx_image_meta_get_plane_info (const vx_image image,$/;"	f	file:
+gst_tiovx_image_meta_init	gst-libs/gst/tiovx/gsttiovximagemeta.c	/^gst_tiovx_image_meta_init (GstMeta * meta, gpointer params, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_init_buffer_utils_debug	gst-libs/gst/tiovx/gsttiovxbufferutils.c	/^gst_tiovx_init_buffer_utils_debug (void)$/;"	f
+gst_tiovx_init_debug	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_init_debug (void)$/;"	f
+gst_tiovx_isp	tests/check/gsttiovxisp.c	/^GST_CHECK_MAIN (gst_tiovx_isp);$/;"	v
+gst_tiovx_isp_add_sensor_meta	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_add_sensor_meta (GstTIOVXMiso * miso, GstBuffer * buf)$/;"	f	file:
+gst_tiovx_isp_ae_mode_get_type	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_ae_mode_get_type (void)$/;"	f	file:
+gst_tiovx_isp_allocate_single_user_data_object	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_allocate_single_user_data_object (GstTIOVXISP * self,$/;"	f	file:
+gst_tiovx_isp_allocate_user_data_objects	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_allocate_user_data_objects (GstTIOVXISP * self)$/;"	f	file:
+gst_tiovx_isp_awb_mode_get_type	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_awb_mode_get_type (void)$/;"	f	file:
+gst_tiovx_isp_class_init	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_class_init (GstTIOVXISPClass * klass)$/;"	f	file:
+gst_tiovx_isp_configure_module	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_configure_module (GstTIOVXMiso * miso)$/;"	f	file:
+gst_tiovx_isp_create_graph	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_create_graph (GstTIOVXMiso * miso,$/;"	f	file:
+gst_tiovx_isp_debug	ext/tiovx/gsttiovxisp.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_isp_debug);$/;"	v
+gst_tiovx_isp_deinit_module	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_deinit_module (GstTIOVXMiso * miso)$/;"	f	file:
+gst_tiovx_isp_finalize	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_isp_fixate_caps	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_fixate_caps (GstTIOVXMiso * self,$/;"	f	file:
+gst_tiovx_isp_get_blocksize	tests/check/gsttiovxisp.c	/^gst_tiovx_isp_get_blocksize (const guint width,$/;"	f	file:
+gst_tiovx_isp_get_format_msb	tests/check/gsttiovxisp.c	/^gst_tiovx_isp_get_format_msb (const gchar * formats)$/;"	f	file:
+gst_tiovx_isp_get_int_range_pair_value	tests/check/gsttiovxisp.c	/^gst_tiovx_isp_get_int_range_pair_value (gint begin, gint end)$/;"	f	file:
+gst_tiovx_isp_get_node_info	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_get_node_info (GstTIOVXMiso * agg,$/;"	f	file:
+gst_tiovx_isp_get_property	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_isp_init	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_init (GstTIOVXISP * self)$/;"	f	file:
+gst_tiovx_isp_init_module	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_init_module (GstTIOVXMiso * miso,$/;"	f	file:
+gst_tiovx_isp_map_2A_values	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_map_2A_values (GstTIOVXISP * self, int exposure_time,$/;"	f	file:
+gst_tiovx_isp_modeling_init	tests/check/gsttiovxisp.c	/^gst_tiovx_isp_modeling_init (TIOVXISPModeled * element)$/;"	f	file:
+gst_tiovx_isp_pad_class_init	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_pad_class_init (GstTIOVXIspPadClass * klass)$/;"	f	file:
+gst_tiovx_isp_pad_debug_category	ext/tiovx/gsttiovxisp.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_isp_pad_debug_category);$/;"	v
+gst_tiovx_isp_pad_finalize	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_pad_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_isp_pad_get_property	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_pad_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_isp_pad_init	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_pad_init (GstTIOVXIspPad * self)$/;"	f	file:
+gst_tiovx_isp_pad_set_property	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_pad_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_isp_parent_class	ext/tiovx/gsttiovxisp.c	587;"	d	file:
+gst_tiovx_isp_postprocess	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_postprocess (GstTIOVXMiso * miso)$/;"	f	file:
+gst_tiovx_isp_read_2a_config_file	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_read_2a_config_file (GstTIOVXIspPad * self)$/;"	f	file:
+gst_tiovx_isp_release_buffer	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_release_buffer (GstTIOVXMiso * miso)$/;"	f	file:
+gst_tiovx_isp_set_property	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_isp_suite	tests/check/gsttiovxisp.c	/^gst_tiovx_isp_suite (void)$/;"	f	file:
+gst_tiovx_isp_target_get_type	ext/tiovx/gsttiovxisp.c	/^gst_tiovx_isp_target_get_type (void)$/;"	f	file:
+gst_tiovx_ldc	tests/check/gsttiovxldc.c	/^GST_CHECK_MAIN (gst_tiovx_ldc);$/;"	v
+gst_tiovx_ldc_class_init	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_class_init (GstTIOVXLDCClass * klass)$/;"	f	file:
+gst_tiovx_ldc_compare_caps	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_compare_caps (GstTIOVXSimo * simo, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_ldc_configure_module	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_configure_module (GstTIOVXSimo * simo)$/;"	f	file:
+gst_tiovx_ldc_create_graph	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_create_graph (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_ldc_debug	ext/tiovx/gsttiovxldc.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_ldc_debug);$/;"	v
+gst_tiovx_ldc_deinit_module	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_deinit_module (GstTIOVXSimo * simo)$/;"	f	file:
+gst_tiovx_ldc_finalize	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_ldc_fixate_caps	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_fixate_caps (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_ldc_get_node_info	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_get_node_info (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_ldc_get_property	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_ldc_get_sink_caps	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_get_sink_caps (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_ldc_get_src_caps	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_get_src_caps (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_ldc_init	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_init (GstTIOVXLDC * self)$/;"	f	file:
+gst_tiovx_ldc_init_module	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_init_module (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_ldc_parent_class	ext/tiovx/gsttiovxldc.c	184;"	d	file:
+gst_tiovx_ldc_request_new_pad	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_request_new_pad (GstElement * element,$/;"	f	file:
+gst_tiovx_ldc_set_property	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_ldc_suite	tests/check/gsttiovxldc.c	/^gst_tiovx_ldc_suite (void)$/;"	f	file:
+gst_tiovx_ldc_target_get_type	ext/tiovx/gsttiovxldc.c	/^gst_tiovx_ldc_target_get_type (void)$/;"	f	file:
+gst_tiovx_mem_alloc_class_init	ext/tiovx/gsttiovxmemalloc.c	/^gst_tiovx_mem_alloc_class_init (GstTIOVXMemAllocClass * klass)$/;"	f	file:
+gst_tiovx_mem_alloc_debug_category	ext/tiovx/gsttiovxmemalloc.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_mem_alloc_debug_category);$/;"	v
+gst_tiovx_mem_alloc_finalize	ext/tiovx/gsttiovxmemalloc.c	/^gst_tiovx_mem_alloc_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_mem_alloc_get_property	ext/tiovx/gsttiovxmemalloc.c	/^gst_tiovx_mem_alloc_get_property (GObject * object, guint property_id,$/;"	f	file:
+gst_tiovx_mem_alloc_init	ext/tiovx/gsttiovxmemalloc.c	/^gst_tiovx_mem_alloc_init (GstTIOVXMemAlloc * self)$/;"	f	file:
+gst_tiovx_mem_alloc_propose_allocation	ext/tiovx/gsttiovxmemalloc.c	/^gst_tiovx_mem_alloc_propose_allocation (GstBaseTransform * trans,$/;"	f	file:
+gst_tiovx_mem_alloc_set_caps	ext/tiovx/gsttiovxmemalloc.c	/^gst_tiovx_mem_alloc_set_caps (GstBaseTransform * trans,$/;"	f	file:
+gst_tiovx_mem_alloc_set_property	ext/tiovx/gsttiovxmemalloc.c	/^gst_tiovx_mem_alloc_set_property (GObject * object, guint property_id,$/;"	f	file:
+gst_tiovx_memory_get_data	gst-libs/gst/tiovx/gsttiovxallocator.c	/^gst_tiovx_memory_get_data (GstMemory * memory)$/;"	f
+gst_tiovx_meta_free	gst-libs/gst/tiovx/gsttiovxmuxmeta.c	/^gst_tiovx_meta_free (GstMeta * meta, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_meta_init	gst-libs/gst/tiovx/gsttiovxmuxmeta.c	/^gst_tiovx_meta_init (GstMeta * meta, gpointer params, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_meta_init	gst-libs/gst/tiovx/gsttiovxrawimagemeta.c	/^gst_tiovx_meta_init (GstMeta * meta, gpointer params, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_miso_aggregate	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_aggregate (GstAggregator * agg, gboolean timeout)$/;"	f	file:
+gst_tiovx_miso_buffer_to_valid_pad_exemplar	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_buffer_to_valid_pad_exemplar (GstTIOVXMisoPad * pad,$/;"	f	file:
+gst_tiovx_miso_child_proxy_get_child_by_index	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_child_proxy_get_child_by_index (GstChildProxy *$/;"	f	file:
+gst_tiovx_miso_child_proxy_get_child_by_name	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_child_proxy_get_child_by_name (GstChildProxy *$/;"	f	file:
+gst_tiovx_miso_child_proxy_get_children_count	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_child_proxy_get_children_count (GstChildProxy * child_proxy)$/;"	f	file:
+gst_tiovx_miso_child_proxy_init	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_child_proxy_init (gpointer g_iface, gpointer iface_data)$/;"	f	file:
+gst_tiovx_miso_class_init	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_class_init (GstTIOVXMisoClass * klass)$/;"	f	file:
+gst_tiovx_miso_create_output_buffer	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_create_output_buffer (GstTIOVXMiso * self, GstBuffer ** outbuf)$/;"	f	file:
+gst_tiovx_miso_debug_category	gst-libs/gst/tiovx/gsttiovxmiso.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_miso_debug_category);$/;"	v
+gst_tiovx_miso_decide_allocation	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_decide_allocation (GstAggregator * agg, GstQuery * query)$/;"	f	file:
+gst_tiovx_miso_default_fixate_caps	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_default_fixate_caps (GstTIOVXMiso * self, GList * sink_caps_list,$/;"	f	file:
+gst_tiovx_miso_finalize	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_miso_fixate_src_caps	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_fixate_src_caps (GstAggregator * agg, GstCaps * src_caps)$/;"	f
+gst_tiovx_miso_get_sink_caps_list	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_get_sink_caps_list (GstTIOVXMiso * self)$/;"	f	file:
+gst_tiovx_miso_init	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_init (GstTIOVXMiso * self)$/;"	f	file:
+gst_tiovx_miso_modules_init	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_modules_init (GstTIOVXMiso * self)$/;"	f	file:
+gst_tiovx_miso_negotiated_src_caps	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_negotiated_src_caps (GstAggregator * agg, GstCaps * caps)$/;"	f
+gst_tiovx_miso_pad_class_init	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_pad_class_init (GstTIOVXMisoPadClass * klass)$/;"	f	file:
+gst_tiovx_miso_pad_debug_category	gst-libs/gst/tiovx/gsttiovxmiso.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_miso_pad_debug_category);$/;"	v
+gst_tiovx_miso_pad_finalize	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_pad_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_miso_pad_get_property	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_pad_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_miso_pad_init	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_pad_init (GstTIOVXMisoPad * tiovx_miso_pad)$/;"	f	file:
+gst_tiovx_miso_pad_set_params	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_pad_set_params (GstTIOVXMisoPad * pad, vx_object_array array,$/;"	f
+gst_tiovx_miso_pad_set_property	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_pad_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_miso_process_graph	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_process_graph (GstAggregator * agg)$/;"	f	file:
+gst_tiovx_miso_propose_allocation	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_propose_allocation (GstAggregator * agg,$/;"	f	file:
+gst_tiovx_miso_release_pad	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_release_pad (GstElement * element, GstPad * pad)$/;"	f	file:
+gst_tiovx_miso_request_new_pad	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_request_new_pad (GstElement * element,$/;"	f	file:
+gst_tiovx_miso_start	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_start (GstAggregator * agg)$/;"	f	file:
+gst_tiovx_miso_stop	gst-libs/gst/tiovx/gsttiovxmiso.c	/^gst_tiovx_miso_stop (GstAggregator * agg)$/;"	f	file:
+gst_tiovx_mosaic_check_dimension	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_check_dimension (GstTIOVXMosaic * self,$/;"	f	file:
+gst_tiovx_mosaic_class_init	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_class_init (GstTIOVXMosaicClass * klass)$/;"	f	file:
+gst_tiovx_mosaic_configure_module	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_configure_module (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_mosaic_create_graph	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_create_graph (GstTIOVXMiso * agg, vx_context context,$/;"	f	file:
+gst_tiovx_mosaic_debug	ext/tiovx/gsttiovxmosaic.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_mosaic_debug);$/;"	v
+gst_tiovx_mosaic_deinit_module	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_deinit_module (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_mosaic_finalize	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_finalize (GObject * object)$/;"	f	file:
+gst_tiovx_mosaic_fixate_caps	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_fixate_caps (GstTIOVXMiso * self,$/;"	f	file:
+gst_tiovx_mosaic_fixate_structure_fields	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_fixate_structure_fields (GstStructure * structure, gint width,$/;"	f	file:
+gst_tiovx_mosaic_get_node_info	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_get_node_info (GstTIOVXMiso * agg,$/;"	f	file:
+gst_tiovx_mosaic_get_property	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_mosaic_init	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_init (GstTIOVXMosaic * self)$/;"	f	file:
+gst_tiovx_mosaic_init_module	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_init_module (GstTIOVXMiso * agg, vx_context context,$/;"	f	file:
+gst_tiovx_mosaic_load_background_image	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_load_background_image (GstTIOVXMosaic * self,$/;"	f	file:
+gst_tiovx_mosaic_load_mosaic_module_objects	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_load_mosaic_module_objects (GstTIOVXMosaic * self)$/;"	f	file:
+gst_tiovx_mosaic_modeling_init	tests/check/gsttiovxmosaic.c	/^gst_tiovx_mosaic_modeling_init (TIOVXMosaicModeled * element)$/;"	f	file:
+gst_tiovx_mosaic_pad_class_init	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_pad_class_init (GstTIOVXMosaicPadClass * klass)$/;"	f	file:
+gst_tiovx_mosaic_pad_debug_category	ext/tiovx/gsttiovxmosaic.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_mosaic_pad_debug_category);$/;"	v
+gst_tiovx_mosaic_pad_get_properties_array	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_pad_get_properties_array (GstTIOVXMosaicPad * self,$/;"	f	file:
+gst_tiovx_mosaic_pad_get_property	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_pad_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_mosaic_pad_init	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_pad_init (GstTIOVXMosaicPad * self)$/;"	f	file:
+gst_tiovx_mosaic_pad_set_properties_array	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_pad_set_properties_array (GstTIOVXMosaicPad * self,$/;"	f	file:
+gst_tiovx_mosaic_pad_set_property	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_pad_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_mosaic_parent_class	ext/tiovx/gsttiovxmosaic.c	537;"	d	file:
+gst_tiovx_mosaic_release_buffer	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_release_buffer (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_mosaic_set_property	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_mosaic_target_get_type	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_target_get_type (void)$/;"	f	file:
+gst_tiovx_mosaic_validate_candidate_dimension	ext/tiovx/gsttiovxmosaic.c	/^gst_tiovx_mosaic_validate_candidate_dimension (GstTIOVXMiso * self,$/;"	f	file:
+gst_tiovx_multi_scaler_class_init	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_class_init (GstTIOVXMultiScalerClass * klass)$/;"	f	file:
+gst_tiovx_multi_scaler_compare_caps	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_compare_caps (GstTIOVXSimo * simo, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_multi_scaler_configure_module	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_configure_module (GstTIOVXSimo * simo)$/;"	f	file:
+gst_tiovx_multi_scaler_create_graph	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_create_graph (GstTIOVXSimo * simo, vx_context context,$/;"	f	file:
+gst_tiovx_multi_scaler_debug	ext/tiovx/gsttiovxmultiscaler.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_multi_scaler_debug);$/;"	v
+gst_tiovx_multi_scaler_deinit_module	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_deinit_module (GstTIOVXSimo * simo)$/;"	f	file:
+gst_tiovx_multi_scaler_fixate_caps	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_fixate_caps (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_multi_scaler_get_node_info	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_get_node_info (GstTIOVXSimo * simo, vx_node * node,$/;"	f	file:
+gst_tiovx_multi_scaler_get_property	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_multi_scaler_get_sink_caps	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_get_sink_caps (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_multi_scaler_get_src_caps	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_get_src_caps (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_multi_scaler_init	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_init (GstTIOVXMultiScaler * self)$/;"	f	file:
+gst_tiovx_multi_scaler_init_module	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_init_module (GstTIOVXSimo * simo, vx_context context,$/;"	f	file:
+gst_tiovx_multi_scaler_interpolation_method_get_type	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_interpolation_method_get_type (void)$/;"	f	file:
+gst_tiovx_multi_scaler_parent_class	ext/tiovx/gsttiovxmultiscaler.c	187;"	d	file:
+gst_tiovx_multi_scaler_set_property	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_multi_scaler_target_get_type	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tiovx_multi_scaler_target_get_type (void)$/;"	f	file:
+gst_tiovx_multiscaler_pad_class_init	ext/tiovx/gsttiovxmultiscalerpad.c	/^gst_tiovx_multiscaler_pad_class_init (GstTIOVXMultiScalerPadClass * klass)$/;"	f	file:
+gst_tiovx_multiscaler_pad_debug_category	ext/tiovx/gsttiovxmultiscalerpad.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_multiscaler_pad_debug_category);$/;"	v
+gst_tiovx_multiscaler_pad_get_property	ext/tiovx/gsttiovxmultiscalerpad.c	/^gst_tiovx_multiscaler_pad_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_multiscaler_pad_init	ext/tiovx/gsttiovxmultiscalerpad.c	/^gst_tiovx_multiscaler_pad_init (GstTIOVXMultiScalerPad * self)$/;"	f	file:
+gst_tiovx_multiscaler_pad_set_property	ext/tiovx/gsttiovxmultiscalerpad.c	/^gst_tiovx_multiscaler_pad_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_mux	tests/check/gsttiovxmux.c	/^GST_CHECK_MAIN (gst_tiovx_mux);$/;"	v
+gst_tiovx_mux_aggregate	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_aggregate (GstAggregator * agg, gboolean timeout)$/;"	f	file:
+gst_tiovx_mux_child_proxy_get_child_by_index	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_child_proxy_get_child_by_index (GstChildProxy *$/;"	f	file:
+gst_tiovx_mux_child_proxy_get_children_count	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_child_proxy_get_children_count (GstChildProxy * child_proxy)$/;"	f	file:
+gst_tiovx_mux_child_proxy_init	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_child_proxy_init (gpointer g_iface, gpointer iface_data)$/;"	f	file:
+gst_tiovx_mux_class_init	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_class_init (GstTIOVXMuxClass * klass)$/;"	f	file:
+gst_tiovx_mux_debug_category	ext/tiovx/gsttiovxmux.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_mux_debug_category);$/;"	v
+gst_tiovx_mux_finalize	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_mux_fixate_src_caps	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_fixate_src_caps (GstAggregator * agg, GstCaps * filter)$/;"	f
+gst_tiovx_mux_get_sink_caps_list	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_get_sink_caps_list (GstTIOVXMux * self)$/;"	f	file:
+gst_tiovx_mux_get_src_caps	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_get_src_caps (GstTIOVXMux * self, GstCaps * filter)$/;"	f	file:
+gst_tiovx_mux_init	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_init (GstTIOVXMux * self)$/;"	f	file:
+gst_tiovx_mux_meta_api_get_type	gst-libs/gst/tiovx/gsttiovxmuxmeta.c	/^gst_tiovx_mux_meta_api_get_type (void)$/;"	f
+gst_tiovx_mux_meta_get_info	gst-libs/gst/tiovx/gsttiovxmuxmeta.c	/^gst_tiovx_mux_meta_get_info (void)$/;"	f
+gst_tiovx_mux_negotiated_src_caps	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_negotiated_src_caps (GstAggregator * agg, GstCaps * caps)$/;"	f	file:
+gst_tiovx_mux_pad_class_init	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_pad_class_init (GstTIOVXMuxPadClass * klass)$/;"	f	file:
+gst_tiovx_mux_pad_debug_category	ext/tiovx/gsttiovxmux.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_mux_pad_debug_category);$/;"	v
+gst_tiovx_mux_pad_finalize	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_pad_finalize (GObject * object)$/;"	f	file:
+gst_tiovx_mux_pad_get_property	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_pad_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_mux_pad_init	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_pad_init (GstTIOVXMuxPad * self)$/;"	f	file:
+gst_tiovx_mux_pad_set_property	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_pad_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_mux_propose_allocation	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_propose_allocation (GstAggregator * agg,$/;"	f	file:
+gst_tiovx_mux_release_pad	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_release_pad (GstElement * element, GstPad * pad)$/;"	f	file:
+gst_tiovx_mux_request_new_pad	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_request_new_pad (GstElement * element,$/;"	f	file:
+gst_tiovx_mux_src_query	ext/tiovx/gsttiovxmux.c	/^gst_tiovx_mux_src_query (GstAggregator * agg, GstQuery * query)$/;"	f	file:
+gst_tiovx_mux_suite	tests/check/gsttiovxmux.c	/^gst_tiovx_mux_suite (void)$/;"	f	file:
+gst_tiovx_pad	tests/check/libs/gsttiovxpad.c	/^GST_CHECK_MAIN (gst_tiovx_pad);$/;"	v
+gst_tiovx_pad_acquire_buffer	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_acquire_buffer (GstTIOVXPad * self, GstBuffer ** buffer,$/;"	f
+gst_tiovx_pad_chain	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_chain (GstPad * pad, GstObject * parent, GstBuffer ** buffer)$/;"	f
+gst_tiovx_pad_class_init	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_class_init (GstTIOVXPadClass * klass)$/;"	f	file:
+gst_tiovx_pad_debug_category	gst-libs/gst/tiovx/gsttiovxpad.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_pad_debug_category);$/;"	v
+gst_tiovx_pad_finalize	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_finalize (GObject * object)$/;"	f	file:
+gst_tiovx_pad_get_exemplar	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_get_exemplar (GstTIOVXPad * pad)$/;"	f
+gst_tiovx_pad_get_params	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_get_params (GstTIOVXPad * pad, vx_object_array * array,$/;"	f
+gst_tiovx_pad_get_property	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_pad_init	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_init (GstTIOVXPad * self)$/;"	f	file:
+gst_tiovx_pad_peer_query_allocation	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_peer_query_allocation (GstTIOVXPad * self, GstCaps * caps)$/;"	f
+gst_tiovx_pad_process_allocation_query	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_process_allocation_query (GstTIOVXPad * self, GstQuery * query)$/;"	f	file:
+gst_tiovx_pad_query	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_query (GstPad * pad, GstObject * parent, GstQuery * query)$/;"	f
+gst_tiovx_pad_set_exemplar	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_set_exemplar (GstTIOVXPad * self, vx_reference exemplar)$/;"	f
+gst_tiovx_pad_set_params	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_set_params (GstTIOVXPad * pad, vx_object_array array,$/;"	f
+gst_tiovx_pad_set_property	gst-libs/gst/tiovx/gsttiovxpad.c	/^gst_tiovx_pad_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_pad_suite	tests/check/libs/gsttiovxpad.c	/^gst_tiovx_pad_suite (void)$/;"	f	file:
+gst_tiovx_performance	gst-libs/gst/tiovx/gsttiovxutils.c	/^GST_DEBUG_CATEGORY (gst_tiovx_performance);$/;"	v
+gst_tiovx_pyramid	tests/check/gsttiovxpyramid.c	/^GST_CHECK_MAIN (gst_tiovx_pyramid);$/;"	v
+gst_tiovx_pyramid_buffer_pool	tests/check/libs/gsttiovxpyramidbufferpool.c	/^GST_CHECK_MAIN (gst_tiovx_pyramid_buffer_pool);$/;"	v
+gst_tiovx_pyramid_buffer_pool_add_meta_to_buffer	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	/^gst_tiovx_pyramid_buffer_pool_add_meta_to_buffer (GstTIOVXBufferPool * self,$/;"	f
+gst_tiovx_pyramid_buffer_pool_class_init	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	/^gst_tiovx_pyramid_buffer_pool_class_init (GstTIOVXPyramidBufferPoolClass *$/;"	f	file:
+gst_tiovx_pyramid_buffer_pool_debug_category	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_pyramid_buffer_pool_debug_category);$/;"	v
+gst_tiovx_pyramid_buffer_pool_free_buffer_meta	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	/^gst_tiovx_pyramid_buffer_pool_free_buffer_meta (GstTIOVXBufferPool * self,$/;"	f
+gst_tiovx_pyramid_buffer_pool_init	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	/^gst_tiovx_pyramid_buffer_pool_init (GstTIOVXPyramidBufferPool * self)$/;"	f	file:
+gst_tiovx_pyramid_buffer_pool_parent_class	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	88;"	d	file:
+gst_tiovx_pyramid_buffer_pool_suite	tests/check/libs/gsttiovxpyramidbufferpool.c	/^gst_tiovx_pyramid_buffer_pool_suite (void)$/;"	f	file:
+gst_tiovx_pyramid_buffer_pool_test_category	tests/check/libs/gsttiovxpyramidbufferpool.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_pyramid_buffer_pool_test_category);$/;"	v
+gst_tiovx_pyramid_buffer_pool_validate_caps	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	/^gst_tiovx_pyramid_buffer_pool_validate_caps (GstTIOVXBufferPool * self,$/;"	f	file:
+gst_tiovx_pyramid_class_init	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_class_init (GstTIOVXPyramidClass * klass)$/;"	f	file:
+gst_tiovx_pyramid_compare_caps	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_compare_caps (GstTIOVXSiso * trans, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_pyramid_create_graph	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_create_graph (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_tiovx_pyramid_debug	ext/tiovx/gsttiovxpyramid.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_pyramid_debug);$/;"	v
+gst_tiovx_pyramid_deinit_module	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_deinit_module (GstTIOVXSiso * trans, vx_context context)$/;"	f	file:
+gst_tiovx_pyramid_fixate_caps	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_fixate_caps (GstBaseTransform * base,$/;"	f	file:
+gst_tiovx_pyramid_get_node_info	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_get_node_info (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_pyramid_get_property	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_pyramid_init	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_init (GstTIOVXPyramid * self)$/;"	f	file:
+gst_tiovx_pyramid_init_module	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_init_module (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_tiovx_pyramid_meta_api_get_type	gst-libs/gst/tiovx/gsttiovxpyramidmeta.c	/^gst_tiovx_pyramid_meta_api_get_type (void)$/;"	f
+gst_tiovx_pyramid_meta_get_info	gst-libs/gst/tiovx/gsttiovxpyramidmeta.c	/^gst_tiovx_pyramid_meta_get_info (void)$/;"	f
+gst_tiovx_pyramid_meta_init	gst-libs/gst/tiovx/gsttiovxpyramidmeta.c	/^gst_tiovx_pyramid_meta_init (GstMeta * meta, gpointer params,$/;"	f	file:
+gst_tiovx_pyramid_parent_class	ext/tiovx/gsttiovxpyramid.c	174;"	d	file:
+gst_tiovx_pyramid_release_buffer	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_release_buffer (GstTIOVXSiso * trans)$/;"	f	file:
+gst_tiovx_pyramid_set_max_levels	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_set_max_levels (GstTIOVXPyramid * self,$/;"	f	file:
+gst_tiovx_pyramid_set_property	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_pyramid_suite	tests/check/gsttiovxpyramid.c	/^gst_tiovx_pyramid_suite (void)$/;"	f	file:
+gst_tiovx_pyramid_target_get_type	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_target_get_type (void)$/;"	f	file:
+gst_tiovx_pyramid_transform_caps	ext/tiovx/gsttiovxpyramid.c	/^gst_tiovx_pyramid_transform_caps (GstBaseTransform *$/;"	f	file:
+gst_tiovx_queueable_class_init	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^gst_tiovx_queueable_class_init (GstTIOVXQueueableClass * klass)$/;"	f	file:
+gst_tiovx_queueable_get_params	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^gst_tiovx_queueable_get_params (GstTIOVXQueueable * obj,$/;"	f
+gst_tiovx_queueable_init	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^gst_tiovx_queueable_init (GstTIOVXQueueable * self)$/;"	f	file:
+gst_tiovx_queueable_set_params	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^gst_tiovx_queueable_set_params (GstTIOVXQueueable * obj,$/;"	f
+gst_tiovx_raw_image_buffer_pool_add_meta_to_buffer	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^gst_tiovx_raw_image_buffer_pool_add_meta_to_buffer (GstTIOVXBufferPool * self,$/;"	f	file:
+gst_tiovx_raw_image_buffer_pool_class_init	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^gst_tiovx_raw_image_buffer_pool_class_init (GstTIOVXRawImageBufferPoolClass *$/;"	f	file:
+gst_tiovx_raw_image_buffer_pool_debug	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_raw_image_buffer_pool_debug);$/;"	v
+gst_tiovx_raw_image_buffer_pool_free_buffer_meta	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^gst_tiovx_raw_image_buffer_pool_free_buffer_meta (GstTIOVXBufferPool * self,$/;"	f	file:
+gst_tiovx_raw_image_buffer_pool_init	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^gst_tiovx_raw_image_buffer_pool_init (GstTIOVXRawImageBufferPool * self)$/;"	f	file:
+gst_tiovx_raw_image_buffer_pool_parent_class	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	86;"	d	file:
+gst_tiovx_raw_image_buffer_pool_validate_caps	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^gst_tiovx_raw_image_buffer_pool_validate_caps (GstTIOVXBufferPool * self,$/;"	f	file:
+gst_tiovx_raw_image_meta_api_get_type	gst-libs/gst/tiovx/gsttiovxrawimagemeta.c	/^gst_tiovx_raw_image_meta_api_get_type (void)$/;"	f
+gst_tiovx_raw_image_meta_get_info	gst-libs/gst/tiovx/gsttiovxrawimagemeta.c	/^gst_tiovx_raw_image_meta_get_info (void)$/;"	f
+gst_tiovx_raw_meta_extract_image_params	gst-libs/gst/tiovx/gsttiovxrawimagemeta.c	/^gst_tiovx_raw_meta_extract_image_params (const tivx_raw_image image,$/;"	f	file:
+gst_tiovx_sde_class_init	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_class_init (GstTIOVXSdeClass * klass)$/;"	f	file:
+gst_tiovx_sde_configure_module	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_configure_module (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_sde_create_graph	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_create_graph (GstTIOVXMiso * agg, vx_context context,$/;"	f	file:
+gst_tiovx_sde_debug	ext/tiovx/gsttiovxsde.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_sde_debug);$/;"	v
+gst_tiovx_sde_deinit_module	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_deinit_module (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_sde_finalize	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_finalize (GObject * object)$/;"	f	file:
+gst_tiovx_sde_fixate_caps	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_fixate_caps (GstTIOVXMiso * miso,$/;"	f	file:
+gst_tiovx_sde_get_node_info	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_get_node_info (GstTIOVXMiso * agg,$/;"	f	file:
+gst_tiovx_sde_get_property	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_sde_init	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_init (GstTIOVXSde * self)$/;"	f	file:
+gst_tiovx_sde_init_module	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_init_module (GstTIOVXMiso * agg, vx_context context,$/;"	f	file:
+gst_tiovx_sde_max_disparity_get_type	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_max_disparity_get_type (void)$/;"	f	file:
+gst_tiovx_sde_min_disparity_get_type	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_min_disparity_get_type (void)$/;"	f	file:
+gst_tiovx_sde_parent_class	ext/tiovx/gsttiovxsde.c	293;"	d	file:
+gst_tiovx_sde_release_buffer	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_release_buffer (GstTIOVXMiso * agg)$/;"	f	file:
+gst_tiovx_sde_set_property	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_sde_target_get_type	ext/tiovx/gsttiovxsde.c	/^gst_tiovx_sde_target_get_type (void)$/;"	f	file:
+gst_tiovx_sde_viz_class_init	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_class_init (GstTIOVXSdeVizClass * klass)$/;"	f	file:
+gst_tiovx_sde_viz_compare_caps	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_compare_caps (GstTIOVXSiso * trans, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_sde_viz_create_graph	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_create_graph (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_tiovx_sde_viz_debug	ext/tiovx/gsttiovxsdeviz.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_sde_viz_debug);$/;"	v
+gst_tiovx_sde_viz_deinit_module	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_deinit_module (GstTIOVXSiso * trans, vx_context context)$/;"	f	file:
+gst_tiovx_sde_viz_get_node_info	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_get_node_info (GstTIOVXSiso * trans,$/;"	f	file:
+gst_tiovx_sde_viz_get_property	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_get_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_sde_viz_init	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_init (GstTIOVXSdeViz * self)$/;"	f	file:
+gst_tiovx_sde_viz_init_module	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_init_module (GstTIOVXSiso * trans, vx_context context,$/;"	f	file:
+gst_tiovx_sde_viz_max_disparity_get_type	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_max_disparity_get_type (void)$/;"	f	file:
+gst_tiovx_sde_viz_min_disparity_get_type	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_min_disparity_get_type (void)$/;"	f	file:
+gst_tiovx_sde_viz_parent_class	ext/tiovx/gsttiovxsdeviz.c	241;"	d	file:
+gst_tiovx_sde_viz_release_buffer	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_release_buffer (GstTIOVXSiso * trans)$/;"	f	file:
+gst_tiovx_sde_viz_set_property	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_set_property (GObject * object, guint prop_id,$/;"	f	file:
+gst_tiovx_sde_viz_target_get_type	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_target_get_type (void)$/;"	f	file:
+gst_tiovx_sde_viz_transform_caps	ext/tiovx/gsttiovxsdeviz.c	/^gst_tiovx_sde_viz_transform_caps (GstBaseTransform * base,$/;"	f	file:
+gst_tiovx_sensor_meta_api_get_type	gst-libs/gst/tiovx/gsttiovxsensormeta.c	/^gst_tiovx_sensor_meta_api_get_type (void)$/;"	f
+gst_tiovx_sensor_meta_free	gst-libs/gst/tiovx/gsttiovxsensormeta.c	/^gst_tiovx_sensor_meta_free (GstMeta * meta, GstBuffer * buffer)$/;"	f
+gst_tiovx_sensor_meta_get_info	gst-libs/gst/tiovx/gsttiovxsensormeta.c	/^gst_tiovx_sensor_meta_get_info (void)$/;"	f
+gst_tiovx_sensor_meta_init	gst-libs/gst/tiovx/gsttiovxsensormeta.c	/^gst_tiovx_sensor_meta_init (GstMeta * meta, gpointer params, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_simo_chain	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_chain (GstPad * pad, GstObject * parent, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_simo_change_state	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_change_state (GstElement * element, GstStateChange transition)$/;"	f	file:
+gst_tiovx_simo_child_proxy_get_child_by_index	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_child_proxy_get_child_by_index (GstChildProxy *$/;"	f	file:
+gst_tiovx_simo_child_proxy_get_child_by_name	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_child_proxy_get_child_by_name (GstChildProxy *$/;"	f	file:
+gst_tiovx_simo_child_proxy_get_children_count	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_child_proxy_get_children_count (GstChildProxy * child_proxy)$/;"	f	file:
+gst_tiovx_simo_child_proxy_init	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_child_proxy_init (gpointer g_iface, gpointer iface_data)$/;"	f	file:
+gst_tiovx_simo_class_init	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_class_init (GstTIOVXSimoClass * klass)$/;"	f	file:
+gst_tiovx_simo_debug_category	gst-libs/gst/tiovx/gsttiovxsimo.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_simo_debug_category);$/;"	v
+gst_tiovx_simo_default_fixate_caps	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_default_fixate_caps (GstTIOVXSimo * self, GstCaps * sink_caps,$/;"	f	file:
+gst_tiovx_simo_default_get_sink_caps	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_default_get_sink_caps (GstTIOVXSimo * self,$/;"	f	file:
+gst_tiovx_simo_default_get_src_caps	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_default_get_src_caps (GstTIOVXSimo * self,$/;"	f	file:
+gst_tiovx_simo_finalize	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_finalize (GObject * gobject)$/;"	f	file:
+gst_tiovx_simo_free_buffer_list	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_free_buffer_list (GstBuffer ** buffer_list, gint list_length)$/;"	f	file:
+gst_tiovx_simo_get_instance_private	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_get_instance_private (GstTIOVXSimo * self)$/;"	f	file:
+gst_tiovx_simo_get_num_pads	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_get_num_pads (GstTIOVXSimo * self)$/;"	f
+gst_tiovx_simo_get_src_caps_list	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_get_src_caps_list (GstTIOVXSimo * self)$/;"	f	file:
+gst_tiovx_simo_get_type	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_get_type (void)$/;"	f
+gst_tiovx_simo_init	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_init (GstTIOVXSimo * self, GstTIOVXSimoClass * klass)$/;"	f	file:
+gst_tiovx_simo_modules_deinit	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_modules_deinit (GstTIOVXSimo * self)$/;"	f	file:
+gst_tiovx_simo_modules_init	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_modules_init (GstTIOVXSimo * self, GstCaps * sink_caps,$/;"	f	file:
+gst_tiovx_simo_pads_to_vx_references	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_pads_to_vx_references (GstTIOVXSimo * self, GList * pads,$/;"	f	file:
+gst_tiovx_simo_process_graph	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_process_graph (GstTIOVXSimo * self)$/;"	f	file:
+gst_tiovx_simo_push_buffers	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_push_buffers (GstTIOVXSimo * simo, GList * pads,$/;"	f	file:
+gst_tiovx_simo_release_pad	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_release_pad (GstElement * element, GstPad * pad)$/;"	f	file:
+gst_tiovx_simo_request_new_pad	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_request_new_pad (GstElement * element, GstPadTemplate * templ,$/;"	f	file:
+gst_tiovx_simo_set_caps	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_set_caps (GstTIOVXSimo * self, GstPad * pad, GstCaps * sink_caps,$/;"	f	file:
+gst_tiovx_simo_sink_event	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_sink_event (GstPad * pad, GstObject * parent, GstEvent * event)$/;"	f	file:
+gst_tiovx_simo_sink_query	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_sink_query (GstPad * pad, GstObject * parent, GstQuery * query)$/;"	f	file:
+gst_tiovx_simo_src_query	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_src_query (GstPad * pad, GstObject * parent, GstQuery * query)$/;"	f	file:
+gst_tiovx_simo_start	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_start (GstTIOVXSimo * self)$/;"	f	file:
+gst_tiovx_simo_stop	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_stop (GstTIOVXSimo * self)$/;"	f	file:
+gst_tiovx_simo_trigger_downstream_pads	gst-libs/gst/tiovx/gsttiovxsimo.c	/^gst_tiovx_simo_trigger_downstream_pads (GList * srcpads)$/;"	f	file:
+gst_tiovx_siso_class_init	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_class_init (GstTIOVXSisoClass * klass)$/;"	f	file:
+gst_tiovx_siso_debug_category	gst-libs/gst/tiovx/gsttiovxsiso.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_siso_debug_category);$/;"	v
+gst_tiovx_siso_decide_allocation	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_decide_allocation (GstBaseTransform * trans, GstQuery * query)$/;"	f	file:
+gst_tiovx_siso_finalize	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_finalize (GObject * obj)$/;"	f	file:
+gst_tiovx_siso_get_property	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_get_property (GObject * object, guint property_id,$/;"	f	file:
+gst_tiovx_siso_init	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_init (GstTIOVXSiso * self)$/;"	f	file:
+gst_tiovx_siso_is_subclass_complete	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_is_subclass_complete (GstTIOVXSiso * self)$/;"	f	file:
+gst_tiovx_siso_modules_deinit	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_modules_deinit (GstTIOVXSiso * self)$/;"	f	file:
+gst_tiovx_siso_modules_init	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_modules_init (GstTIOVXSiso * self)$/;"	f	file:
+gst_tiovx_siso_process_graph	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_process_graph (GstTIOVXSiso * self)$/;"	f	file:
+gst_tiovx_siso_propose_allocation	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_propose_allocation (GstBaseTransform * trans,$/;"	f	file:
+gst_tiovx_siso_set_caps	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_set_caps (GstBaseTransform * trans, GstCaps * incaps,$/;"	f	file:
+gst_tiovx_siso_set_property	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_set_property (GObject * object, guint property_id,$/;"	f	file:
+gst_tiovx_siso_stop	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_stop (GstBaseTransform * trans)$/;"	f	file:
+gst_tiovx_siso_transform	gst-libs/gst/tiovx/gsttiovxsiso.c	/^gst_tiovx_siso_transform (GstBaseTransform * trans, GstBuffer * inbuf,$/;"	f	file:
+gst_tiovx_tensor_buffer_pool	tests/check/libs/gsttiovxtensorbufferpool.c	/^GST_CHECK_MAIN (gst_tiovx_tensor_buffer_pool);$/;"	v
+gst_tiovx_tensor_buffer_pool_add_meta_to_buffer	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	/^gst_tiovx_tensor_buffer_pool_add_meta_to_buffer (GstTIOVXBufferPool * self,$/;"	f
+gst_tiovx_tensor_buffer_pool_class_init	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	/^gst_tiovx_tensor_buffer_pool_class_init (GstTIOVXTensorBufferPoolClass * klass)$/;"	f	file:
+gst_tiovx_tensor_buffer_pool_debug_category	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	/^GST_DEBUG_CATEGORY_STATIC (gst_tiovx_tensor_buffer_pool_debug_category);$/;"	v
+gst_tiovx_tensor_buffer_pool_free_buffer_meta	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	/^gst_tiovx_tensor_buffer_pool_free_buffer_meta (GstTIOVXBufferPool * self,$/;"	f
+gst_tiovx_tensor_buffer_pool_init	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	/^gst_tiovx_tensor_buffer_pool_init (GstTIOVXTensorBufferPool * self)$/;"	f	file:
+gst_tiovx_tensor_buffer_pool_parent_class	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	86;"	d	file:
+gst_tiovx_tensor_buffer_pool_suite	tests/check/libs/gsttiovxtensorbufferpool.c	/^gst_tiovx_tensor_buffer_pool_suite (void)$/;"	f	file:
+gst_tiovx_tensor_buffer_pool_validate_caps	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	/^gst_tiovx_tensor_buffer_pool_validate_caps (GstTIOVXBufferPool * self,$/;"	f	file:
+gst_tiovx_tensor_get_tensor_bit_depth	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_tensor_get_tensor_bit_depth (vx_enum data_type)$/;"	f
+gst_tiovx_tensor_meta_api_get_type	gst-libs/gst/tiovx/gsttiovxtensormeta.c	/^gst_tiovx_tensor_meta_api_get_type (void)$/;"	f
+gst_tiovx_tensor_meta_get_dim_stride	gst-libs/gst/tiovx/gsttiovxtensormeta.c	/^gst_tiovx_tensor_meta_get_dim_stride (const vx_tensor tensor,$/;"	f	file:
+gst_tiovx_tensor_meta_get_info	gst-libs/gst/tiovx/gsttiovxtensormeta.c	/^gst_tiovx_tensor_meta_get_info (void)$/;"	f
+gst_tiovx_tensor_meta_init	gst-libs/gst/tiovx/gsttiovxtensormeta.c	/^gst_tiovx_tensor_meta_init (GstMeta * meta, gpointer params, GstBuffer * buffer)$/;"	f	file:
+gst_tiovx_test_simo_class_init	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_class_init (GstTestTIOVXSimoClass * klass)$/;"	f	file:
+gst_tiovx_test_simo_compare_caps	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_compare_caps (GstTIOVXSimo * element, GstCaps * caps1,$/;"	f	file:
+gst_tiovx_test_simo_configure_module	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_configure_module (GstTIOVXSimo * element)$/;"	f	file:
+gst_tiovx_test_simo_create_graph	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_create_graph (GstTIOVXSimo * element, vx_context context,$/;"	f	file:
+gst_tiovx_test_simo_deinit_module	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_deinit_module (GstTIOVXSimo * element)$/;"	f	file:
+gst_tiovx_test_simo_fixate_caps	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_fixate_caps (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tiovx_test_simo_get_node_info	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_get_node_info (GstTIOVXSimo * element, vx_node * node,$/;"	f	file:
+gst_tiovx_test_simo_init	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_init (GstTestTIOVXSimo * self)$/;"	f	file:
+gst_tiovx_test_simo_init_module	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_init_module (GstTIOVXSimo * element, vx_context context,$/;"	f	file:
+gst_tiovx_test_simo_parent_class	tests/check/libs/gsttiovxsimo.c	117;"	d	file:
+gst_tiovx_test_simo_plugin_init	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_plugin_init (GstPlugin * plugin)$/;"	f	file:
+gst_tiovx_test_simo_plugin_register	tests/check/libs/gsttiovxsimo.c	/^gst_tiovx_test_simo_plugin_register (void)$/;"	f	file:
+gst_tiovx_transfer_handle	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tiovx_transfer_handle (GstDebugCategory * category, vx_reference src,$/;"	f
+gst_tiovx_validate_tiovx_buffer	gst-libs/gst/tiovx/gsttiovxbufferutils.c	/^gst_tiovx_validate_tiovx_buffer (GstDebugCategory * category,$/;"	f
+gst_tioxv_get_pyramid_caps_info	gst-libs/gst/tiovx/gsttiovxutils.c	/^gst_tioxv_get_pyramid_caps_info (GObject * object, GstDebugCategory * category,$/;"	f
+gst_tivox_multi_scaler_compute_named	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tivox_multi_scaler_compute_named (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tivox_multi_scaler_compute_sink_dimension	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tivox_multi_scaler_compute_sink_dimension (GstTIOVXSimo * simo,$/;"	f	file:
+gst_tivox_multi_scaler_compute_src_dimension	ext/tiovx/gsttiovxmultiscaler.c	/^gst_tivox_multi_scaler_compute_src_dimension (GstTIOVXSimo * simo,$/;"	f	file:
+gst_valid_formats	tests/check/gsttiovxldc.c	/^static const gchar *gst_valid_formats[] = {$/;"	v	file:
+h3a_stats_memory	ext/tiovx/gsttiovxisp.c	/^  GstMemory *h3a_stats_memory;$/;"	m	struct:_GstTIOVXISP	file:
+h3a_stats_param_id	ext/tiovx/gsttiovxisp.c	/^static const int h3a_stats_param_id = 9;$/;"	v	file:
+has_background_image	ext/tiovx/gsttiovxmosaic.c	/^  gboolean has_background_image;$/;"	m	struct:_GstTIOVXMosaic	file:
+has_background_pad	ext/tiovx/gsttiovxmosaic.c	/^  gboolean has_background_pad;$/;"	m	struct:_GstTIOVXMosaic	file:
+height	ext/tiovx/gsttiovxmosaic.c	/^  gint height[MAX_NUM_CHANNELS];$/;"	m	struct:_GstTIOVXMosaicPad	file:
+height	gst-libs/gst/tiovx/gsttidloutmeta.h	/^  guint height;$/;"	m	struct:_GstTiDlOutMeta
+height	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  guint height;$/;"	m	struct:_GstTIOVXImageInfo
+height	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  guint height;$/;"	m	struct:_GstTIOVXPyramidInfo
+height	tests/check/gsttiovxdlcolorblend.c	/^  const guint *height;$/;"	m	struct:__anon52	file:
+height	tests/check/gsttiovxdlcolorblend.c	/^  const guint *height;$/;"	m	struct:__anon53	file:
+height	tests/check/gsttiovxdlcolorblend.c	/^  const guint *height;$/;"	m	struct:__anon54	file:
+height	tests/check/gsttiovxdlpreproc.c	/^  const guint *height;$/;"	m	struct:__anon43	file:
+height	tests/check/gsttiovxmosaic.c	/^  const guint *height;$/;"	m	struct:__anon40	file:
+height_range	tests/check/gsttiovxisp.c	/^  const Range *height_range;$/;"	m	struct:__anon48	file:
+held_buffers	ext/tiovx/gsttiovxdelay.c	/^  GQueue *held_buffers;$/;"	m	struct:_GstTIOVXDelay	file:
+horizontal_search_range	ext/tiovx/gsttiovxdof.c	/^  gint horizontal_search_range;$/;"	m	struct:_GstTIOVXDOF	file:
+horizontal_search_range_default	ext/tiovx/gsttiovxdof.c	/^static const int horizontal_search_range_default = 191;$/;"	v	file:
+horizontal_search_range_max	ext/tiovx/gsttiovxdof.c	/^static const int horizontal_search_range_max = 191;$/;"	v	file:
+horizontal_search_range_min	ext/tiovx/gsttiovxdof.c	/^static const int horizontal_search_range_min = 0;$/;"	v	file:
+hwa_loads	ext/tiovx/gsttiperfoverlay.cpp	/^      hwa_loads[4];$/;"	m	struct:_GstTIPerfOverlay	file:
+id	tests/check/gsttiovxisp.c	/^  const guint id;$/;"	m	struct:__anon47	file:
+image_buf	ext/tiovx/gsttidlpostproc.cpp	/^      image_buf;$/;"	m	struct:_GstTIDLPostProc	file:
+image_handler	ext/tiovx/gsttiperfoverlay.cpp	/^      image_handler;$/;"	m	struct:_GstTIPerfOverlay	file:
+image_height	ext/tiovx/gsttidlpostproc.cpp	/^      image_height;$/;"	m	struct:_GstTIDLPostProc	file:
+image_height	ext/tiovx/gsttiperfoverlay.cpp	/^      image_height;$/;"	m	struct:_GstTIPerfOverlay	file:
+image_info	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  GstTIOVXImageInfo image_info;$/;"	m	struct:_GstTIOVXImageMeta
+image_info	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  GstTIOVXRawImageInfo image_info;$/;"	m	struct:_GstTIOVXRawImageMeta
+image_pad	ext/tiovx/gsttidlpostproc.cpp	/^      image_pad;$/;"	m	struct:_GstTIDLPostProc	file:
+image_pad	ext/tiovx/gsttiovxdlcolorblend.c	/^  GstPad *image_pad;$/;"	m	struct:_GstTIOVXDLColorBlend	file:
+image_sink_template	ext/tiovx/gsttidlpostproc.cpp	/^    image_sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+image_sink_template	ext/tiovx/gsttiovxdlcolorblend.c	/^static GstStaticPadTemplate image_sink_template =$/;"	v	file:
+image_width	ext/tiovx/gsttidlpostproc.cpp	/^      image_width;$/;"	m	struct:_GstTIDLPostProc	file:
+image_width	ext/tiovx/gsttiperfoverlay.cpp	/^      image_width;$/;"	m	struct:_GstTIPerfOverlay	file:
+in_caps	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  GstCaps *in_caps;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+in_param_index	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  guint in_param_index;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+in_pool_size	ext/tiovx/gsttidlinferer.cpp	/^      in_pool_size;$/;"	m	struct:_GstTIDLInferer	file:
+in_pool_size	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  guint in_pool_size;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+inferer	ext/tiovx/gsttidlinferer.cpp	/^      inferer;$/;"	m	struct:_GstTIDLInferer	file:
+inferer_config	ext/tiovx/gsttidlinferer.cpp	/^      inferer_config;$/;"	m	struct:_GstTIDLInferer	file:
+init	tests/check/libs/gsttiovxallocator.c	/^init (void)$/;"	f	file:
+init	tests/check/libs/gsttiovxpad.c	/^init (GstTIOVXPad ** pad, vx_context * context, vx_reference * reference)$/;"	f	file:
+init_module	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*init_module)              (GstTIOVXMiso *agg, vx_context context, GList* sink_pads_list, GstPad * src_pad, guint num_channels);$/;"	m	struct:_GstTIOVXMisoClass
+init_module	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  gboolean      (*init_module)              (GstTIOVXSimo *self, vx_context context, GstTIOVXPad *sink_pad,$/;"	m	struct:_GstTIOVXSimoClass
+init_module	gst-libs/gst/tiovx/gsttiovxsiso.h	/^  gboolean      (*init_module)              (GstTIOVXSiso *trans, vx_context context, GstCaps * in_caps,$/;"	m	struct:_GstTIOVXSisoClass
+initialize_demux_harness_and_element	tests/check/gsttiovxdemux.c	/^initialize_demux_harness_and_element (GstHarness ** h)$/;"	f	file:
+initialize_harness_and_element	tests/check/gsttiovxmux.c	/^initialize_harness_and_element (GstHarness * h[], guint num_inputs)$/;"	f	file:
+initialize_harness_and_element	tests/check/libs/gsttiovxmiso.c	/^initialize_harness_and_element (GstHarness ** h, GstElement ** dummy_siso)$/;"	f	file:
+initialize_harness_and_element	tests/check/libs/gsttiovxsimo.c	/^initialize_harness_and_element (GstHarness ** h, GstElement ** dummy_siso)$/;"	f	file:
+initialize_harness_and_element	tests/check/libs/gsttiovxsiso.c	/^initialize_harness_and_element (GstHarness ** h)$/;"	f	file:
+initialize_non_tiovx_buffer_pool	tests/check/libs/gsttiovxpad.c	/^initialize_non_tiovx_buffer_pool (GstBufferPool ** buffer_pool)$/;"	f	file:
+initialize_tiovx_buffer_pool	tests/check/libs/gsttiovxpad.c	/^initialize_tiovx_buffer_pool (GstBufferPool ** buffer_pool)$/;"	f	file:
+input	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  vx_object_array input;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+input	tests/check/libs/gsttiovxmiso.c	/^  vx_object_array input[TEST_MISO_INPUT];$/;"	m	struct:_GstTestTIOVXMiso	file:
+input	tests/check/libs/gsttiovxsimo.c	/^  vx_object_array input;$/;"	m	struct:_GstTestTIOVXSimo	file:
+input	tests/check/libs/gsttiovxsiso.c	/^  vx_object_array input;$/;"	m	struct:_GstTestTIOVXSiso	file:
+input_buffs	ext/tiovx/gsttidlinferer.cpp	/^      input_buffs;$/;"	m	struct:_GstTIDLInferer	file:
+input_height	ext/tiovx/gsttidlinferer.cpp	/^      input_height;$/;"	m	struct:_GstTIDLInferer	file:
+input_height	gst-libs/gst/tiovx/gsttidloutmeta.h	/^  guint input_height;$/;"	m	struct:_GstTiDlOutMeta
+input_left_param_id	ext/tiovx/gsttiovxsde.c	/^static const int input_left_param_id = 1;$/;"	v	file:
+input_param_id	ext/tiovx/gsttiovxdof.c	/^static const int input_param_id = 3;$/;"	v	file:
+input_param_id	ext/tiovx/gsttiovxisp.c	/^static const int input_param_id = 3;$/;"	v	file:
+input_param_id	ext/tiovx/gsttiovxmultiscaler.c	/^static const int input_param_id = 0;$/;"	v	file:
+input_param_id	tests/check/libs/gsttiovxmiso.c	/^  guint input_param_id[TEST_MISO_INPUT];$/;"	m	struct:_GstTestTIOVXMiso	file:
+input_param_id	tests/check/libs/gsttiovxsimo.c	/^static const int input_param_id = 0;$/;"	v	file:
+input_param_id	tests/check/libs/gsttiovxsiso.c	/^  guint input_param_id;$/;"	m	struct:_GstTestTIOVXSiso	file:
+input_param_id_start	ext/tiovx/gsttiovxmosaic.c	/^static const int input_param_id_start = 3;$/;"	v	file:
+input_ref	ext/tiovx/gsttidlinferer.cpp	/^      input_ref;$/;"	m	struct:_GstTIDLInferer	file:
+input_ref	ext/tiovx/gsttidlpostproc.cpp	/^      input_ref;$/;"	m	struct:_GstTIDLPostProc	file:
+input_ref	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  vx_reference input_ref;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+input_ref	tests/check/libs/gsttiovxmiso.c	/^  vx_reference input_ref[TEST_MISO_INPUT];$/;"	m	struct:_GstTestTIOVXMiso	file:
+input_ref	tests/check/libs/gsttiovxsimo.c	/^  vx_reference input_ref;$/;"	m	struct:_GstTestTIOVXSimo	file:
+input_ref	tests/check/libs/gsttiovxsiso.c	/^  vx_reference input_ref;$/;"	m	struct:_GstTestTIOVXSiso	file:
+input_ref_param_id	ext/tiovx/gsttiovxdof.c	/^static const int input_ref_param_id = 4;$/;"	v	file:
+input_reference	ext/tiovx/gsttiovxdemux.c	/^  vx_reference input_reference;$/;"	m	struct:_GstTIOVXDemux	file:
+input_references	ext/tiovx/gsttiovxisp.c	/^  vx_reference input_references[MAX_NUM_CHANNELS];$/;"	m	struct:_GstTIOVXISP	file:
+input_right_param_id	ext/tiovx/gsttiovxsde.c	/^static const int input_right_param_id = 2;$/;"	v	file:
+input_width	ext/tiovx/gsttidlinferer.cpp	/^      input_width;$/;"	m	struct:_GstTIDLInferer	file:
+input_width	gst-libs/gst/tiovx/gsttidloutmeta.h	/^  guint input_width;$/;"	m	struct:_GstTiDlOutMeta
+interpolation_method	ext/tiovx/gsttiovxmultiscaler.c	/^  gint interpolation_method;$/;"	m	struct:_GstTIOVXMultiScaler	file:
+intersect_with_template_caps	ext/tiovx/gsttiovxdemux.c	/^intersect_with_template_caps (GstCaps * caps, GstPad * pad)$/;"	f	file:
+intersect_with_template_caps	ext/tiovx/gsttiovxmux.c	/^intersect_with_template_caps (GstCaps * caps, GstPad * pad)$/;"	f	file:
+intersect_with_template_caps	gst-libs/gst/tiovx/gsttiovxmiso.c	/^intersect_with_template_caps (GstCaps * caps, GstPad * pad)$/;"	f	file:
+intersect_with_template_caps	gst-libs/gst/tiovx/gsttiovxsimo.c	/^intersect_with_template_caps (GstCaps * caps, GstPad * pad)$/;"	f	file:
+isp	tests/check/gsttiovxisp.c	/^  const gchar *isp;$/;"	m	struct:__anon47	file:
+kGstImageFormat	tests/check/libs/gsttiovximagebufferpool.c	/^static const char *kGstImageFormat = "UYVY";$/;"	v	file:
+kGstImageFormat	tests/check/libs/gsttiovxpad.c	/^static const char *kGstImageFormat = "UYVY";$/;"	v	file:
+kGstImageFormat	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const char *kGstImageFormat = "rggb";$/;"	v	file:
+kGstPyramidFormat	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const GstVideoFormat kGstPyramidFormat = GST_VIDEO_FORMAT_GRAY8;$/;"	v	file:
+kImageHeight	tests/check/gsttiovxcolorconvert.c	/^static const int kImageHeight = 480;$/;"	v	file:
+kImageHeight	tests/check/gsttiovxdemux.c	/^static const int kImageHeight = 240;$/;"	v	file:
+kImageHeight	tests/check/gsttiovxdlcolorconvert.c	/^static const int kImageHeight = 480;$/;"	v	file:
+kImageHeight	tests/check/gsttiovxmux.c	/^static const int kImageHeight = 240;$/;"	v	file:
+kImageHeight	tests/check/libs/gsttiovximagebufferpool.c	/^static const int kImageHeight = 480;$/;"	v	file:
+kImageHeight	tests/check/libs/gsttiovxpad.c	/^static const int kImageHeight = 480;$/;"	v	file:
+kImageHeight	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const gint kImageHeight = 480;$/;"	v	file:
+kImageLineInterleaved	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const gboolean kImageLineInterleaved = FALSE;$/;"	v	file:
+kImageMetaHeightAfter	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const gint kImageMetaHeightAfter = 20;$/;"	v	file:
+kImageMetaHeightBefore	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const gint kImageMetaHeightBefore = 20;$/;"	v	file:
+kImageNumExposures	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const gint kImageNumExposures = 1;$/;"	v	file:
+kImageWidth	tests/check/gsttiovxcolorconvert.c	/^static const int kImageWidth = 640;$/;"	v	file:
+kImageWidth	tests/check/gsttiovxdemux.c	/^static const int kImageWidth = 320;$/;"	v	file:
+kImageWidth	tests/check/gsttiovxdlcolorconvert.c	/^static const int kImageWidth = 640;$/;"	v	file:
+kImageWidth	tests/check/gsttiovxmux.c	/^static const int kImageWidth = 320;$/;"	v	file:
+kImageWidth	tests/check/libs/gsttiovximagebufferpool.c	/^static const int kImageWidth = 640;$/;"	v	file:
+kImageWidth	tests/check/libs/gsttiovxpad.c	/^static const int kImageWidth = 640;$/;"	v	file:
+kImageWidth	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const gint kImageWidth = 640;$/;"	v	file:
+kMaxBuffers	tests/check/libs/gsttiovximagebufferpool.c	/^static const int kMaxBuffers = 4;$/;"	v	file:
+kMaxBuffers	tests/check/libs/gsttiovxpad.c	/^static const int kMaxBuffers = 4;$/;"	v	file:
+kMaxBuffers	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const int kMaxBuffers = 4;$/;"	v	file:
+kMaxBuffers	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const int kMaxBuffers = 4;$/;"	v	file:
+kMaxBuffers	tests/check/libs/gsttiovxtensorbufferpool.c	/^static const int kMaxBuffers = 4;$/;"	v	file:
+kMinBuffers	tests/check/libs/gsttiovximagebufferpool.c	/^static const int kMinBuffers = 1;$/;"	v	file:
+kMinBuffers	tests/check/libs/gsttiovxpad.c	/^static const int kMinBuffers = 1;$/;"	v	file:
+kMinBuffers	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const int kMinBuffers = 1;$/;"	v	file:
+kMinBuffers	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const int kMinBuffers = 1;$/;"	v	file:
+kMinBuffers	tests/check/libs/gsttiovxtensorbufferpool.c	/^static const int kMinBuffers = 1;$/;"	v	file:
+kPyramidHeight	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const int kPyramidHeight = 960;$/;"	v	file:
+kPyramidLevels	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const int kPyramidLevels = 3;$/;"	v	file:
+kPyramidScale	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const double kPyramidScale = 0.5f;$/;"	v	file:
+kPyramidWidth	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const int kPyramidWidth = 1280;$/;"	v	file:
+kSize	tests/check/libs/gsttiovximagebufferpool.c	/^static const int kSize = kImageWidth * kImageHeight * 2;$/;"	v	file:
+kSize	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const int kSize = kPyramidWidth * kPyramidHeight * (1 + 1 \/ 4 + 1 \/ 16);$/;"	v	file:
+kSize	tests/check/libs/gsttiovxrawimagebufferpool.c	/^static const int kSize = kImageWidth * kImageHeight * 2;$/;"	v	file:
+kStrPyramidFormat	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const char *kStrPyramidFormat = "GRAY8";$/;"	v	file:
+kTIOVXImageFormat	tests/check/libs/gsttiovximagebufferpool.c	/^static const vx_df_image kTIOVXImageFormat = VX_DF_IMAGE_UYVY;$/;"	v	file:
+kTIOVXImageFormat	tests/check/libs/gsttiovxpad.c	/^static const vx_df_image kTIOVXImageFormat = VX_DF_IMAGE_UYVY;$/;"	v	file:
+kTIOVXPyramidFormat	tests/check/libs/gsttiovxpyramidbufferpool.c	/^static const vx_df_image kTIOVXPyramidFormat = VX_DF_IMAGE_U8;$/;"	v	file:
+ldc_ds_factor	ext/tiovx/gsttiovxldc.c	/^  guint ldc_ds_factor;$/;"	m	struct:_GstTIOVXLDC	file:
+ldc_init_x	ext/tiovx/gsttiovxldc.c	/^  guint ldc_init_x;$/;"	m	struct:_GstTIOVXLDC	file:
+ldc_init_y	ext/tiovx/gsttiovxldc.c	/^  guint ldc_init_y;$/;"	m	struct:_GstTIOVXLDC	file:
+ldc_table_height	ext/tiovx/gsttiovxldc.c	/^  guint ldc_table_height;$/;"	m	struct:_GstTIOVXLDC	file:
+ldc_table_width	ext/tiovx/gsttiovxldc.c	/^  guint ldc_table_width;$/;"	m	struct:_GstTIOVXLDC	file:
+left_sink_template	ext/tiovx/gsttiovxsde.c	/^static GstStaticPadTemplate left_sink_template =$/;"	v	file:
+levels	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  vx_size levels;$/;"	m	struct:_GstTIOVXPyramidInfo
+line_interleaved	ext/tiovx/gsttiovxisp.c	/^  gboolean line_interleaved;$/;"	m	struct:_GstTIOVXISP	file:
+lines_interleaved	tests/check/gsttiovxisp.c	/^  const gboolean *lines_interleaved;$/;"	m	struct:__anon49	file:
+lut_file	ext/tiovx/gsttiovxldc.c	/^  gchar *lut_file;$/;"	m	struct:_GstTIOVXLDC	file:
+main	tests/examples/gsttiovx_example.c	/^main (int argc, char **argv)$/;"	f
+main_title_font_property	ext/tiovx/gsttiperfoverlay.cpp	/^      main_title_font_property;$/;"	m	struct:_GstTIPerfOverlay	file:
+max	tests/check/gsttiovxisp.c	/^  const guint max;$/;"	m	struct:__anon46	file:
+max_dim_value	ext/tiovx/gsttiovxmosaic.c	/^static const gint max_dim_value = G_MAXINT32;$/;"	v	file:
+max_format_msb	ext/tiovx/gsttiovxisp.c	/^static const gint max_format_msb = 16;$/;"	v	file:
+max_meta_height_after	ext/tiovx/gsttiovxisp.c	/^static const gint max_meta_height_after = 8192;$/;"	v	file:
+max_meta_height_before	ext/tiovx/gsttiovxisp.c	/^static const gint max_meta_height_before = 8192;$/;"	v	file:
+max_num_exposures	ext/tiovx/gsttiovxisp.c	/^static const gint max_num_exposures = 4;$/;"	v	file:
+max_start_value	ext/tiovx/gsttiovxmosaic.c	/^static const gint max_start_value = G_MAXINT32;$/;"	v	file:
+mean	ext/tiovx/gsttiovxdlpreproc.c	/^  gfloat mean[MEAN_DIM];$/;"	m	struct:_GstTIOVXDLPreProc	file:
+mean	tests/check/gsttiovxdlpreproc.c	/^  const gdouble *mean;$/;"	m	struct:__anon45	file:
+median_filter_enable	ext/tiovx/gsttiovxdof.c	/^  gboolean median_filter_enable;$/;"	m	struct:_GstTIOVXDOF	file:
+median_filter_enable	ext/tiovx/gsttiovxsde.c	/^  gboolean median_filter_enable;$/;"	m	struct:_GstTIOVXSde	file:
+median_filter_enable_default	ext/tiovx/gsttiovxdof.c	/^static const gboolean median_filter_enable_default = TRUE;$/;"	v	file:
+median_filter_enable_default	ext/tiovx/gsttiovxsde.c	/^static const gboolean median_filter_enable_default = TRUE;$/;"	v	file:
+mem_ptr	gst-libs/gst/tiovx/gsttiovxallocator.h	/^  tivx_shared_mem_ptr_t mem_ptr;$/;"	m	struct:_GstTIOVXMemoryData
+memory_batched_quark	gst-libs/gst/tiovx/gsttiovxutils.c	/^static GQuark memory_batched_quark = 0;$/;"	v	file:
+meta	ext/tiovx/gsttidlpostproc.cpp	/^      meta;$/;"	m	struct:_GstTIDLPostProc	file:
+meta	gst-libs/gst/tiovx/gsttidloutmeta.h	/^  GstMeta meta;$/;"	m	struct:_GstTiDlOutMeta
+meta	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  GstMeta meta;$/;"	m	struct:_GstTIOVXImageMeta
+meta	gst-libs/gst/tiovx/gsttiovxmuxmeta.h	/^  GstMeta meta;$/;"	m	struct:_GstTIOVXMuxMeta
+meta	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  GstMeta meta;$/;"	m	struct:_GstTIOVXPyramidMeta
+meta	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  GstMeta meta;$/;"	m	struct:_GstTIOVXRawImageMeta
+meta	gst-libs/gst/tiovx/gsttiovxsensormeta.h	/^  GstMeta meta;$/;"	m	struct:_GstTIOVXSensorMeta
+meta	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  GstMeta meta;$/;"	m	struct:_GstTIOVXTensorMeta
+meta_after	gst-libs/gst/tiovx/gsttiovxsensormeta.h	/^  void *meta_after;$/;"	m	struct:_GstTIOVXSensorMeta
+meta_after_size	ext/tiovx/gsttiovxisp.c	/^  gint meta_after_size;$/;"	m	struct:_GstTIOVXISP	file:
+meta_after_size	gst-libs/gst/tiovx/gsttiovxsensormeta.h	/^  guint meta_after_size;$/;"	m	struct:_GstTIOVXSensorMeta
+meta_before	gst-libs/gst/tiovx/gsttiovxsensormeta.h	/^  void *meta_before;$/;"	m	struct:_GstTIOVXSensorMeta
+meta_before_size	ext/tiovx/gsttiovxisp.c	/^  gint meta_before_size;$/;"	m	struct:_GstTIOVXISP	file:
+meta_before_size	gst-libs/gst/tiovx/gsttiovxsensormeta.h	/^  guint meta_before_size;$/;"	m	struct:_GstTIOVXSensorMeta
+meta_height_after	ext/tiovx/gsttiovxisp.c	/^  gint meta_height_after;$/;"	m	struct:_GstTIOVXISP	file:
+meta_height_after_range	tests/check/gsttiovxisp.c	/^  const Range *meta_height_after_range;$/;"	m	struct:__anon49	file:
+meta_height_before	ext/tiovx/gsttiovxisp.c	/^  gint meta_height_before;$/;"	m	struct:_GstTIOVXISP	file:
+meta_height_before_range	tests/check/gsttiovxisp.c	/^  const Range *meta_height_before_range;$/;"	m	struct:__anon49	file:
+min	tests/check/gsttiovxisp.c	/^  const guint min;$/;"	m	struct:__anon46	file:
+min_dim_value	ext/tiovx/gsttiovxmosaic.c	/^static const gint min_dim_value = -1;$/;"	v	file:
+min_enable_channel	ext/tiovx/gsttiovxmosaic.c	/^static const gint min_enable_channel = -1;$/;"	v	file:
+min_format_msb	ext/tiovx/gsttiovxisp.c	/^static const gint min_format_msb = 1;$/;"	v	file:
+min_meta_height_after	ext/tiovx/gsttiovxisp.c	/^static const gint min_meta_height_after = 0;$/;"	v	file:
+min_meta_height_before	ext/tiovx/gsttiovxisp.c	/^static const gint min_meta_height_before = 0;$/;"	v	file:
+min_num_exposures	ext/tiovx/gsttiovxisp.c	/^static const gint min_num_exposures = 1;$/;"	v	file:
+min_start_value	ext/tiovx/gsttiovxmosaic.c	/^static const gint min_start_value = -1;$/;"	v	file:
+model	ext/tiovx/gsttidlinferer.cpp	/^      model;$/;"	m	struct:_GstTIDLInferer	file:
+model	ext/tiovx/gsttidlpostproc.cpp	/^      model;$/;"	m	struct:_GstTIDLPostProc	file:
+module_max_num_addr	tests/check/gsttiovxdemux.c	75;"	d	file:
+module_max_num_addr	tests/check/gsttiovxmux.c	75;"	d	file:
+motion_direction_id	ext/tiovx/gsttiovxdof.c	/^  gint motion_direction_id;$/;"	m	struct:_GstTIOVXDOF	file:
+motion_smoothness_factor	ext/tiovx/gsttiovxdof.c	/^  gint motion_smoothness_factor;$/;"	m	struct:_GstTIOVXDOF	file:
+motion_smoothness_factor_default	ext/tiovx/gsttiovxdof.c	/^static const int motion_smoothness_factor_default = 24;$/;"	v	file:
+motion_smoothness_factor_max	ext/tiovx/gsttiovxdof.c	/^static const int motion_smoothness_factor_max = 31;$/;"	v	file:
+motion_smoothness_factor_min	ext/tiovx/gsttiovxdof.c	/^static const int motion_smoothness_factor_min = 0;$/;"	v	file:
+mutex	ext/tiovx/gsttidlpostproc.cpp	/^      mutex;$/;"	m	struct:_GstTIDLPostProc	file:
+mutex	gst-libs/gst/tiovx/gsttiovxcontext.c	/^static GMutex mutex = { 0 };$/;"	v	file:
+mutex	tests/check/test_utils.h	/^  GMutex mutex;$/;"	m	struct:_BufferCounter
+node	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  vx_node node;$/;"	m	struct:_GstTIOVXMisoPrivate	file:
+node	gst-libs/gst/tiovx/gsttiovxsimo.c	/^  vx_node node;$/;"	m	struct:_GstTIOVXSimoPrivate	file:
+node	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  vx_node node;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+node	tests/check/libs/gsttiovxmiso.c	/^  vx_node node;$/;"	m	struct:_GstTestTIOVXMiso	file:
+node	tests/check/libs/gsttiovxsimo.c	/^  vx_node node;$/;"	m	struct:_GstTestTIOVXSimo	file:
+node	tests/check/libs/gsttiovxsiso.c	/^  vx_node node;$/;"	m	struct:_GstTestTIOVXSiso	file:
+node_param_id	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  gint node_param_id;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+node_param_id	gst-libs/gst/tiovx/gsttiovxpad.c	/^  gint node_param_id;$/;"	m	struct:_GstTIOVXPadPrivate	file:
+node_param_id	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^  gint node_param_id;$/;"	m	struct:_GstTIOVXQueueable	file:
+num_channels	ext/tiovx/gsttiovxisp.c	/^  gint num_channels;$/;"	m	struct:_GstTIOVXISP	file:
+num_channels	gst-libs/gst/tiovx/gsttiovxbufferpool.c	/^  guint num_channels;$/;"	m	struct:_GstTIOVXBufferPoolPrivate	file:
+num_channels	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  gint num_channels;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+num_channels	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  guint num_channels;$/;"	m	struct:_GstTIOVXMisoPrivate	file:
+num_channels	gst-libs/gst/tiovx/gsttiovxpad.c	/^  gint num_channels;$/;"	m	struct:_GstTIOVXPadPrivate	file:
+num_channels	gst-libs/gst/tiovx/gsttiovxsimo.c	/^  guint num_channels;$/;"	m	struct:_GstTIOVXSimoPrivate	file:
+num_channels	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  guint num_channels;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+num_classes	ext/tiovx/gsttiovxdlcolorblend.c	/^  guint num_classes;$/;"	m	struct:_GstTIOVXDLColorBlend	file:
+num_classes	tests/check/gsttiovxdlcolorblend.c	/^  const guint64 *num_classes;$/;"	m	struct:__anon55	file:
+num_dims	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  vx_size num_dims;$/;"	m	struct:_GstTIOVXTensorInfo
+num_exposures	ext/tiovx/gsttiovxisp.c	/^  gint num_exposures;$/;"	m	struct:_GstTIOVXISP	file:
+num_exposures	gst-libs/gst/tiovx/gsttiovxrawimagemeta.h	/^  guint num_exposures;$/;"	m	struct:_GstTIOVXRawImageInfo
+num_exposures_range	tests/check/gsttiovxisp.c	/^  const Range *num_exposures_range;$/;"	m	struct:__anon49	file:
+num_graphs	ext/tiovx/gsttiperfoverlay.cpp	/^      num_graphs;$/;"	m	struct:_GstTIPerfOverlay	file:
+num_graphs_negotiated	ext/tiovx/gsttiperfoverlay.cpp	/^      num_graphs_negotiated;$/;"	m	struct:_GstTIPerfOverlay	file:
+num_outputs	gst-libs/gst/tiovx/gsttidloutmeta.h	/^  guint num_outputs;$/;"	m	struct:_GstTiDlOutMeta
+num_planes	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  guint num_planes;$/;"	m	struct:_GstTIOVXImageInfo
+num_src_pads	ext/tiovx/gsttiovxldc.c	/^  gint num_src_pads;$/;"	m	struct:_GstTIOVXLDC	file:
+obj	ext/tiovx/gsttiovxcolorconvert.c	/^  TIOVXColorConvertModuleObj obj;$/;"	m	struct:_GstTIOVXColorconvert	file:
+obj	ext/tiovx/gsttiovxdlcolorblend.c	/^  TIOVXDLColorBlendModuleObj *obj;$/;"	m	struct:_GstTIOVXDLColorBlend	file:
+obj	ext/tiovx/gsttiovxdlcolorconvert.c	/^  TIOVXDLColorConvertModuleObj obj;$/;"	m	struct:_GstTIOVXDLColorconvert	file:
+obj	ext/tiovx/gsttiovxdlpreproc.c	/^  TIOVXDLPreProcModuleObj *obj;$/;"	m	struct:_GstTIOVXDLPreProc	file:
+obj	ext/tiovx/gsttiovxdof.c	/^  TIOVXDofModuleObj obj;$/;"	m	struct:_GstTIOVXDOF	file:
+obj	ext/tiovx/gsttiovxdofviz.c	/^  TIOVXDofVizModuleObj obj;$/;"	m	struct:_GstTIOVXDofViz	file:
+obj	ext/tiovx/gsttiovxldc.c	/^  TIOVXLDCModuleObj obj;$/;"	m	struct:_GstTIOVXLDC	file:
+obj	ext/tiovx/gsttiovxmosaic.c	/^  TIOVXImgMosaicModuleObj obj;$/;"	m	struct:_GstTIOVXMosaic	file:
+obj	ext/tiovx/gsttiovxmultiscaler.c	/^  TIOVXMultiScalerModuleObj obj;$/;"	m	struct:_GstTIOVXMultiScaler	file:
+obj	ext/tiovx/gsttiovxpyramid.c	/^  TIOVXPyramidModuleObj obj;$/;"	m	struct:_GstTIOVXPyramid	file:
+obj	ext/tiovx/gsttiovxsde.c	/^  TIOVXSdeModuleObj obj;$/;"	m	struct:_GstTIOVXSde	file:
+obj	ext/tiovx/gsttiovxsdeviz.c	/^  TIOVXSdeVizModuleObj obj;$/;"	m	struct:_GstTIOVXSdeViz	file:
+offsets	gst-libs/gst/tiovx/gsttidloutmeta.h	/^  guint offsets[MAX_TIDL_OUTPUTS];$/;"	m	struct:_GstTiDlOutMeta
+out_block_height	ext/tiovx/gsttiovxldc.c	/^  guint out_block_height;$/;"	m	struct:_GstTIOVXLDC	file:
+out_block_width	ext/tiovx/gsttiovxldc.c	/^  guint out_block_width;$/;"	m	struct:_GstTIOVXLDC	file:
+out_caps	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  GstCaps *out_caps;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+out_meta	ext/tiovx/gsttidlinferer.cpp	/^      out_meta;$/;"	m	struct:_GstTIDLInferer	file:
+out_param_index	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  guint out_param_index;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+out_pool_size	ext/tiovx/gsttidlinferer.cpp	/^      out_pool_size;$/;"	m	struct:_GstTIDLInferer	file:
+out_pool_size	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  guint out_pool_size;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+output	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  vx_object_array output;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+output	tests/check/libs/gsttiovxmiso.c	/^  vx_object_array output;$/;"	m	struct:_GstTestTIOVXMiso	file:
+output	tests/check/libs/gsttiovxsimo.c	/^  vx_object_array output[TEST_SIMO_OUTPUT];$/;"	m	struct:_GstTestTIOVXSimo	file:
+output	tests/check/libs/gsttiovxsiso.c	/^  vx_object_array output;$/;"	m	struct:_GstTestTIOVXSiso	file:
+output0_param_id	ext/tiovx/gsttiovxisp.c	/^static const int output0_param_id = 4;$/;"	v	file:
+output2_param_id	ext/tiovx/gsttiovxisp.c	/^static const int output2_param_id = 6;$/;"	v	file:
+output_buffs	ext/tiovx/gsttidlinferer.cpp	/^      output_buffs;$/;"	m	struct:_GstTIDLInferer	file:
+output_flow_param_id	ext/tiovx/gsttiovxdof.c	/^static const int output_flow_param_id = 8;$/;"	v	file:
+output_height	ext/tiovx/gsttidlinferer.cpp	/^      output_height;$/;"	m	struct:_GstTIDLInferer	file:
+output_param_id	ext/tiovx/gsttiovxmosaic.c	/^static const int output_param_id = 1;$/;"	v	file:
+output_param_id	ext/tiovx/gsttiovxsde.c	/^static const int output_param_id = 3;$/;"	v	file:
+output_param_id	tests/check/libs/gsttiovxmiso.c	/^  guint output_param_id;$/;"	m	struct:_GstTestTIOVXMiso	file:
+output_param_id	tests/check/libs/gsttiovxsiso.c	/^  guint output_param_id;$/;"	m	struct:_GstTestTIOVXSiso	file:
+output_param_id_start	ext/tiovx/gsttiovxmultiscaler.c	/^static const int output_param_id_start = 1;$/;"	v	file:
+output_param_id_start	tests/check/libs/gsttiovxsimo.c	/^static const int output_param_id_start = 1;$/;"	v	file:
+output_ref	ext/tiovx/gsttidlinferer.cpp	/^      output_ref;$/;"	m	struct:_GstTIDLInferer	file:
+output_ref	ext/tiovx/gsttidlpostproc.cpp	/^      output_ref;$/;"	m	struct:_GstTIDLPostProc	file:
+output_ref	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  vx_reference output_ref;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+output_ref	tests/check/libs/gsttiovxmiso.c	/^  vx_reference output_ref;$/;"	m	struct:_GstTestTIOVXMiso	file:
+output_ref	tests/check/libs/gsttiovxsimo.c	/^  vx_reference output_ref[TEST_SIMO_OUTPUT];$/;"	m	struct:_GstTestTIOVXSimo	file:
+output_ref	tests/check/libs/gsttiovxsiso.c	/^  vx_reference output_ref;$/;"	m	struct:_GstTestTIOVXSiso	file:
+output_width	ext/tiovx/gsttidlinferer.cpp	/^      output_width;$/;"	m	struct:_GstTIDLInferer	file:
+overlay	ext/tiovx/gsttiperfoverlay.cpp	/^      overlay;$/;"	m	struct:_GstTIPerfOverlay	file:
+overlay_color	ext/tiovx/gsttiperfoverlay.cpp	/^      overlay_color;$/;"	m	struct:_GstTIPerfOverlay	file:
+overlay_height	ext/tiovx/gsttiperfoverlay.cpp	/^      overlay_height;$/;"	m	struct:_GstTIPerfOverlay	file:
+overlay_perf_stats	ext/tiovx/gsttiperfoverlay.cpp	/^overlay_perf_stats (GstTIPerfOverlay * self)$/;"	f	file:
+overlay_pos_x	ext/tiovx/gsttiperfoverlay.cpp	/^      overlay_pos_x;$/;"	m	struct:_GstTIPerfOverlay	file:
+overlay_pos_y	ext/tiovx/gsttiperfoverlay.cpp	/^      overlay_pos_y;$/;"	m	struct:_GstTIPerfOverlay	file:
+overlay_text_color	ext/tiovx/gsttiperfoverlay.cpp	/^      overlay_text_color;$/;"	m	struct:_GstTIPerfOverlay	file:
+overlay_width	ext/tiovx/gsttiperfoverlay.cpp	/^      overlay_width;$/;"	m	struct:_GstTIPerfOverlay	file:
+parent	ext/tiovx/gsttiovxdelay.c	/^  GstBaseTransform parent;$/;"	m	struct:_GstTIOVXDelay	file:
+parent	ext/tiovx/gsttiovxdemux.c	/^  GstElement parent;$/;"	m	struct:_GstTIOVXDemux	file:
+parent	ext/tiovx/gsttiovxdof.c	/^  GstTIOVXMiso parent;$/;"	m	struct:_GstTIOVXDOF	file:
+parent	ext/tiovx/gsttiovxmemalloc.c	/^  GstBaseTransform parent;$/;"	m	struct:_GstTIOVXMemAlloc	file:
+parent	ext/tiovx/gsttiovxmosaic.c	/^  GstTIOVXMiso parent;$/;"	m	struct:_GstTIOVXMosaic	file:
+parent	ext/tiovx/gsttiovxmux.c	/^  GstAggregatorPad parent;$/;"	m	struct:_GstTIOVXMuxPad	file:
+parent	ext/tiovx/gsttiovxsde.c	/^  GstTIOVXMiso parent;$/;"	m	struct:_GstTIOVXSde	file:
+parent	gst-libs/gst/tiovx/gsttiovximagebufferpool.c	/^  GstTIOVXBufferPool parent;$/;"	m	struct:_GstTIOVXImageBufferPool	file:
+parent	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  GstAggregatorPad parent;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+parent	gst-libs/gst/tiovx/gsttiovxpyramidbufferpool.c	/^  GstTIOVXBufferPool parent;$/;"	m	struct:_GstTIOVXPyramidBufferPool	file:
+parent	gst-libs/gst/tiovx/gsttiovxqueueableobject.c	/^  GObject parent;$/;"	m	struct:_GstTIOVXQueueable	file:
+parent	gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c	/^  GstTIOVXBufferPool parent;$/;"	m	struct:_GstTIOVXRawImageBufferPool	file:
+parent	gst-libs/gst/tiovx/gsttiovxtensorbufferpool.c	/^  GstTIOVXBufferPool parent;$/;"	m	struct:_GstTIOVXTensorBufferPool	file:
+parent	tests/check/libs/gsttiovxmiso.c	/^  GstTIOVXMiso parent;$/;"	m	struct:_GstTestTIOVXMiso	file:
+parent	tests/check/libs/gsttiovxsimo.c	/^  GstTIOVXSimo parent;$/;"	m	struct:_GstTestTIOVXSimo	file:
+parent	tests/check/libs/gsttiovxsiso.c	/^  GstTIOVXSiso parent;$/;"	m	struct:_GstTestTIOVXSiso	file:
+parent_class	ext/tiovx/gsttiovxdemux.c	/^static GstElementClass *parent_class = NULL;$/;"	v	file:
+parent_class	ext/tiovx/gsttiovxisp.c	/^  GstTIOVXMisoPadClass parent_class;$/;"	m	struct:_GstTIOVXIspPadClass	file:
+parent_class	ext/tiovx/gsttiovxmosaic.c	/^  GstTIOVXMisoPadClass parent_class;$/;"	m	struct:_GstTIOVXMosaicPadClass	file:
+parent_class	ext/tiovx/gsttiovxmultiscalerpad.h	/^  GstTIOVXPadClass parent_class;$/;"	m	struct:_GstTIOVXMultiScalerPadClass
+parent_class	gst-libs/gst/tiovx/gsttiovxbufferpool.h	/^  GstBufferPoolClass parent_class;$/;"	m	struct:_GstTIOVXBufferPoolClass
+parent_class	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  GstAggregatorClass parent_class;$/;"	m	struct:_GstTIOVXMisoClass
+parent_class	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  GstAggregatorPad parent_class;$/;"	m	struct:_GstTIOVXMisoPadClass
+parent_class	gst-libs/gst/tiovx/gsttiovxpad.h	/^  GstPadClass parent_class;$/;"	m	struct:_GstTIOVXPadClass
+parent_class	gst-libs/gst/tiovx/gsttiovxsimo.c	/^static GstElementClass *parent_class = NULL;$/;"	v	file:
+parent_class	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  GstElementClass parent_class;$/;"	m	struct:_GstTIOVXSimoClass
+parent_class	gst-libs/gst/tiovx/gsttiovxsiso.h	/^  GstBaseTransformClass parent_class;$/;"	m	struct:_GstTIOVXSisoClass
+parent_class	tests/check/libs/gsttiovxmiso.c	/^  GstTIOVXMisoClass parent_class;$/;"	m	struct:_GstTestTIOVXMisoClass	file:
+parent_class	tests/check/libs/gsttiovxsimo.c	/^  GstTIOVXSimoClass parent_class;$/;"	m	struct:_GstTestTIOVXSimoClass	file:
+parent_class	tests/check/libs/gsttiovxsiso.c	/^  GstTIOVXSisoClass parent_class;$/;"	m	struct:_GstTestTIOVXSisoClass	file:
+pipelines_caps_negotiation_fail	tests/check/gsttiovxcolorconvert.c	/^static const gchar *pipelines_caps_negotiation_fail[] = {$/;"	v	file:
+pipelines_caps_negotiation_fail	tests/check/gsttiovxdlcolorconvert.c	/^static const gchar *pipelines_caps_negotiation_fail[] = {$/;"	v	file:
+pipelines_caps_negotiation_fail	tests/check/gsttiovxldc.c	/^static const gchar *pipelines_caps_negotiation_fail[] = {$/;"	v	file:
+pipelines_caps_negotiation_fail	tests/check/gsttiovxpyramid.c	/^static const gchar *pipelines_caps_negotiation_fail[] = {$/;"	v	file:
+pipelines_caps_negotiation_success	tests/check/gsttiovxcolorconvert.c	/^static const gchar *pipelines_caps_negotiation_success[] = {$/;"	v	file:
+pipelines_caps_negotiation_success	tests/check/gsttiovxdlcolorconvert.c	/^static const gchar *pipelines_caps_negotiation_success[] = {$/;"	v	file:
+pipelines_caps_negotiation_success	tests/check/gsttiovxldc.c	/^static const gchar *pipelines_caps_negotiation_success[] = {$/;"	v	file:
+pipelines_caps_negotiation_success	tests/check/gsttiovxpyramid.c	/^static const gchar *pipelines_caps_negotiation_success[] = {$/;"	v	file:
+pixel_pad	ext/tiovx/gsttiovxldc.c	/^  guint pixel_pad;$/;"	m	struct:_GstTIOVXLDC	file:
+plane_heights	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  guint plane_heights[MODULE_MAX_NUM_PLANES];$/;"	m	struct:_GstTIOVXImageInfo
+plane_offset	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  gsize plane_offset[MODULE_MAX_NUM_PLANES];$/;"	m	struct:_GstTIOVXImageInfo
+plane_sizes	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  guint plane_sizes[MODULE_MAX_NUM_PLANES];$/;"	m	struct:_GstTIOVXImageInfo
+plane_steps_x	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  guint plane_steps_x[MODULE_MAX_NUM_PLANES];$/;"	m	struct:_GstTIOVXImageInfo
+plane_steps_y	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  guint plane_steps_y[MODULE_MAX_NUM_PLANES];$/;"	m	struct:_GstTIOVXImageInfo
+plane_stride_x	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  gint plane_stride_x[MODULE_MAX_NUM_PLANES];$/;"	m	struct:_GstTIOVXImageInfo
+plane_stride_y	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  gint plane_stride_y[MODULE_MAX_NUM_PLANES];$/;"	m	struct:_GstTIOVXImageInfo
+plane_widths	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  guint plane_widths[MODULE_MAX_NUM_PLANES];$/;"	m	struct:_GstTIOVXImageInfo
+pool_size	ext/tiovx/gsttiovxmemalloc.c	/^  guint pool_size;$/;"	m	struct:_GstTIOVXMemAlloc	file:
+pool_size	ext/tiovx/gsttiovxmux.c	/^  guint pool_size;$/;"	m	struct:_GstTIOVXMuxPad	file:
+pool_size	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  guint pool_size;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+pool_size	gst-libs/gst/tiovx/gsttiovxpad.c	/^  guint pool_size;$/;"	m	struct:_GstTIOVXPadPrivate	file:
+pool_size	tests/check/gsttiovxdlcolorblend.c	/^  const guint *pool_size;$/;"	m	struct:__anon52	file:
+pool_size	tests/check/gsttiovxdlcolorblend.c	/^  const guint *pool_size;$/;"	m	struct:__anon53	file:
+pool_size	tests/check/gsttiovxdlcolorblend.c	/^  const guint *pool_size;$/;"	m	struct:__anon54	file:
+pool_size_range	tests/check/gsttiovxisp.c	/^  const Range *pool_size_range;$/;"	m	struct:__anon48	file:
+post_proc_config	ext/tiovx/gsttidlpostproc.cpp	/^      post_proc_config;$/;"	m	struct:_GstTIDLPostProc	file:
+post_proc_obj	ext/tiovx/gsttidlpostproc.cpp	/^      post_proc_obj;$/;"	m	struct:_GstTIDLPostProc	file:
+postprocess	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*postprocess)              (GstTIOVXMiso * self);$/;"	m	struct:_GstTIOVXMisoClass
+postprocess	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  gboolean (*postprocess)              (GstTIOVXSimo *self);$/;"	m	struct:_GstTIOVXSimoClass
+postprocess_iter	ext/tiovx/gsttiovxisp.c	/^  guint postprocess_iter;$/;"	m	struct:_GstTIOVXISP	file:
+postprocess_skip_frames	ext/tiovx/gsttiovxisp.c	/^static const guint postprocess_skip_frames = 1;$/;"	v	file:
+preprocess	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*preprocess)               (GstTIOVXMiso *self);$/;"	m	struct:_GstTIOVXMisoClass
+preprocess	gst-libs/gst/tiovx/gsttiovxsimo.h	/^  gboolean (*preprocess)               (GstTIOVXSimo *self);$/;"	m	struct:_GstTIOVXSimoClass
+previous_fps_timestamp	ext/tiovx/gsttiperfoverlay.cpp	/^      previous_fps_timestamp;$/;"	m	struct:_GstTIPerfOverlay	file:
+previous_stats_timestamp	ext/tiovx/gsttiperfoverlay.cpp	/^      previous_stats_timestamp;$/;"	m	struct:_GstTIPerfOverlay	file:
+private_offset	gst-libs/gst/tiovx/gsttiovxsimo.c	/^static gint private_offset = 0;$/;"	v	file:
+properties	tests/check/gsttiovxisp.c	/^  Properties properties;$/;"	m	struct:__anon50	file:
+properties	tests/check/gsttiovxmosaic.c	/^  Properties properties;$/;"	m	struct:__anon42	file:
+pyramid_info	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  GstTIOVXPyramidInfo pyramid_info;$/;"	m	struct:_GstTIOVXPyramidMeta
+query_allocation	tests/check/libs/gsttiovxpad.c	/^query_allocation (GstTIOVXPad * pad)$/;"	f	file:
+queueable_objects	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  GList *queueable_objects;$/;"	m	struct:_GstTIOVXMisoPrivate	file:
+queueable_objects	gst-libs/gst/tiovx/gsttiovxsimo.c	/^  GList *queueable_objects;$/;"	m	struct:_GstTIOVXSimoPrivate	file:
+reduced_range_search_enable	ext/tiovx/gsttiovxsde.c	/^  gboolean reduced_range_search_enable;$/;"	m	struct:_GstTIOVXSde	file:
+reduced_range_search_enable_default	ext/tiovx/gsttiovxsde.c	/^static const gboolean reduced_range_search_enable_default = FALSE;$/;"	v	file:
+release_buffer	gst-libs/gst/tiovx/gsttiovxmiso.h	/^  gboolean      (*release_buffer)           (GstTIOVXMiso *agg);$/;"	m	struct:_GstTIOVXMisoClass
+release_buffer	gst-libs/gst/tiovx/gsttiovxsiso.h	/^  gboolean      (*release_buffer)           (GstTIOVXSiso *trans);$/;"	m	struct:_GstTIOVXSisoClass
+repeat_after_eos	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  gboolean repeat_after_eos;$/;"	m	struct:_GstTIOVXMisoPadPrivate	file:
+right_sink_template	ext/tiovx/gsttiovxsde.c	/^static GstStaticPadTemplate right_sink_template =$/;"	v	file:
+roi_height	ext/tiovx/gsttiovxmultiscalerpad.h	/^  guint roi_height;$/;"	m	struct:_GstTIOVXMultiScalerPad
+roi_startx	ext/tiovx/gsttiovxmultiscalerpad.h	/^  guint roi_startx;$/;"	m	struct:_GstTIOVXMultiScalerPad
+roi_starty	ext/tiovx/gsttiovxmultiscalerpad.h	/^  guint roi_starty;$/;"	m	struct:_GstTIOVXMultiScalerPad
+roi_width	ext/tiovx/gsttiovxmultiscalerpad.h	/^  guint roi_width;$/;"	m	struct:_GstTIOVXMultiScalerPad
+scale	ext/tiovx/gsttiovxdlpreproc.c	/^  gfloat scale[SCALE_DIM];$/;"	m	struct:_GstTIOVXDLPreProc	file:
+scale	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  gdouble scale;$/;"	m	struct:_GstTIOVXPyramidInfo
+scale	tests/check/gsttiovxdlpreproc.c	/^  const gdouble *scale;$/;"	m	struct:__anon45	file:
+sem_image	ext/tiovx/gsttidlpostproc.cpp	/^      sem_image;$/;"	m	struct:_GstTIDLPostProc	file:
+sem_tensor	ext/tiovx/gsttidlpostproc.cpp	/^      sem_tensor;$/;"	m	struct:_GstTIDLPostProc	file:
+sensorObj	ext/tiovx/gsttiovxldc.c	/^  SensorObj sensorObj;$/;"	m	struct:_GstTIOVXLDC	file:
+sensor_id	tests/check/gsttiovxisp.c	/^  const gchar **sensor_id;$/;"	m	struct:__anon49	file:
+sensor_in_data	ext/tiovx/gsttiovxisp.c	/^  sensor_config_get sensor_in_data;$/;"	m	struct:_GstTIOVXIspPad	file:
+sensor_name	ext/tiovx/gsttiovxisp.c	/^  gchar *sensor_name;$/;"	m	struct:_GstTIOVXISP	file:
+sensor_name	ext/tiovx/gsttiovxldc.c	/^  gchar *sensor_name;$/;"	m	struct:_GstTIOVXLDC	file:
+sensor_obj	ext/tiovx/gsttiovxisp.c	/^  SensorObj sensor_obj;$/;"	m	struct:_GstTIOVXISP	file:
+sensor_out_data	ext/tiovx/gsttiovxisp.c	/^  sensor_config_set sensor_out_data;$/;"	m	struct:_GstTIOVXIspPad	file:
+singleton	gst-libs/gst/tiovx/gsttiovxcontext.c	/^static GObject *singleton = NULL;$/;"	v	file:
+sink_buffer_pool	ext/tiovx/gsttidlinferer.cpp	/^      sink_buffer_pool;$/;"	m	struct:_GstTIDLInferer	file:
+sink_buffer_pool	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  GstBufferPool *sink_buffer_pool;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+sink_pad	tests/check/gsttiovxdlcolorblend.c	/^  PadTemplateSink sink_pad;$/;"	m	struct:__anon55	file:
+sink_pad	tests/check/gsttiovxdlpreproc.c	/^  PadTemplateSink sink_pad;$/;"	m	struct:__anon45	file:
+sink_pad	tests/check/gsttiovxisp.c	/^  PadTemplate sink_pad;$/;"	m	struct:__anon50	file:
+sink_pad	tests/check/gsttiovxmosaic.c	/^  PadTemplate sink_pad;$/;"	m	struct:__anon42	file:
+sink_template	ext/tiovx/gsttidlinferer.cpp	/^    sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxcolorconvert.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxdelay.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxdemux.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxdlcolorconvert.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxdlpreproc.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxdof.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxdofviz.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxisp.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink_%u",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxldc.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxmemalloc.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxmosaic.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink_%u",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxmultiscaler.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxmux.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink_%u",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxpyramid.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiovxsdeviz.c	/^static GstStaticPadTemplate sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sink_template	ext/tiovx/gsttiperfoverlay.cpp	/^    sink_template = GST_STATIC_PAD_TEMPLATE ("sink",$/;"	v	file:
+sinkpad	ext/tiovx/gsttiovxdemux.c	/^  GstTIOVXPad *sinkpad;$/;"	m	struct:_GstTIOVXDemux	file:
+sinkpad	gst-libs/gst/tiovx/gsttiovxsimo.c	/^  GstTIOVXPad *sinkpad;$/;"	m	struct:_GstTIOVXSimoPrivate	file:
+size	gst-libs/gst/tiovx/gsttiovxallocator.h	/^  gsize size;$/;"	m	struct:_GstTIOVXMemoryData
+size	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  guint size;$/;"	m	struct:_GstTIOVXPyramidInfo
+small_font_property	ext/tiovx/gsttiperfoverlay.cpp	/^      small_font_property;$/;"	m	struct:_GstTIPerfOverlay	file:
+split_triplet	crossbuild/environment	/^split_triplet() {$/;"	f
+src_pad	ext/tiovx/gsttidlpostproc.cpp	/^      src_pad;$/;"	m	struct:_GstTIDLPostProc	file:
+src_pad	tests/check/gsttiovxdlcolorblend.c	/^  PadTemplateSrc src_pad;$/;"	m	struct:__anon55	file:
+src_pad	tests/check/gsttiovxdlpreproc.c	/^  PadTemplateSrc src_pad;$/;"	m	struct:__anon45	file:
+src_pad	tests/check/gsttiovxmosaic.c	/^  PadTemplate src_pad;$/;"	m	struct:__anon42	file:
+src_pads	tests/check/gsttiovxisp.c	/^  PadTemplate src_pads;$/;"	m	struct:__anon50	file:
+src_template	ext/tiovx/gsttidlinferer.cpp	/^    src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttidlpostproc.cpp	/^    src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxcolorconvert.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxdelay.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxdemux.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src_%u",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxdlcolorblend.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxdlcolorconvert.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxdlpreproc.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxdof.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxdofviz.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxisp.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxldc.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src_%u",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxmemalloc.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxmosaic.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxmultiscaler.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src_%u",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxmux.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxpyramid.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxsde.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiovxsdeviz.c	/^static GstStaticPadTemplate src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+src_template	ext/tiovx/gsttiperfoverlay.cpp	/^    src_template = GST_STATIC_PAD_TEMPLATE ("src",$/;"	v	file:
+srcpads	ext/tiovx/gsttiovxdemux.c	/^  GList *srcpads;$/;"	m	struct:_GstTIOVXDemux	file:
+srcpads	gst-libs/gst/tiovx/gsttiovxsimo.c	/^  GList *srcpads;$/;"	m	struct:_GstTIOVXSimoPrivate	file:
+start_pad	tests/check/libs/gsttiovxpad.c	/^start_pad (GstTIOVXPad * pad)$/;"	f	file:
+start_tiovx	tests/check/libs/gsttiovxpad.c	/^start_tiovx (void)$/;"	f	file:
+startx	ext/tiovx/gsttiovxmosaic.c	/^  gint startx[MAX_NUM_CHANNELS];$/;"	m	struct:_GstTIOVXMosaicPad	file:
+starty	ext/tiovx/gsttiovxmosaic.c	/^  gint starty[MAX_NUM_CHANNELS];$/;"	m	struct:_GstTIOVXMosaicPad	file:
+stop	ext/tiovx/gsttidlpostproc.cpp	/^      stop;$/;"	m	struct:_GstTIDLPostProc	file:
+target	tests/check/gsttiovxdlcolorblend.c	/^  const gchar **target;$/;"	m	struct:__anon55	file:
+target	tests/check/gsttiovxisp.c	/^  const gchar **target;$/;"	m	struct:__anon49	file:
+target	tests/check/gsttiovxmosaic.c	/^  const gchar **target;$/;"	m	struct:__anon41	file:
+target_id	ext/tiovx/gsttiovxcolorconvert.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXColorconvert	file:
+target_id	ext/tiovx/gsttiovxdlcolorblend.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXDLColorBlend	file:
+target_id	ext/tiovx/gsttiovxdlcolorconvert.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXDLColorconvert	file:
+target_id	ext/tiovx/gsttiovxdlpreproc.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXDLPreProc	file:
+target_id	ext/tiovx/gsttiovxdof.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXDOF	file:
+target_id	ext/tiovx/gsttiovxdofviz.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXDofViz	file:
+target_id	ext/tiovx/gsttiovxisp.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXISP	file:
+target_id	ext/tiovx/gsttiovxldc.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXLDC	file:
+target_id	ext/tiovx/gsttiovxmosaic.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXMosaic	file:
+target_id	ext/tiovx/gsttiovxmultiscaler.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXMultiScaler	file:
+target_id	ext/tiovx/gsttiovxpyramid.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXPyramid	file:
+target_id	ext/tiovx/gsttiovxsde.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXSde	file:
+target_id	ext/tiovx/gsttiovxsdeviz.c	/^  gint target_id;$/;"	m	struct:_GstTIOVXSdeViz	file:
+target_id_to_target_name	ext/tiovx/gsttiovxcolorconvert.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxdlcolorblend.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxdlcolorconvert.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxdof.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxdofviz.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxisp.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxldc.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxmosaic.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxmultiscaler.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxpyramid.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxsde.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+target_id_to_target_name	ext/tiovx/gsttiovxsdeviz.c	/^target_id_to_target_name (gint target_id)$/;"	f	file:
+tensor_buf	ext/tiovx/gsttidlpostproc.cpp	/^      tensor_buf;$/;"	m	struct:_GstTIDLPostProc	file:
+tensor_format	ext/tiovx/gsttiovxdlpreproc.c	/^  gint tensor_format;$/;"	m	struct:_GstTIOVXDLPreProc	file:
+tensor_format	tests/check/gsttiovxdlpreproc.c	/^  const gchar **tensor_format;$/;"	m	struct:__anon44	file:
+tensor_info	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  GstTIOVXTensorInfo tensor_info;$/;"	m	struct:_GstTIOVXTensorMeta
+tensor_pad	ext/tiovx/gsttidlpostproc.cpp	/^      tensor_pad;$/;"	m	struct:_GstTIDLPostProc	file:
+tensor_pad	ext/tiovx/gsttiovxdlcolorblend.c	/^  GstPad *tensor_pad;$/;"	m	struct:_GstTIOVXDLColorBlend	file:
+tensor_pad	tests/check/gsttiovxdlcolorblend.c	/^  PadTemplateTensor tensor_pad;$/;"	m	struct:__anon55	file:
+tensor_ref	ext/tiovx/gsttidlpostproc.cpp	/^      tensor_ref;$/;"	m	struct:_GstTIDLPostProc	file:
+tensor_sink_template	ext/tiovx/gsttidlpostproc.cpp	/^    tensor_sink_template = GST_STATIC_PAD_TEMPLATE ("tensor",$/;"	v	file:
+tensor_sink_template	ext/tiovx/gsttiovxdlcolorblend.c	/^static GstStaticPadTemplate tensor_sink_template =$/;"	v	file:
+tensor_size	gst-libs/gst/tiovx/gsttiovxtensormeta.h	/^  vx_size tensor_size;$/;"	m	struct:_GstTIOVXTensorInfo
+test_create_pipeline	tests/check/test_utils.h	/^test_create_pipeline (const gchar * pipe_desc)$/;"	f
+test_create_pipeline_fail	tests/check/test_utils.h	/^test_create_pipeline_fail (const gchar * pipe_desc)$/;"	f
+test_lines	tests/check/gsttiovx_multiple_transitions.c	/^static const gchar *test_lines[] = {$/;"	v	file:
+test_new_buffer	tests/check/libs/gsttiovxtensorbufferpool.c	/^test_new_buffer (vx_enum data_type, vx_size expected_size)$/;"	f	file:
+test_pipelines	tests/check/gsttiovxmultiscaler.c	/^static const gchar *test_pipelines[] = {$/;"	v	file:
+test_states_change_async	tests/check/test_utils.h	/^test_states_change_async (const gchar * pipe_desc, guint num_state_changes)$/;"	f
+test_states_change_async_fail	tests/check/test_utils.h	/^test_states_change_async_fail (const gchar * pipe_desc, guint num_state_changes)$/;"	f
+test_states_change_async_fail_success	tests/check/test_utils.h	/^test_states_change_async_fail_success (const gchar * pipe_desc, guint num_state_changes)$/;"	f
+test_states_change_base	tests/check/test_utils.h	/^test_states_change_base (const gchar * pipe_desc,$/;"	f
+test_states_change_fail	tests/check/test_utils.h	/^test_states_change_fail (const gchar * pipe_desc, guint num_state_changes)$/;"	f
+test_states_change_success	tests/check/test_utils.h	/^test_states_change_success (const gchar * pipe_desc, guint num_state_changes)$/;"	f
+test_tiovx_siso_input_param_index	tests/check/libs/gsttiovxsiso.c	/^static const int test_tiovx_siso_input_param_index = 0;$/;"	v	file:
+test_tiovx_siso_output_param_index	tests/check/libs/gsttiovxsiso.c	/^static const int test_tiovx_siso_output_param_index = 1;$/;"	v	file:
+text_color	ext/tiovx/gsttiperfoverlay.cpp	/^      text_color;$/;"	m	struct:_GstTIPerfOverlay	file:
+texture_filter_enable	ext/tiovx/gsttiovxsde.c	/^  gboolean texture_filter_enable;$/;"	m	struct:_GstTIOVXSde	file:
+texture_filter_enable_default	ext/tiovx/gsttiovxsde.c	/^static const gboolean texture_filter_enable_default = FALSE;$/;"	v	file:
+threshold_left_right	ext/tiovx/gsttiovxsde.c	/^  gint threshold_left_right;$/;"	m	struct:_GstTIOVXSde	file:
+threshold_left_right_default	ext/tiovx/gsttiovxsde.c	/^static const int threshold_left_right_default = 3;$/;"	v	file:
+threshold_left_right_max	ext/tiovx/gsttiovxsde.c	/^static const int threshold_left_right_max = 255;$/;"	v	file:
+threshold_left_right_min	ext/tiovx/gsttiovxsde.c	/^static const int threshold_left_right_min = 0;$/;"	v	file:
+threshold_texture	ext/tiovx/gsttiovxsde.c	/^  gint threshold_texture;$/;"	m	struct:_GstTIOVXSde	file:
+threshold_texture_default	ext/tiovx/gsttiovxsde.c	/^static const int threshold_texture_default = 100;$/;"	v	file:
+threshold_texture_max	ext/tiovx/gsttiovxsde.c	/^static const int threshold_texture_max = 255;$/;"	v	file:
+threshold_texture_min	ext/tiovx/gsttiovxsde.c	/^static const int threshold_texture_min = 0;$/;"	v	file:
+ti_2a_wrapper	ext/tiovx/gsttiovxisp.c	/^  TI_2A_wrapper ti_2a_wrapper;$/;"	m	struct:_GstTIOVXIspPad	file:
+ti_ovx_init	ext/tiovx/gsttiovx.c	/^ti_ovx_init (GstPlugin * plugin)$/;"	f	file:
+tiovx_array_lenght	gst-libs/gst/tiovx/gsttiovxrawimagemeta.c	/^static const vx_size tiovx_array_lenght = 1;$/;"	v	file:
+tiovx_context	ext/tiovx/gsttidlpostproc.cpp	/^      tiovx_context;$/;"	m	struct:_GstTIDLPostProc	file:
+tiovx_context	ext/tiovx/gsttiovxdemux.c	/^  GstTIOVXContext *tiovx_context;$/;"	m	struct:_GstTIOVXDemux	file:
+tiovx_context	ext/tiovx/gsttiovxmemalloc.c	/^  GstTIOVXContext *tiovx_context;$/;"	m	struct:_GstTIOVXMemAlloc	file:
+tiovx_context	ext/tiovx/gsttiovxmux.c	/^  GstTIOVXContext *tiovx_context;$/;"	m	struct:_GstTIOVXMux	file:
+tiovx_context	ext/tiovx/gsttiperfoverlay.cpp	/^      tiovx_context;$/;"	m	struct:_GstTIPerfOverlay	file:
+tiovx_context	gst-libs/gst/tiovx/gsttiovxmiso.c	/^  GstTIOVXContext *tiovx_context;$/;"	m	struct:_GstTIOVXMisoPrivate	file:
+tiovx_context	gst-libs/gst/tiovx/gsttiovxsimo.c	/^  GstTIOVXContext *tiovx_context;$/;"	m	struct:_GstTIOVXSimoPrivate	file:
+tiovx_context	gst-libs/gst/tiovx/gsttiovxsiso.c	/^  GstTIOVXContext *tiovx_context;$/;"	m	struct:_GstTIOVXSisoPrivate	file:
+tiovxdlcolorblend_data_type	tests/check/gsttiovxdlcolorblend.c	/^    * tiovxdlcolorblend_data_type[TIOVXDLCOLORBLEND_DATA_TYPE_ARRAY_SIZE] = {$/;"	v	file:
+tiovxdlcolorblend_data_type_enum	tests/check/gsttiovxdlcolorblend.c	/^    tiovxdlcolorblend_data_type_enum$/;"	v	typeref:enum:vx_type_e	file:
+tiovxdlcolorblend_formats	tests/check/gsttiovxdlcolorblend.c	/^    * tiovxdlcolorblend_formats[TIOVXDLCOLORBLEND_FORMATS_ARRAY_SIZE] = {$/;"	v	file:
+tiovxdlcolorblend_height	tests/check/gsttiovxdlcolorblend.c	/^static const guint tiovxdlcolorblend_height[] = { 1, 1080 };$/;"	v	file:
+tiovxdlcolorblend_num_classes	tests/check/gsttiovxdlcolorblend.c	/^static const guint64 tiovxdlcolorblend_num_classes[] = { 0, 4294967295U };$/;"	v	file:
+tiovxdlcolorblend_pool_size	tests/check/gsttiovxdlcolorblend.c	/^static const guint tiovxdlcolorblend_pool_size[] = { 2, 16 };$/;"	v	file:
+tiovxdlcolorblend_targets	tests/check/gsttiovxdlcolorblend.c	/^    * tiovxdlcolorblend_targets[TIOVXDLCOLORBLEND_TARGETS_ARRAY_SIZE] = {$/;"	v	file:
+tiovxdlcolorblend_width	tests/check/gsttiovxdlcolorblend.c	/^static const guint tiovxdlcolorblend_width[] = { 1, 2048 };$/;"	v	file:
+tiovxdlpreproc_channel_order	tests/check/gsttiovxdlpreproc.c	/^    * tiovxdlpreproc_channel_order[TIOVXDLPREPROC_CHANNEL_ORDER_ARRAY_SIZE] = {$/;"	v	file:
+tiovxdlpreproc_data_type	tests/check/gsttiovxdlpreproc.c	/^    * tiovxdlpreproc_data_type[TIOVXDLPREPROC_DATA_TYPE_ARRAY_SIZE] = {$/;"	v	file:
+tiovxdlpreproc_formats	tests/check/gsttiovxdlpreproc.c	/^static const gchar *tiovxdlpreproc_formats[TIOVXDLPREPROC_FORMATS_ARRAY_SIZE] = {$/;"	v	file:
+tiovxdlpreproc_framerate	tests/check/gsttiovxdlpreproc.c	/^static const guint tiovxdlpreproc_framerate[] = { 1, 2147483647 };$/;"	v	file:
+tiovxdlpreproc_height	tests/check/gsttiovxdlpreproc.c	/^static const guint tiovxdlpreproc_height[] = { 1, 1080 };$/;"	v	file:
+tiovxdlpreproc_mean	tests/check/gsttiovxdlpreproc.c	/^static const gdouble tiovxdlpreproc_mean[] = { 0.0, 255.0 };$/;"	v	file:
+tiovxdlpreproc_scale	tests/check/gsttiovxdlpreproc.c	/^static const gdouble tiovxdlpreproc_scale[] = { 0.0, 1.0 };$/;"	v	file:
+tiovxdlpreproc_tensor_format	tests/check/gsttiovxdlpreproc.c	/^    * tiovxdlpreproc_tensor_format[TIOVXDLPREPROC_TENSOR_FORMAT_ARRAY_SIZE] = {$/;"	v	file:
+tiovxdlpreproc_width	tests/check/gsttiovxdlpreproc.c	/^static const guint tiovxdlpreproc_width[] = { 1, 2048 };$/;"	v	file:
+tiovxisp_ae_num_skip_frames	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_ae_num_skip_frames = { 0, 4294967295 };$/;"	v	file:
+tiovxisp_analog_gain	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_analog_gain = { 0, 4294967295 };$/;"	v	file:
+tiovxisp_awb_num_skip_frames	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_awb_num_skip_frames = { 0, 4294967295 };$/;"	v	file:
+tiovxisp_color_temperature	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_color_temperature = { 0, 4294967295 };$/;"	v	file:
+tiovxisp_dcc	tests/check/gsttiovxisp.c	/^static const DCC *tiovxisp_dcc[TIOVXISP_DCC_ARRAY_SIZE] = {$/;"	v	file:
+tiovxisp_dcc_imx219	tests/check/gsttiovxisp.c	/^static const DCC tiovxisp_dcc_imx219 =$/;"	v	file:
+tiovxisp_exposure_time	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_exposure_time = { 0, 4294967295 };$/;"	v	file:
+tiovxisp_format_msb	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_format_msb = { 1, 16 };$/;"	v	file:
+tiovxisp_height	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_height = { 1, 1080 };$/;"	v	file:
+tiovxisp_input_formats	tests/check/gsttiovxisp.c	/^static const gchar *tiovxisp_input_formats[TIOVXISP_INPUT_FORMATS_ARRAY_SIZE] = {$/;"	v	file:
+tiovxisp_lines_interleaved	tests/check/gsttiovxisp.c	/^static const gboolean tiovxisp_lines_interleaved[] = { FALSE, TRUE };$/;"	v	file:
+tiovxisp_meta_height_after	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_meta_height_after = { 0, 8192 };$/;"	v	file:
+tiovxisp_meta_height_before	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_meta_height_before = { 0, 8192 };$/;"	v	file:
+tiovxisp_num_exposures	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_num_exposures = { 1, 3 };$/;"	v	file:
+tiovxisp_output_formats	tests/check/gsttiovxisp.c	/^static const gchar *tiovxisp_output_formats[TIOVXISP_OUTPUT_FORMATS_ARRAY_SIZE]$/;"	v	file:
+tiovxisp_pool_size	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_pool_size = { 2, 16 };$/;"	v	file:
+tiovxisp_target	tests/check/gsttiovxisp.c	/^static const gchar *tiovxisp_target[TIOVXISP_TARGET_ARRAY_SIZE] = {$/;"	v	file:
+tiovxisp_width	tests/check/gsttiovxisp.c	/^static const Range tiovxisp_width = { 1, 2048 };$/;"	v	file:
+tiovxmosaic_formats	tests/check/gsttiovxmosaic.c	/^static const gchar *tiovxmosaic_formats[TIOVXMOSAIC_FORMATS_ARRAY_SIZE] = {$/;"	v	file:
+tiovxmosaic_framerate	tests/check/gsttiovxmosaic.c	/^static const guint tiovxmosaic_framerate[] = { 1, 2147483647 };$/;"	v	file:
+tiovxmosaic_height	tests/check/gsttiovxmosaic.c	/^static const guint tiovxmosaic_height[] = { 1, 8192 };$/;"	v	file:
+tiovxmosaic_target	tests/check/gsttiovxmosaic.c	/^static const gchar *tiovxmosaic_target[TIOVXMOSAIC_TARGET_ARRAY_SIZE] = {$/;"	v	file:
+tiovxmosaic_width	tests/check/gsttiovxmosaic.c	/^static const guint tiovxmosaic_width[] = { 1, 8192 };$/;"	v	file:
+title	ext/tiovx/gsttiperfoverlay.cpp	/^      title;$/;"	m	struct:_GstTIPerfOverlay	file:
+title_font_property	ext/tiovx/gsttiperfoverlay.cpp	/^      title_font_property;$/;"	m	struct:_GstTIPerfOverlay	file:
+tivx_raw_format_to_gst_format	gst-libs/gst/tiovx/gsttiovxutils.c	/^tivx_raw_format_to_gst_format (const enum tivx_raw_image_pixel_container_e$/;"	f
+top_n	ext/tiovx/gsttidlpostproc.cpp	/^      top_n;$/;"	m	struct:_GstTIDLPostProc	file:
+types	gst-libs/gst/tiovx/gsttidloutmeta.h	/^  guint types[MAX_TIDL_OUTPUTS];$/;"	m	struct:_GstTiDlOutMeta
+update_fps_interval	ext/tiovx/gsttiperfoverlay.cpp	/^      update_fps_interval;$/;"	m	struct:_GstTIPerfOverlay	file:
+update_fps_interval_m	ext/tiovx/gsttiperfoverlay.cpp	/^      update_fps_interval_m;$/;"	m	struct:_GstTIPerfOverlay	file:
+update_perf_stats	ext/tiovx/gsttiperfoverlay.cpp	/^update_perf_stats (GstTIPerfOverlay * self)$/;"	f	file:
+update_stats_interval	ext/tiovx/gsttiperfoverlay.cpp	/^      update_stats_interval;$/;"	m	struct:_GstTIPerfOverlay	file:
+update_stats_interval_m	ext/tiovx/gsttiperfoverlay.cpp	/^      update_stats_interval_m;$/;"	m	struct:_GstTIPerfOverlay	file:
+upwards_search_range	ext/tiovx/gsttiovxdof.c	/^  gint upwards_search_range;$/;"	m	struct:_GstTIOVXDOF	file:
+user_data_allocator	ext/tiovx/gsttiovxisp.c	/^  GstTIOVXAllocator *user_data_allocator;$/;"	m	struct:_GstTIOVXISP	file:
+user_data_allocator	ext/tiovx/gsttiovxmosaic.c	/^  GstTIOVXAllocator *user_data_allocator;$/;"	m	struct:_GstTIOVXMosaic	file:
+uv_offset	ext/tiovx/gsttiperfoverlay.cpp	/^      uv_offset;$/;"	m	struct:_GstTIPerfOverlay	file:
+validate_caps	gst-libs/gst/tiovx/gsttiovxbufferpool.h	/^  gboolean (*validate_caps) (GstTIOVXBufferPool * self, const GstCaps * caps,$/;"	m	struct:_GstTIOVXBufferPoolClass
+vertical_search_range_default	ext/tiovx/gsttiovxdof.c	/^static const int vertical_search_range_default = 48;$/;"	v	file:
+vertical_search_range_max	ext/tiovx/gsttiovxdof.c	/^static const int vertical_search_range_max = 62;$/;"	v	file:
+vertical_search_range_min	ext/tiovx/gsttiovxdof.c	/^static const int vertical_search_range_min = 0;$/;"	v	file:
+videodev	ext/tiovx/gsttiovxisp.c	/^  gchar *videodev;$/;"	m	struct:_GstTIOVXIspPad	file:
+viss_obj	ext/tiovx/gsttiovxisp.c	/^  TIOVXVISSModuleObj viss_obj;$/;"	m	struct:_GstTIOVXISP	file:
+viz_confidence	ext/tiovx/gsttiovxsdeviz.c	/^  guint viz_confidence;$/;"	m	struct:_GstTIOVXSdeViz	file:
+viz_threshold	ext/tiovx/gsttidlpostproc.cpp	/^      viz_threshold;$/;"	m	struct:_GstTIDLPostProc	file:
+vx_format_to_gst_format	gst-libs/gst/tiovx/gsttiovxutils.c	/^vx_format_to_gst_format (const vx_df_image format)$/;"	f
+width	ext/tiovx/gsttiovxmosaic.c	/^  gint width[MAX_NUM_CHANNELS];$/;"	m	struct:_GstTIOVXMosaicPad	file:
+width	gst-libs/gst/tiovx/gsttiovximagemeta.h	/^  guint width;$/;"	m	struct:_GstTIOVXImageInfo
+width	gst-libs/gst/tiovx/gsttiovxpyramidmeta.h	/^  guint width;$/;"	m	struct:_GstTIOVXPyramidInfo
+width	tests/check/gsttiovxdlcolorblend.c	/^  const guint *width;$/;"	m	struct:__anon52	file:
+width	tests/check/gsttiovxdlcolorblend.c	/^  const guint *width;$/;"	m	struct:__anon53	file:
+width	tests/check/gsttiovxdlcolorblend.c	/^  const guint *width;$/;"	m	struct:__anon54	file:
+width	tests/check/gsttiovxdlpreproc.c	/^  const guint *width;$/;"	m	struct:__anon43	file:
+width	tests/check/gsttiovxmosaic.c	/^  const guint *width;$/;"	m	struct:__anon40	file:
+width_range	tests/check/gsttiovxisp.c	/^  const Range *width_range;$/;"	m	struct:__anon48	file:
+widths	gst-libs/gst/tiovx/gsttidloutmeta.h	/^  guint widths[MAX_TIDL_OUTPUTS];$/;"	m	struct:_GstTiDlOutMeta
+window_downscaling_max_ratio	ext/tiovx/gsttiovxmosaic.c	/^static const int window_downscaling_max_ratio = 4;$/;"	v	file:


### PR DESCRIPTION
Add support to dump stats on terminal. Also, remove option of overlay text, since its redundant

Signed-off-by: Rahul T R <r-ravikumar@ti.com>