### PR TITLE
ext: tiovx: isp: Get meta before and after from caps

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxrawimagebufferpool.c
@@ -129,6 +129,7 @@ gst_tiovx_raw_image_buffer_pool_validate_caps (GstTIOVXBufferPool * self,
   GstTIOVXRawImageBufferPool *raw_buffer_pool = NULL;
   GstStructure *structure = NULL;
   gint gst_img_width = 0, gst_img_height = 0;
+  gint gst_meta_height_before = 0, gst_meta_height_after = 0;
   tivx_raw_image_format_t tivx_format = { };
   uint32_t tivx_img_width = 0, tivx_img_height = 0;
   gboolean ret = FALSE;
@@ -142,6 +143,10 @@ gst_tiovx_raw_image_buffer_pool_validate_caps (GstTIOVXBufferPool * self,
   structure = gst_caps_get_structure (caps, 0);
   gst_structure_get_int (structure, "width", &gst_img_width);
   gst_structure_get_int (structure, "height", &gst_img_height);
+  gst_structure_get_int (structure, "meta-height-before",
+      &gst_meta_height_before);
+  gst_structure_get_int (structure, "meta-height-after",
+      &gst_meta_height_after);
 
   gst_format = gst_structure_get_string (structure, "format");
 
@@ -157,7 +162,8 @@ gst_tiovx_raw_image_buffer_pool_validate_caps (GstTIOVXBufferPool * self,
     goto out;
   }
 
-  if (gst_img_height != tivx_img_height) {
+  if (gst_img_height - gst_meta_height_before - gst_meta_height_after
+        != tivx_img_height) {
     GST_ERROR_OBJECT (self, "Exemplar and caps's height don't match");
     goto out;
   }

--- a/gst-libs/gst/tiovx/gsttiovxutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxutils.c
@@ -731,6 +731,7 @@ gst_tiovx_get_exemplar_from_caps (GObject * object, GstDebugCategory * category,
     tivx_raw_image_format_t TIOVXImageFormat = { };
     GstStructure *caps_st = NULL;
     const gchar *format_str = NULL;
+    gint meta_height_before = 0, meta_height_after = 0;
 
     if (!gst_video_info_from_caps (&info, caps)) {
       GST_CAT_ERROR_OBJECT (category, object,
@@ -744,13 +745,17 @@ gst_tiovx_get_exemplar_from_caps (GObject * object, GstDebugCategory * category,
     TIOVXImageFormat.pixel_container =
         gst_format_to_tivx_raw_format (format_str);
 
+    gst_structure_get_int (caps_st, "meta-height-before", &meta_height_before);
+    gst_structure_get_int (caps_st, "meta-height-after", &meta_height_after);
+    raw_image_params.meta_height_before = meta_height_before;
+    raw_image_params.meta_height_after = meta_height_after;
     raw_image_params.width = GST_VIDEO_INFO_WIDTH (&info);
-    raw_image_params.height = GST_VIDEO_INFO_HEIGHT (&info);
+    raw_image_params.height = GST_VIDEO_INFO_HEIGHT (&info)
+                              - raw_image_params.meta_height_before
+                              - raw_image_params.meta_height_after;
     raw_image_params.num_exposures = RAW_IMAGE_NUM_EXPOSURES;
     raw_image_params.line_interleaved = FALSE;
     raw_image_params.format[0] = TIOVXImageFormat;
-    raw_image_params.meta_height_before = 0;
-    raw_image_params.meta_height_after = 0;
 
     GST_CAT_INFO_OBJECT (category, object,
         "creating raw image with width: %d\t height: %d\t format: 0x%x",


### PR DESCRIPTION
Get meta before and after from caps insted of property, which makes to simpler to validate and create exemplars using caps

Signed-off-by: Rahul T R <r-ravikumar@ti.com>