### PR TITLE
gst-libs: Use neon intrinsics for memcpy

### DIFF
--- a/ext/tiovx/gsttiovxdlpreproc.c
+++ b/ext/tiovx/gsttiovxdlpreproc.c
@@ -634,8 +634,8 @@ gst_tiovx_dl_pre_proc_init_module (GstTIOVXSiso * trans,
   preproc->params.channel_order = self->channel_order;
   preproc->params.tensor_format = self->tensor_format;
 
-  memcpy (preproc->params.scale, self->scale, sizeof (preproc->params.scale));
-  memcpy (preproc->params.mean, self->mean, sizeof (preproc->params.mean));
+  memcpy_neon (preproc->params.scale, self->scale, sizeof (preproc->params.scale));
+  memcpy_neon (preproc->params.mean, self->mean, sizeof (preproc->params.mean));
 
   GST_DEBUG_OBJECT (self, "Preproc Scale parameters: %f, %f, %f",
       preproc->params.scale[0], preproc->params.scale[1],

--- a/gst-libs/gst/tiovx/gsttiovxbufferutils.c
+++ b/gst-libs/gst/tiovx/gsttiovxbufferutils.c
@@ -232,7 +232,7 @@ gst_tiovx_buffer_copy (GstDebugCategory * category, GstBufferPool * pool,
   if (in_info.size == out_size) {
     GST_CAT_LOG (gst_tiovx_buffer_performance,
         "Both buffers have the same size, copying as is");
-    memcpy ((void *) ti_memory->mem_ptr.host_ptr, in_info.data, out_size);
+    memcpy_neon ((void *) ti_memory->mem_ptr.host_ptr, in_info.data, out_size);
     goto free;
   }
 
@@ -246,7 +246,7 @@ gst_tiovx_buffer_copy (GstDebugCategory * category, GstBufferPool * pool,
         plane_steps_x[plane_idx];
 
     for (j = 0; j < plane_heights[plane_idx] / plane_steps_y[plane_idx]; j++) {
-      memcpy ((void *) out_data_ptr, in_data_ptr, copy_size);
+      memcpy_neon ((void *) out_data_ptr, in_data_ptr, copy_size);
       total_copied += copy_size;
 
       in_data_ptr += copy_size;

--- a/gst-libs/gst/tiovx/gsttiovxsensormeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxsensormeta.c
@@ -149,14 +149,14 @@ gst_buffer_add_tiovx_sensor_meta (GstBuffer * buffer,
   sensor_meta->meta_before_size = meta_before_size;
   if (sensor_meta->meta_before_size) {
     sensor_meta->meta_before = g_malloc (sensor_meta->meta_before_size);
-    memcpy (sensor_meta->meta_before, meta_before,
+    memcpy_neon (sensor_meta->meta_before, meta_before,
         sensor_meta->meta_before_size);
   }
 
   sensor_meta->meta_after_size = meta_after_size;
   if (sensor_meta->meta_after_size) {
     sensor_meta->meta_after = g_malloc (sensor_meta->meta_after_size);
-    memcpy (sensor_meta->meta_after, meta_after, sensor_meta->meta_after_size);
+    memcpy_neon (sensor_meta->meta_after, meta_after, sensor_meta->meta_after_size);
   }
 
   return sensor_meta;

--- a/gst-libs/gst/tiovx/gsttiovxutils.h
+++ b/gst-libs/gst/tiovx/gsttiovxutils.h
@@ -265,4 +265,12 @@ gst_tioxv_get_pyramid_caps_info (GObject * object, GstDebugCategory * category,
     const GstCaps * caps, gint * levels, gdouble * scale, gint * width, gint * height,
     GstVideoFormat * format);
 
+/**
+ * memcpy_neon:
+ *
+ * Memcpy using neon intrinsics
+ *
+ */
+void memcpy_neon(void *dest, const void *src, size_t len);
+
 #endif /* __GST_TIOVX_UTILS_H__ */


### PR DESCRIPTION
To improve the latency while importing buffers
from non tiovx buffer pools