### PR TITLE
ext: tiovx: preproc: Initiate DL Inferer in ARM Only mode

### DIFF
--- a/ext/tiovx/gsttiovxdlpreproc.cpp
+++ b/ext/tiovx/gsttiovxdlpreproc.cpp
@@ -967,7 +967,7 @@ gst_tiovx_dl_pre_proc_parse_model (GstTIOVXDLPreProc * self)
 
     // Make inferer config for tensor data-type
     inferer_config = new InfererConfig;
-    status = inferer_config->getConfig (self->model, TRUE, 1);
+    status = inferer_config->getConfig (self->model, FALSE, 1);
     if (status < 0) {
       GST_ERROR_OBJECT (self, "Failed to get inferer config");
       return;

--- a/ext/tiovx/gsttipreproc.cpp
+++ b/ext/tiovx/gsttipreproc.cpp
@@ -684,7 +684,7 @@ gst_ti_pre_proc_parse_model (GstTIPreProc * self)
 
     // Make inferer config for tensor data-type
     inferer_config = new InfererConfig;
-    status = inferer_config->getConfig (self->model, TRUE, 1);
+    status = inferer_config->getConfig (self->model, FALSE, 1);
     if (status < 0) {
       GST_ERROR_OBJECT (self, "Failed to get inferer config");
       return;


### PR DESCRIPTION
Initiate DL Inferer in ARM Only mode for reading the output data type. Output data type does not change on tidl offload.