### PR TITLE
Remove volatile from GType

### DIFF
--- a/ext/ti/gsttiperfoverlay.cpp
+++ b/ext/ti/gsttiperfoverlay.cpp
@@ -1096,7 +1096,7 @@ overlay_perf_stats_text (GstTIPerfOverlay * self)
               self->overlay_color);
 
   value = self->cpu_load->cpu_load / 100u;
-  if (value < 50) {
+  if (value <= 50) {
     text_color = self->color_green;
   } else if (value > 50 && value <= 80) {
     text_color = self->color_yellow;
@@ -1121,7 +1121,7 @@ overlay_perf_stats_text (GstTIPerfOverlay * self)
     if (appIpcIsCpuEnabled (cpu_id) && NULL != g_strrstr (cpuName, "c7x")) {
       c7x_load = self->c7x_loads[cpu_id];
       value = c7x_load.cpu_load / 100u;
-      if (value < 50) {
+      if (value <= 50) {
         text_color = self->color_green;
       } else if (value > 50 && value <= 80) {
         text_color = self->color_yellow;
@@ -1151,7 +1151,7 @@ overlay_perf_stats_text (GstTIPerfOverlay * self)
           && hwaLoad->total_time > 0) {
         load = (hwaLoad->active_time * 10000) / hwaLoad->total_time;
         value = load / 100;
-        if (value < 50) {
+        if (value <= 50) {
           text_color = self->color_green;
         } else if (value > 50 && value <= 80) {
           text_color = self->color_yellow;

--- a/gst-libs/gst/ti/gsttidloutmeta.c
+++ b/gst-libs/gst/ti/gsttidloutmeta.c
@@ -70,7 +70,7 @@ static gboolean gst_tidl_out_meta_init (GstMeta * meta,
 GType
 gst_tidl_out_meta_api_get_type (void)
 {
-  static volatile GType type = 0;
+  static GType type = 0;
   static const gchar *tags[] =
       { GST_META_TAG_VIDEO_STR, GST_META_TAG_MEMORY_STR, NULL };
 

--- a/gst-libs/gst/tiovx/gsttiovximagemeta.c
+++ b/gst-libs/gst/tiovx/gsttiovximagemeta.c
@@ -73,7 +73,7 @@ static gboolean gst_tiovx_image_meta_init (GstMeta * meta,
 GType
 gst_tiovx_image_meta_api_get_type (void)
 {
-  static volatile GType type = 0;
+  static GType type = 0;
   static const gchar *tags[] =
       { GST_META_TAG_VIDEO_STR, GST_META_TAG_MEMORY_STR, NULL };
 

--- a/gst-libs/gst/tiovx/gsttiovxmuxmeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxmuxmeta.c
@@ -74,7 +74,7 @@ static void gst_tiovx_meta_free (GstMeta * meta, GstBuffer * buffer);
 GType
 gst_tiovx_mux_meta_api_get_type (void)
 {
-  static volatile GType type = 0;
+  static GType type = 0;
   static const gchar *tags[] =
       { GST_META_TAG_VIDEO_STR, GST_META_TAG_MEMORY_STR, NULL };
 

--- a/gst-libs/gst/tiovx/gsttiovxpyramidmeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxpyramidmeta.c
@@ -73,7 +73,7 @@ static gboolean gst_tiovx_pyramid_meta_init (GstMeta * meta,
 GType
 gst_tiovx_pyramid_meta_api_get_type (void)
 {
-  static volatile GType type = 0;
+  static GType type = 0;
   static const gchar *tags[] =
       /* No Video tag needed */
   { GST_META_TAG_MEMORY_STR, NULL };

--- a/gst-libs/gst/tiovx/gsttiovxrawimagemeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxrawimagemeta.c
@@ -75,7 +75,7 @@ static gboolean gst_tiovx_meta_init (GstMeta * meta,
 GType
 gst_tiovx_raw_image_meta_api_get_type (void)
 {
-  static volatile GType type = 0;
+  static GType type = 0;
   static const gchar *tags[] =
       { GST_META_TAG_VIDEO_STR, GST_META_TAG_MEMORY_STR, NULL };
 

--- a/gst-libs/gst/tiovx/gsttiovxtensormeta.c
+++ b/gst-libs/gst/tiovx/gsttiovxtensormeta.c
@@ -71,9 +71,9 @@ static gboolean gst_tiovx_tensor_meta_init (GstMeta * meta,
 GType
 gst_tiovx_tensor_meta_api_get_type (void)
 {
-  static volatile GType type = 0;
+  static GType type = 0;
   static const gchar *tags[] =
-      /* No Video tag needed */
+  /* No Video tag needed */
   { GST_META_TAG_MEMORY_STR, NULL };
 
   if (g_once_init_enter (&type)) {


### PR DESCRIPTION
Remove volatile from GType as g_once_init_enter
ignores volatile keyword