### PR TITLE
HACK: gst-libs: tiovxbufferpool: Set max buffers to min

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovxbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxbufferpool.c
@@ -155,6 +155,9 @@ gst_tiovx_buffer_pool_set_config (GstBufferPool * pool, GstStructure * config)
     goto error;
   }
 
+  gst_buffer_pool_config_set_params (config, caps, size, min_buffers,
+          min_buffers);
+
   if (NULL == caps) {
     GST_ERROR_OBJECT (self, "Requested buffer pool configuration without caps");
     goto error;


### PR DESCRIPTION
All tiovx elements configures both min and max buffers equal to pool size resulting allocation of exact pool size number of buffers. whereas if pool size is configured by some upstream element ex: v4l2h264dec it might configure different min and max. This is resulting in some issue with HW decoder piplines in j721s2, j784s4 and am62a, since there is a limitation in dmabuf import feature cannot work with newly allocated buffers
Fix this by setting max and min, in bufferpool set config