### PR TITLE
Revert "tiovxmiso: Increase minimum pool size"

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovxmiso.c
+++ b/gst-libs/gst/tiovx/gsttiovxmiso.c
@@ -76,7 +76,7 @@
 #include <gst/video/video.h>
 
 /* BufferPool constants */
-#define MIN_POOL_SIZE 4
+#define MIN_POOL_SIZE 2
 #define MAX_POOL_SIZE 16
 
 


### PR DESCRIPTION
This reverts commit 63024e5e320fa47e7a4e0e9de94e324f802c08b3.

This was done as a workaround for cpature not working with dmabuf import. Root cause for this was found in a patch in gst plugins good and fixed now