### PR TITLE
Revert "HACK: gst-libs: tiovxbufferpool: Set max buffers to min"

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovxbufferpool.c
+++ b/gst-libs/gst/tiovx/gsttiovxbufferpool.c
@@ -155,9 +155,6 @@ gst_tiovx_buffer_pool_set_config (GstBufferPool * pool, GstStructure * config)
     goto error;
   }
 
-  gst_buffer_pool_config_set_params (config, caps, size, min_buffers,
-          min_buffers);
-
   if (NULL == caps) {
     GST_ERROR_OBJECT (self, "Requested buffer pool configuration without caps");
     goto error;


### PR DESCRIPTION
This reverts commit 450f6280e2f0ebca6ff9f4c9f4a74902f3fba293.

This is now handled in gst-plugins-good patch in yocto layer