### PR TITLE
Fixes "ext: tiovx: mosaic: Use vxQueryImage to get stride info"

### DIFF
--- a/ext/tiovx/gsttiovxmosaic.c
+++ b/ext/tiovx/gsttiovxmosaic.c
@@ -1404,7 +1404,7 @@ gst_tiovx_mosaic_load_background_image (GstTIOVXMosaic * self,
   vx_status status = VX_FAILURE;
   gboolean ret = FALSE;
   void *addr = NULL;
-  guint num_planes = 0;
+  vx_size num_planes = 0;
   vx_size data_size = 0;
   GstTIOVXMemoryData *ti_memory = NULL;
   FILE *background_img_file = NULL;
@@ -1429,7 +1429,7 @@ gst_tiovx_mosaic_load_background_image (GstTIOVXMosaic * self,
         background_img);
     goto out;
   }
-  GST_DEBUG_OBJECT (self, "Number of planes for background image: %d",
+  GST_DEBUG_OBJECT (self, "Number of planes for background image: %lu",
       num_planes);
 
   status =
@@ -1508,7 +1508,7 @@ gst_tiovx_mosaic_load_background_image (GstTIOVXMosaic * self,
   if (data_size == file_size) {
     GST_DEBUG_OBJECT (self,
         "Got background image with no padding; width matches stride");
-    fread (addr, 1, 0, background_img_file);
+    fread (addr, 1, file_size, background_img_file);
   } else {
     void  *plane_addr = addr;
 

--- a/gst-libs/gst/tiovx/gsttiovximagemeta.c
+++ b/gst-libs/gst/tiovx/gsttiovximagemeta.c
@@ -110,7 +110,7 @@ gst_tiovx_image_meta_init (GstMeta * meta, gpointer params, GstBuffer * buffer)
 
 static void
 gst_tiovx_image_meta_get_plane_info (const vx_image image,
-    guint * num_planes, gint * plane_stride_x, gint * plane_stride_y,
+    vx_size * num_planes, gint * plane_stride_x, gint * plane_stride_y,
     gint * plane_step_x, gint * plane_step_y, gint * plane_width,
     gint * plane_height, guint * plane_offsets, guint * plane_sizes)
 {
@@ -156,7 +156,7 @@ gst_buffer_add_tiovx_image_meta (GstBuffer * buffer,
   gint plane_heights[MODULE_MAX_NUM_PLANES] = { 0 };
   vx_uint32 plane_sizes[MODULE_MAX_NUM_PLANES];
   vx_uint32 plane_offsets[MODULE_MAX_NUM_PLANES];
-  guint num_planes = 0;
+  vx_size num_planes = 0;
   guint plane_idx = 0;
   gint i = 0;
   vx_object_array array;


### PR DESCRIPTION
Fixes commit c901be6750f57742ce2afa013b84ebf2b16e5639. Fix data type for num_planes guint -> vx_size