### PR TITLE
ext: ti: tiperfoverlay: Fix a warning with updated in apps_utils

### DIFF
--- a/ext/ti/gsttiperfoverlay.cpp
+++ b/ext/ti/gsttiperfoverlay.cpp
@@ -777,7 +777,7 @@ dump_perf_stats (GstTIPerfOverlay * self)
 
   app_perf_stats_cpu_load_t cpu_load;
   for (guint cpu_id = 0; cpu_id < APP_IPC_CPU_MAX; cpu_id++) {
-    gchar *cpuName = appIpcGetCpuName(cpu_id);
+    const gchar *cpuName = appIpcGetCpuName(cpu_id);
     if (appIpcIsCpuEnabled (cpu_id) &&
         (NULL != g_strrstr (cpuName, "c7x") ||
         NULL != g_strrstr (cpuName, "mcu"))) {


### PR DESCRIPTION
gchar *cpu_name -> const gchar *cpu_name