### PR TITLE
miso: Fix enqueue and setting ref list

### DIFF
--- a/ext/tiovx/gsttiovxdof.c
+++ b/ext/tiovx/gsttiovxdof.c
@@ -625,20 +625,20 @@ gst_tiovx_dof_get_node_info (GstTIOVXMiso * agg,
             "sink") == 0) {
       gst_tiovx_miso_pad_set_params (pad, dof->obj.input.arr[0],
           (vx_reference *) & dof->obj.input.pyramid_handle[0],
-          dof->obj.input.graph_parameter_index, input_param_id);
+          dof->obj.input.graph_parameter_index, input_param_id, 0);
     } else
         if (g_strcmp0 (GST_PAD_TEMPLATE_NAME_TEMPLATE (GST_PAD_PAD_TEMPLATE
                 (pad)), "delayed_sink") == 0) {
       gst_tiovx_miso_pad_set_params (pad, dof->obj.input_ref.arr[0],
           (vx_reference *) & dof->obj.input_ref.pyramid_handle[0],
-          dof->obj.input_ref.graph_parameter_index, input_ref_param_id);
+          dof->obj.input_ref.graph_parameter_index, input_ref_param_id, 0);
     }
   }
 
   gst_tiovx_miso_pad_set_params (GST_TIOVX_MISO_PAD (src_pad),
       dof->obj.output_flow_vector.arr[0],
       (vx_reference *) & dof->obj.output_flow_vector.image_handle[0],
-      dof->obj.output_flow_vector.graph_parameter_index, output_flow_param_id);
+      dof->obj.output_flow_vector.graph_parameter_index, output_flow_param_id, 0);
 
   *node = dof->obj.node;
   return TRUE;

--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -1380,7 +1380,7 @@ gst_tiovx_isp_get_node_info (GstTIOVXMiso * agg,
     if (0 == i) {
       gst_tiovx_miso_pad_set_params (sink_pad,
           NULL, (vx_reference *) & self->viss_obj.input.image_handle[i],
-          graph_parameter_index, input_param_id);
+          graph_parameter_index, input_param_id, 0);
       graph_parameter_index++;
 
     } else {
@@ -1388,7 +1388,7 @@ gst_tiovx_isp_get_node_info (GstTIOVXMiso * agg,
           vxGetObjectArrayItem (self->viss_obj.input.arr[0], i);
 
       gst_tiovx_miso_pad_set_params (sink_pad,
-          NULL, (vx_reference *) & self->input_references[i], -1, -1);
+          NULL, (vx_reference *) & self->input_references[i], -1, -1, 0);
     }
   }
 
@@ -1397,7 +1397,7 @@ gst_tiovx_isp_get_node_info (GstTIOVXMiso * agg,
     gst_tiovx_miso_pad_set_params (GST_TIOVX_MISO_PAD (src_pad),
         self->viss_obj.output0.arr[0],
         (vx_reference *) & self->viss_obj.output0.image_handle[0],
-        graph_parameter_index, output0_param_id);
+        graph_parameter_index, output0_param_id, 0);
   }
 
   if (self->viss_obj.params.enable_bayer_op)
@@ -1407,7 +1407,7 @@ gst_tiovx_isp_get_node_info (GstTIOVXMiso * agg,
     gst_tiovx_miso_pad_set_params (GST_TIOVX_MISO_PAD (src_pad),
         self->viss_obj.output2.arr[0],
         (vx_reference *) & self->viss_obj.output2.image_handle[0],
-        graph_parameter_index, output2_param_id);
+        graph_parameter_index, output2_param_id, 0);
   }
   graph_parameter_index++;
 

--- a/ext/tiovx/gsttiovxmosaic.c
+++ b/ext/tiovx/gsttiovxmosaic.c
@@ -1003,18 +1003,19 @@ gst_tiovx_mosaic_get_node_info (GstTIOVXMiso * agg,
 
     gst_tiovx_miso_pad_set_params (pad, mosaic->obj.inputs[i].arr[0],
         (vx_reference *) & mosaic->obj.inputs[i].image_handle[0],
-        mosaic->obj.inputs[i].graph_parameter_index, input_param_id_start + i);
+        mosaic->obj.inputs[i].graph_parameter_index, input_param_id_start + i,
+        1);
     i++;
   }
 
   gst_tiovx_miso_pad_set_params (GST_TIOVX_MISO_PAD (src_pad),
       NULL, (vx_reference *) & mosaic->obj.output_image[0],
-      mosaic->obj.output_graph_parameter_index, output_param_id);
+      mosaic->obj.output_graph_parameter_index, output_param_id, 0);
 
   if (background_pad) {
     /* Background image isn't queued/dequeued use -1 to skip it */
     gst_tiovx_miso_pad_set_params (background_pad,
-        NULL, (vx_reference *) & mosaic->obj.background_image[0], -1, -1);
+        NULL, (vx_reference *) & mosaic->obj.background_image[0], -1, -1, 0);
   }
 
   *node = mosaic->obj.node;

--- a/ext/tiovx/gsttiovxsde.c
+++ b/ext/tiovx/gsttiovxsde.c
@@ -857,20 +857,20 @@ gst_tiovx_sde_get_node_info (GstTIOVXMiso * agg,
             "left_sink") == 0) {
       gst_tiovx_miso_pad_set_params (pad, sde->obj.input_left.arr[0],
           (vx_reference *) & sde->obj.input_left.image_handle[0],
-          sde->obj.input_left.graph_parameter_index, input_left_param_id);
+          sde->obj.input_left.graph_parameter_index, input_left_param_id, 0);
     } else
         if (g_strcmp0 (GST_PAD_TEMPLATE_NAME_TEMPLATE (GST_PAD_PAD_TEMPLATE
                 (pad)), "right_sink") == 0) {
       gst_tiovx_miso_pad_set_params (pad, sde->obj.input_right.arr[0],
           (vx_reference *) & sde->obj.input_right.image_handle[0],
-          sde->obj.input_right.graph_parameter_index, input_right_param_id);
+          sde->obj.input_right.graph_parameter_index, input_right_param_id, 0);
     }
   }
 
   gst_tiovx_miso_pad_set_params (GST_TIOVX_MISO_PAD (src_pad),
       sde->obj.output.arr[0],
       (vx_reference *) & sde->obj.output.image_handle[0],
-      sde->obj.output.graph_parameter_index, output_param_id);
+      sde->obj.output.graph_parameter_index, output_param_id, 0);
 
   *node = sde->obj.node;
   return TRUE;

--- a/gst-libs/gst/tiovx/gsttiovxmiso.h
+++ b/gst-libs/gst/tiovx/gsttiovxmiso.h
@@ -151,6 +151,7 @@ struct _GstTIOVXMisoPadClass
  * @exemplar: VX reference that this pad should use as reference for allocation
  * @graph_param_id: Parameter id that will be used to enqueue this parameter to the Vx Graph
  * @node_param_id: Parameter id that will be used to configure the node
+ * @enqueue_arr: Enqueue object array instead of exempler, if true
  *
  * Sets an exemplar and a param id to the pad, these will be used for future configuration of the
  * given pad.
@@ -163,7 +164,7 @@ struct _GstTIOVXMisoPadClass
  * Returns: nothing
  */
 void gst_tiovx_miso_pad_set_params (GstTIOVXMisoPad *pad, vx_object_array array,
-  vx_reference* exemplar, gint graph_param_id, gint node_param_id);
+  vx_reference* exemplar, gint graph_param_id, gint node_param_id, vx_bool enqueue_arr);
 
 /**
  * gst_tiovx_miso_pad_get_pool_size:

--- a/tests/check/libs/gsttiovxmiso.c
+++ b/tests/check/libs/gsttiovxmiso.c
@@ -165,11 +165,11 @@ gst_test_tiovx_miso_get_node_info (GstTIOVXMiso * agg, GList * sink_pads_list,
     GstTIOVXMisoPad *pad = GST_TIOVX_MISO_PAD (l->data);
 
     gst_tiovx_miso_pad_set_params (pad,
-        test_miso->input[i], &test_miso->input_ref[i], i, i);
+        test_miso->input[i], &test_miso->input_ref[i], i, i, 0);
   }
 
   gst_tiovx_miso_pad_set_params (GST_TIOVX_MISO_PAD (GST_AGGREGATOR
-          (agg)->srcpad), test_miso->output, &test_miso->output_ref, i, i);
+          (agg)->srcpad), test_miso->output, &test_miso->output_ref, i, i, 0);
 
   *node = test_miso->node;
 


### PR DESCRIPTION
Some nodes need objext array to be enqueued, instead of first element