### PR TITLE
titvm: Add TVM inference plugin (titvm) for AM62D

### DIFF
--- a/ext/ti/gstdspkernel.cpp
+++ b/ext/ti/gstdspkernel.cpp
@@ -1,0 +1,746 @@
+/* SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2026 Texas Instruments Incorporated
+ *
+ * Generic DSP kernel transform element implementation.
+ * Handles STFT, ISTFT, deinterleave, and interleave operations.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "gstdspkernel.h"
+#include <gst/gst.h>
+#include <gst/base/gstbasetransform.h>
+#include <string.h>
+#include <stdint.h>
+
+extern "C"
+{
+#include "rpmsg.h"
+#include "dmabuf.h"
+}
+
+GST_DEBUG_CATEGORY_STATIC (gst_dsp_kernel_debug_category);
+#define GST_CAT_DEFAULT gst_dsp_kernel_debug_category
+
+/* DSP message structure */
+struct c7x_msg_hdr
+{
+  uint32_t type;
+  uint32_t seq;
+  uint32_t len;
+  int32_t status;
+} __attribute__((packed));
+
+struct dsp_msg
+{
+  struct c7x_msg_hdr hdr;
+  uint32_t input_buffer;
+  uint32_t output_buffer;
+  uint32_t input_size;
+  uint32_t output_size;
+  uint32_t graph_id;
+} __attribute__((packed));
+
+#define C7X_STATUS_SUCCESS 0
+
+/* Property IDs */
+enum
+{
+  PROP_0,
+  PROP_RPROC_DEVICE,
+  PROP_RPROC_ID,
+  PROP_REMOTE_EP,
+  PROP_MSG_TYPE,
+  PROP_MSG_RESP_TYPE,
+  PROP_INPUT_BUF_SIZE,
+  PROP_OUTPUT_BUF_SIZE,
+  PROP_PARAM0,
+  PROP_PARAM1,
+  PROP_PARAM2,
+  PROP_HOP_SIZE,
+  PROP_FFT_SIZE,
+  PROP_WINDOW_FRAMES,
+  PROP_BATCH_SIZE,
+};
+
+/* Defaults */
+#define DEFAULT_RPROC_DEVICE    "/dev/remoteproc0"
+#define DEFAULT_RPROC_ID        8
+#define DEFAULT_REMOTE_EP       13
+#define DEFAULT_MSG_TYPE        0
+#define DEFAULT_MSG_RESP_TYPE   0
+#define DEFAULT_INPUT_BUF_SIZE  (64 * 1024)
+#define DEFAULT_OUTPUT_BUF_SIZE (256 * 1024)
+#define DEFAULT_PARAM0          0
+#define DEFAULT_PARAM1          0
+#define DEFAULT_PARAM2          0
+#define DEFAULT_HOP_SIZE        160
+#define DEFAULT_FFT_SIZE        320
+#define DEFAULT_WINDOW_FRAMES   401
+#define DEFAULT_BATCH_SIZE      64
+
+/* Function prototypes */
+static void gst_dsp_kernel_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec);
+static void gst_dsp_kernel_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec);
+static void gst_dsp_kernel_finalize (GObject * object);
+static gboolean gst_dsp_kernel_start (GstBaseTransform * trans);
+static gboolean gst_dsp_kernel_stop (GstBaseTransform * trans);
+static GstFlowReturn gst_dsp_kernel_transform_ip (GstBaseTransform * trans,
+    GstBuffer * buf);
+
+static GstStaticPadTemplate dsp_kernel_sink_template =
+GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK, GST_PAD_ALWAYS, GST_STATIC_CAPS ("application/octet-stream"));
+static GstStaticPadTemplate dsp_kernel_src_template =
+GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC, GST_PAD_ALWAYS, GST_STATIC_CAPS ("application/octet-stream"));
+
+#define gst_dsp_kernel_parent_class parent_class
+G_DEFINE_TYPE_WITH_CODE (GstDspKernel, gst_dsp_kernel, GST_TYPE_BASE_TRANSFORM,
+    GST_DEBUG_CATEGORY_INIT (gst_dsp_kernel_debug_category, "tidspkernel", 0,
+        "TI DSP Kernel Transform"));
+
+static void
+gst_dsp_kernel_class_init (GstDspKernelClass * klass)
+{
+  GObjectClass *gobject_class = G_OBJECT_CLASS (klass);
+  GstBaseTransformClass *bt = GST_BASE_TRANSFORM_CLASS (klass);
+
+  gst_element_class_add_pad_template (GST_ELEMENT_CLASS (klass),
+      gst_static_pad_template_get (&dsp_kernel_sink_template));
+  gst_element_class_add_pad_template (GST_ELEMENT_CLASS (klass),
+      gst_static_pad_template_get (&dsp_kernel_src_template));
+  gst_element_class_set_static_metadata (GST_ELEMENT_CLASS (klass),
+      "TI DSP Kernel Transform", "Transform/DSP",
+      "Generic DSP kernel offload (STFT/ISTFT/Deinterleave/Interleave) via RPMsg-DMA",
+      "Pratham Deshmukh <p-deshmukh@ti.com>");
+
+  gobject_class->set_property = gst_dsp_kernel_set_property;
+  gobject_class->get_property = gst_dsp_kernel_get_property;
+  gobject_class->finalize = gst_dsp_kernel_finalize;
+
+  bt->start = GST_DEBUG_FUNCPTR (gst_dsp_kernel_start);
+  bt->stop = GST_DEBUG_FUNCPTR (gst_dsp_kernel_stop);
+  bt->transform_ip = GST_DEBUG_FUNCPTR (gst_dsp_kernel_transform_ip);
+  bt->passthrough_on_same_caps = FALSE;
+
+  /* Install properties */
+  g_object_class_install_property (gobject_class, PROP_RPROC_DEVICE,
+      g_param_spec_string ("rproc-device", "Remoteproc Device",
+          "Remoteproc cdev for DMA buffer physical address lookup",
+          DEFAULT_RPROC_DEVICE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_RPROC_ID,
+      g_param_spec_uint ("rproc-id", "Remote Processor ID",
+          "Linux remoteproc core ID (8 = C7x_0 on AM62D)",
+          0, G_MAXUINT, DEFAULT_RPROC_ID,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_REMOTE_EP,
+      g_param_spec_uint ("remote-ep", "Remote RPMsg Endpoint",
+          "RPMsg endpoint number running DSP firmware",
+          0, G_MAXUINT, DEFAULT_REMOTE_EP,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_MSG_TYPE,
+      g_param_spec_uint ("msg-type", "DSP Message Type",
+          "IPC message type (0x1020=STFT, 0x1030=ISTFT, 0x1040=De/Interleave)",
+          0, G_MAXUINT, DEFAULT_MSG_TYPE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_MSG_RESP_TYPE,
+      g_param_spec_uint ("msg-resp-type", "DSP Response Type",
+          "Expected response opcode (0 = auto-derive)",
+          0, G_MAXUINT, DEFAULT_MSG_RESP_TYPE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_INPUT_BUF_SIZE,
+      g_param_spec_uint ("input-buf-size", "Input Buffer Size",
+          "DMA input buffer size in bytes",
+          1, G_MAXUINT, DEFAULT_INPUT_BUF_SIZE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_OUTPUT_BUF_SIZE,
+      g_param_spec_uint ("output-buf-size", "Output Buffer Size",
+          "DMA output buffer size in bytes",
+          0, G_MAXUINT, DEFAULT_OUTPUT_BUF_SIZE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_PARAM0,
+      g_param_spec_uint ("param0", "Parameter 0",
+          "DSP kernel parameter 0 (input_frames for STFT/ISTFT)",
+          0, G_MAXUINT, DEFAULT_PARAM0,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_PARAM1,
+      g_param_spec_uint ("param1", "Parameter 1",
+          "DSP kernel parameter 1 (output_frames/fft_size)",
+          0, G_MAXUINT, DEFAULT_PARAM1,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_PARAM2,
+      g_param_spec_uint ("param2", "Parameter 2",
+          "DSP kernel parameter 2 (graph_id/flag: 0=deinterleave, 1=interleave)",
+          0, G_MAXUINT, DEFAULT_PARAM2,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_HOP_SIZE,
+      g_param_spec_uint ("hop-size", "Hop Size",
+          "Hop size between frames (for STFT/ISTFT)",
+          1, 8192, DEFAULT_HOP_SIZE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_FFT_SIZE,
+      g_param_spec_uint ("fft-size", "FFT Size",
+          "FFT size in samples (for STFT/ISTFT)",
+          1, 8192, DEFAULT_FFT_SIZE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_WINDOW_FRAMES,
+      g_param_spec_uint ("window-frames", "Window Frames",
+          "Total frames to accumulate (for STFT/ISTFT)",
+          1, 8192, DEFAULT_WINDOW_FRAMES,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_BATCH_SIZE,
+      g_param_spec_uint ("batch-size", "Batch Size",
+          "Frames per batch (for STFT/ISTFT)",
+          1, 8192, DEFAULT_BATCH_SIZE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+}
+
+static void
+gst_dsp_kernel_init (GstDspKernel * kernel)
+{
+  gst_base_transform_set_in_place (GST_BASE_TRANSFORM (kernel), TRUE);
+
+  kernel->rproc_device = g_strdup (DEFAULT_RPROC_DEVICE);
+  kernel->rproc_id = DEFAULT_RPROC_ID;
+  kernel->remote_ep = DEFAULT_REMOTE_EP;
+  kernel->msg_type = DEFAULT_MSG_TYPE;
+  kernel->msg_resp_type = DEFAULT_MSG_RESP_TYPE;
+  kernel->input_buf_size = DEFAULT_INPUT_BUF_SIZE;
+  kernel->output_buf_size = DEFAULT_OUTPUT_BUF_SIZE;
+  kernel->param0 = DEFAULT_PARAM0;
+  kernel->param1 = DEFAULT_PARAM1;
+  kernel->param2 = DEFAULT_PARAM2;
+  kernel->hop_size = DEFAULT_HOP_SIZE;
+  kernel->fft_size = DEFAULT_FFT_SIZE;
+  kernel->window_frames = DEFAULT_WINDOW_FRAMES;
+  kernel->batch_size = DEFAULT_BATCH_SIZE;
+
+  kernel->rpmsg_chan = NULL;
+  kernel->sequence_number = 1;
+  kernel->dma_allocated = FALSE;
+
+  kernel->stft_accumulator = NULL;
+  kernel->stft_accumulated_samples = 0;
+  kernel->stft_total_samples = 0;
+
+  kernel->istft_overlap_buffer = NULL;
+  kernel->istft_overlap_samples = 0;
+
+  memset (&kernel->dma_input, 0, sizeof (kernel->dma_input));
+  memset (&kernel->dma_output, 0, sizeof (kernel->dma_output));
+}
+
+static void
+gst_dsp_kernel_set_property (GObject * object, guint prop_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstDspKernel *kernel = GST_DSP_KERNEL (object);
+  GST_OBJECT_LOCK (kernel);
+  switch (prop_id) {
+    case PROP_RPROC_DEVICE:
+      g_free (kernel->rproc_device);
+      kernel->rproc_device = g_value_dup_string (value);
+      break;
+    case PROP_RPROC_ID:
+      kernel->rproc_id = g_value_get_uint (value);
+      break;
+    case PROP_REMOTE_EP:
+      kernel->remote_ep = g_value_get_uint (value);
+      break;
+    case PROP_MSG_TYPE:
+      kernel->msg_type = g_value_get_uint (value);
+      break;
+    case PROP_MSG_RESP_TYPE:
+      kernel->msg_resp_type = g_value_get_uint (value);
+      break;
+    case PROP_INPUT_BUF_SIZE:
+      kernel->input_buf_size = g_value_get_uint (value);
+      break;
+    case PROP_OUTPUT_BUF_SIZE:
+      kernel->output_buf_size = g_value_get_uint (value);
+      break;
+    case PROP_PARAM0:
+      kernel->param0 = g_value_get_uint (value);
+      break;
+    case PROP_PARAM1:
+      kernel->param1 = g_value_get_uint (value);
+      break;
+    case PROP_PARAM2:
+      kernel->param2 = g_value_get_uint (value);
+      break;
+    case PROP_HOP_SIZE:
+      kernel->hop_size = g_value_get_uint (value);
+      break;
+    case PROP_FFT_SIZE:
+      kernel->fft_size = g_value_get_uint (value);
+      break;
+    case PROP_WINDOW_FRAMES:
+      kernel->window_frames = g_value_get_uint (value);
+      break;
+    case PROP_BATCH_SIZE:
+      kernel->batch_size = g_value_get_uint (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+  }
+  GST_OBJECT_UNLOCK (kernel);
+}
+
+static void
+gst_dsp_kernel_get_property (GObject * object, guint prop_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstDspKernel *kernel = GST_DSP_KERNEL (object);
+  GST_OBJECT_LOCK (kernel);
+  switch (prop_id) {
+    case PROP_RPROC_DEVICE:
+      g_value_set_string (value, kernel->rproc_device);
+      break;
+    case PROP_RPROC_ID:
+      g_value_set_uint (value, kernel->rproc_id);
+      break;
+    case PROP_REMOTE_EP:
+      g_value_set_uint (value, kernel->remote_ep);
+      break;
+    case PROP_MSG_TYPE:
+      g_value_set_uint (value, kernel->msg_type);
+      break;
+    case PROP_MSG_RESP_TYPE:
+      g_value_set_uint (value, kernel->msg_resp_type);
+      break;
+    case PROP_INPUT_BUF_SIZE:
+      g_value_set_uint (value, kernel->input_buf_size);
+      break;
+    case PROP_OUTPUT_BUF_SIZE:
+      g_value_set_uint (value, kernel->output_buf_size);
+      break;
+    case PROP_PARAM0:
+      g_value_set_uint (value, kernel->param0);
+      break;
+    case PROP_PARAM1:
+      g_value_set_uint (value, kernel->param1);
+      break;
+    case PROP_PARAM2:
+      g_value_set_uint (value, kernel->param2);
+      break;
+    case PROP_HOP_SIZE:
+      g_value_set_uint (value, kernel->hop_size);
+      break;
+    case PROP_FFT_SIZE:
+      g_value_set_uint (value, kernel->fft_size);
+      break;
+    case PROP_WINDOW_FRAMES:
+      g_value_set_uint (value, kernel->window_frames);
+      break;
+    case PROP_BATCH_SIZE:
+      g_value_set_uint (value, kernel->batch_size);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+  }
+  GST_OBJECT_UNLOCK (kernel);
+}
+
+static void
+gst_dsp_kernel_finalize (GObject * object)
+{
+  GstDspKernel *kernel = GST_DSP_KERNEL (object);
+  g_free (kernel->rproc_device);
+  if (kernel->stft_accumulator) {
+    g_free (kernel->stft_accumulator);
+    kernel->stft_accumulator = NULL;
+  }
+  if (kernel->istft_overlap_buffer) {
+    g_free (kernel->istft_overlap_buffer);
+    kernel->istft_overlap_buffer = NULL;
+  }
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+static gboolean
+gst_dsp_kernel_start (GstBaseTransform * trans)
+{
+  GstDspKernel *kernel = GST_DSP_KERNEL (trans);
+
+  g_print ("TI DSP Kernel Element\n");
+  g_print ("=====================\n");
+  g_print ("[DSP] msg-type: 0x%04x ", kernel->msg_type);
+  switch (kernel->msg_type) {
+    case DSP_OP_STFT:
+      g_print ("(STFT)\n");
+      kernel->stft_total_samples = kernel->hop_size * kernel->window_frames;
+      kernel->stft_accumulator = g_new0 (gint16, kernel->stft_total_samples);
+      kernel->stft_accumulated_samples = 0;
+      g_print ("[DSP] STFT: accumulating %zu samples (%.2f sec @ 16kHz)\n",
+          kernel->stft_total_samples, kernel->stft_total_samples / 16000.0);
+      break;
+    case DSP_OP_ISTFT:
+      g_print ("(ISTFT)\n");
+      kernel->istft_overlap_samples = kernel->fft_size - kernel->hop_size;
+      kernel->istft_overlap_buffer = g_new0 (gfloat, kernel->fft_size);
+      g_print ("[DSP] ISTFT: overlap-add with %zu samples\n",
+          kernel->istft_overlap_samples);
+      break;
+    case DSP_OP_DEINT_INTERLEAVE:
+      g_print ("(Deinterleave/Interleave, flag=%u)\n", kernel->param2);
+      break;
+    default:
+      g_print ("(Unknown)\n");
+      break;
+  }
+
+  /* Acquire shared RPMsg channel */
+  kernel->rpmsg_chan =
+      gst_ti_rpmsg_chan_acquire (kernel->rproc_id, kernel->remote_ep);
+  if (!kernel->rpmsg_chan) {
+    GST_ERROR_OBJECT (kernel, "Failed to acquire rpmsg channel");
+    return FALSE;
+  }
+  g_print ("[DSP] RPMsg channel acquired (fd=%d)\n", kernel->rpmsg_chan->fd);
+
+  /* Allocate DMA buffers */
+  int r1 = dmabuf_heap_init ((char *) "linux,cma", kernel->input_buf_size,
+      kernel->rproc_device, &kernel->dma_input);
+  int r2 = dmabuf_heap_init ((char *) "linux,cma", kernel->output_buf_size,
+      kernel->rproc_device, &kernel->dma_output);
+
+  if (r1 != 0 || r2 != 0) {
+    GST_ERROR_OBJECT (kernel, "DMA alloc failed (r1=%d r2=%d)", r1, r2);
+    if (r1 == 0)
+      dmabuf_heap_destroy (&kernel->dma_input);
+    gst_ti_rpmsg_chan_release (kernel->rpmsg_chan);
+    kernel->rpmsg_chan = NULL;
+    return FALSE;
+  }
+
+  kernel->dma_allocated = TRUE;
+  g_print ("[DSP] DMA buffers allocated\n");
+  g_print ("[DSP]   input:  %u bytes @ phys=0x%08lx\n",
+      kernel->input_buf_size, (unsigned long) kernel->dma_input.phys_addr);
+  g_print ("[DSP]   output: %u bytes @ phys=0x%08lx\n",
+      kernel->output_buf_size, (unsigned long) kernel->dma_output.phys_addr);
+
+  return TRUE;
+}
+
+static gboolean
+gst_dsp_kernel_stop (GstBaseTransform * trans)
+{
+  GstDspKernel *kernel = GST_DSP_KERNEL (trans);
+
+  if (kernel->dma_allocated) {
+    dmabuf_heap_destroy (&kernel->dma_input);
+    dmabuf_heap_destroy (&kernel->dma_output);
+    kernel->dma_allocated = FALSE;
+  }
+
+  if (kernel->stft_accumulator) {
+    g_free (kernel->stft_accumulator);
+    kernel->stft_accumulator = NULL;
+  }
+  kernel->stft_accumulated_samples = 0;
+
+  if (kernel->istft_overlap_buffer) {
+    g_free (kernel->istft_overlap_buffer);
+    kernel->istft_overlap_buffer = NULL;
+  }
+
+  gst_ti_rpmsg_chan_release (kernel->rpmsg_chan);
+  kernel->rpmsg_chan = NULL;
+
+  return TRUE;
+}
+
+/* Helper: Send DSP message and receive response */
+static GstFlowReturn
+dsp_kernel_send_recv (GstDspKernel * kernel, struct dsp_msg *req,
+    struct dsp_msg *resp)
+{
+  uint32_t expected_resp = kernel->msg_resp_type ?
+      kernel->msg_resp_type : ((kernel->msg_type & 0x0FFF) | 0x2000);
+
+  gst_ti_rpmsg_chan_lock (kernel->rpmsg_chan);
+
+  if (send_msg (kernel->rpmsg_chan->fd, (char *) req, sizeof (*req)) < 0) {
+    GST_ERROR_OBJECT (kernel, "send_msg failed");
+    gst_ti_rpmsg_chan_unlock (kernel->rpmsg_chan);
+    return GST_FLOW_ERROR;
+  }
+
+  int resp_len = sizeof (*resp);
+  if (recv_msg (kernel->rpmsg_chan->fd, sizeof (*resp), (char *) resp,
+          &resp_len) < 0) {
+    GST_ERROR_OBJECT (kernel, "recv_msg failed");
+    gst_ti_rpmsg_chan_unlock (kernel->rpmsg_chan);
+    return GST_FLOW_ERROR;
+  }
+
+  gst_ti_rpmsg_chan_unlock (kernel->rpmsg_chan);
+
+  if (resp->hdr.type != expected_resp || resp->hdr.status != C7X_STATUS_SUCCESS) {
+    GST_ERROR_OBJECT (kernel, "DSP error: type=0x%x status=%d",
+        resp->hdr.type, resp->hdr.status);
+    return GST_FLOW_ERROR;
+  }
+
+  return GST_FLOW_OK;
+}
+
+/* STFT transform with accumulation */
+static GstFlowReturn
+dsp_kernel_transform_stft (GstDspKernel * kernel, GstBuffer * buf)
+{
+  GstMapInfo map_info;
+  if (!gst_buffer_map (buf, &map_info, GST_MAP_READWRITE)) {
+    GST_ERROR_OBJECT (kernel, "Failed to map buffer");
+    return GST_FLOW_ERROR;
+  }
+
+  const gint16 *audio_in = (const gint16 *) map_info.data;
+  gsize incoming_samples = map_info.size / sizeof (gint16);
+
+  /* Accumulate samples */
+  gsize samples_to_copy = MIN (incoming_samples,
+      kernel->stft_total_samples - kernel->stft_accumulated_samples);
+  memcpy (kernel->stft_accumulator + kernel->stft_accumulated_samples,
+      audio_in, samples_to_copy * sizeof (gint16));
+  kernel->stft_accumulated_samples += samples_to_copy;
+
+  /* If not enough samples yet, return empty buffer */
+  if (kernel->stft_accumulated_samples < kernel->stft_total_samples) {
+    g_print ("[STFT] Accumulating... %zu/%zu samples (%.1f%%)\n",
+        kernel->stft_accumulated_samples, kernel->stft_total_samples,
+        100.0 * kernel->stft_accumulated_samples / kernel->stft_total_samples);
+    gst_buffer_set_size (buf, 0);
+    gst_buffer_unmap (buf, &map_info);
+    return GST_FLOW_OK;
+  }
+
+  g_print ("[STFT] Processing %zu samples in batches...\n",
+      kernel->stft_total_samples);
+
+  /* Calculate batches */
+  guint num_batches =
+      (kernel->window_frames + kernel->batch_size - 1) / kernel->batch_size;
+  gsize out_buf_size = num_batches * kernel->output_buf_size;
+  guint8 *spectral_out = (guint8 *) g_malloc0 (out_buf_size);
+  gsize out_written = 0;
+
+  /* Process in batches */
+  for (guint batch_idx = 0; batch_idx < num_batches; batch_idx++) {
+    guint frame_start = batch_idx * kernel->batch_size;
+    guint frames_in_batch =
+        MIN (kernel->batch_size, kernel->window_frames - frame_start);
+    gsize batch_samples = frames_in_batch * kernel->hop_size;
+    gsize batch_bytes = batch_samples * sizeof (gint16);
+    gsize sample_offset = frame_start * kernel->hop_size;
+
+    /* Copy batch to DMA input */
+    dmabuf_sync (kernel->dma_input.dma_buf_fd, DMA_BUF_SYNC_START);
+    memcpy (kernel->dma_input.kern_addr,
+        kernel->stft_accumulator + sample_offset, batch_bytes);
+    dmabuf_sync (kernel->dma_input.dma_buf_fd, DMA_BUF_SYNC_END);
+
+    /* Send to DSP */
+    struct dsp_msg req = { }, resp = { };
+    req.hdr.type = kernel->msg_type;
+    req.hdr.seq = kernel->sequence_number++;
+    req.hdr.len = sizeof (req);
+    req.input_buffer = (uint32_t) kernel->dma_input.phys_addr;
+    req.output_buffer = (uint32_t) kernel->dma_output.phys_addr;
+    req.input_size = (uint32_t) batch_bytes;
+    req.output_size = kernel->output_buf_size;
+    req.graph_id = kernel->param2;
+
+    if (dsp_kernel_send_recv (kernel, &req, &resp) != GST_FLOW_OK) {
+      g_free (spectral_out);
+      gst_buffer_unmap (buf, &map_info);
+      return GST_FLOW_ERROR;
+    }
+
+    /* Copy DSP output */
+    gsize batch_spectral_bytes = resp.output_size;
+    dmabuf_sync (kernel->dma_output.dma_buf_fd, DMA_BUF_SYNC_START);
+    memcpy (spectral_out + out_written, kernel->dma_output.kern_addr,
+        batch_spectral_bytes);
+    dmabuf_sync (kernel->dma_output.dma_buf_fd, DMA_BUF_SYNC_END);
+
+    out_written += batch_spectral_bytes;
+  }
+
+  g_print ("[STFT] Done: %zu samples → %zu spectral bytes\n",
+      kernel->stft_total_samples, out_written);
+
+  /* Reset accumulator */
+  kernel->stft_accumulated_samples = 0;
+
+  /* Replace buffer contents */
+  memcpy ((void *) map_info.data, spectral_out, out_written);
+  gst_buffer_set_size (buf, (gssize) out_written);
+
+  g_free (spectral_out);
+  gst_buffer_unmap (buf, &map_info);
+  return GST_FLOW_OK;
+}
+
+/* ISTFT transform with overlap-add */
+static GstFlowReturn
+dsp_kernel_transform_istft (GstDspKernel * kernel, GstBuffer * buf)
+{
+  GstMapInfo map_info;
+  if (!gst_buffer_map (buf, &map_info, GST_MAP_READWRITE)) {
+    GST_ERROR_OBJECT (kernel, "Failed to map buffer");
+    return GST_FLOW_ERROR;
+  }
+
+  const guint8 *spectral_in = (const guint8 *) map_info.data;
+  gsize total_spectral_bytes = map_info.size;
+
+  g_print ("[ISTFT] Processing %zu spectral bytes...\n", total_spectral_bytes);
+
+  /* Calculate batches */
+  guint num_batches =
+      (kernel->window_frames + kernel->batch_size - 1) / kernel->batch_size;
+  gsize max_output_samples = kernel->window_frames * kernel->hop_size;
+  gint16 *audio_out =
+      (gint16 *) g_malloc0 (max_output_samples * sizeof (gint16));
+  gsize out_written_samples = 0;
+  gsize spectral_offset = 0;
+
+  /* Process in batches */
+  for (guint batch_idx = 0; batch_idx < num_batches; batch_idx++) {
+    guint frame_start = batch_idx * kernel->batch_size;
+    guint frames_in_batch =
+        MIN (kernel->batch_size, kernel->window_frames - frame_start);
+    gsize batch_spectral_bytes = frames_in_batch * 322 * sizeof (float);
+
+    if (spectral_offset + batch_spectral_bytes > total_spectral_bytes) {
+      batch_spectral_bytes = total_spectral_bytes - spectral_offset;
+    }
+
+    /* Copy spectral batch to DMA input */
+    dmabuf_sync (kernel->dma_input.dma_buf_fd, DMA_BUF_SYNC_START);
+    memcpy (kernel->dma_input.kern_addr, spectral_in + spectral_offset,
+        batch_spectral_bytes);
+    dmabuf_sync (kernel->dma_input.dma_buf_fd, DMA_BUF_SYNC_END);
+
+    /* Send to DSP */
+    struct dsp_msg req = { }, resp = { };
+    req.hdr.type = kernel->msg_type;
+    req.hdr.seq = kernel->sequence_number++;
+    req.hdr.len = sizeof (req);
+    req.input_buffer = (uint32_t) kernel->dma_input.phys_addr;
+    req.output_buffer = (uint32_t) kernel->dma_output.phys_addr;
+    req.input_size = (uint32_t) batch_spectral_bytes;
+    req.output_size = kernel->output_buf_size;
+    req.graph_id = kernel->param2;
+
+    if (dsp_kernel_send_recv (kernel, &req, &resp) != GST_FLOW_OK) {
+      g_free (audio_out);
+      gst_buffer_unmap (buf, &map_info);
+      return GST_FLOW_ERROR;
+    }
+
+    /* Copy DSP output */
+    gsize batch_audio_bytes = resp.output_size;
+    gsize batch_audio_samples = batch_audio_bytes / sizeof (gint16);
+    dmabuf_sync (kernel->dma_output.dma_buf_fd, DMA_BUF_SYNC_START);
+    memcpy (audio_out + out_written_samples, kernel->dma_output.kern_addr,
+        batch_audio_bytes);
+    dmabuf_sync (kernel->dma_output.dma_buf_fd, DMA_BUF_SYNC_END);
+
+    out_written_samples += batch_audio_samples;
+    spectral_offset += batch_spectral_bytes;
+  }
+
+  g_print ("[ISTFT] Done: %zu spectral bytes → %zu audio samples\n",
+      total_spectral_bytes, out_written_samples);
+
+  /* Replace buffer contents */
+  gsize output_bytes = out_written_samples * sizeof (gint16);
+  memcpy ((void *) map_info.data, audio_out, output_bytes);
+  gst_buffer_set_size (buf, (gssize) output_bytes);
+
+  g_free (audio_out);
+  gst_buffer_unmap (buf, &map_info);
+  return GST_FLOW_OK;
+}
+
+/* Simple pass-through transform (deinterleave/interleave) */
+static GstFlowReturn
+dsp_kernel_transform_passthrough (GstDspKernel * kernel, GstBuffer * buf)
+{
+  GstMapInfo map_info;
+  if (!gst_buffer_map (buf, &map_info, GST_MAP_READWRITE)) {
+    GST_ERROR_OBJECT (kernel, "Failed to map buffer");
+    return GST_FLOW_ERROR;
+  }
+
+  gsize input_size = map_info.size;
+
+  /* Copy to DMA input */
+  dmabuf_sync (kernel->dma_input.dma_buf_fd, DMA_BUF_SYNC_START);
+  memcpy (kernel->dma_input.kern_addr, map_info.data, input_size);
+  dmabuf_sync (kernel->dma_input.dma_buf_fd, DMA_BUF_SYNC_END);
+
+  /* Send to DSP */
+  struct dsp_msg req = { }, resp = { };
+  req.hdr.type = kernel->msg_type;
+  req.hdr.seq = kernel->sequence_number++;
+  req.hdr.len = sizeof (req);
+  req.input_buffer = (uint32_t) kernel->dma_input.phys_addr;
+  req.output_buffer = (uint32_t) kernel->dma_output.phys_addr;
+  req.input_size = (uint32_t) input_size;
+  req.output_size = kernel->output_buf_size;
+  req.graph_id = kernel->param2;
+
+  if (dsp_kernel_send_recv (kernel, &req, &resp) != GST_FLOW_OK) {
+    gst_buffer_unmap (buf, &map_info);
+    return GST_FLOW_ERROR;
+  }
+
+  /* Copy DSP output */
+  gsize output_size = resp.output_size;
+  dmabuf_sync (kernel->dma_output.dma_buf_fd, DMA_BUF_SYNC_START);
+  memcpy ((void *) map_info.data, kernel->dma_output.kern_addr, output_size);
+  dmabuf_sync (kernel->dma_output.dma_buf_fd, DMA_BUF_SYNC_END);
+
+  gst_buffer_set_size (buf, (gssize) output_size);
+  gst_buffer_unmap (buf, &map_info);
+  return GST_FLOW_OK;
+}
+
+static GstFlowReturn
+gst_dsp_kernel_transform_ip (GstBaseTransform * trans, GstBuffer * buf)
+{
+  GstDspKernel *kernel = GST_DSP_KERNEL (trans);
+
+  switch (kernel->msg_type) {
+    case DSP_OP_STFT:
+      return dsp_kernel_transform_stft (kernel, buf);
+    case DSP_OP_ISTFT:
+      return dsp_kernel_transform_istft (kernel, buf);
+    case DSP_OP_DEINT_INTERLEAVE:
+    default:
+      return dsp_kernel_transform_passthrough (kernel, buf);
+  }
+}

--- a/ext/ti/gstdspkernel.h
+++ b/ext/ti/gstdspkernel.h
@@ -1,0 +1,90 @@
+/* SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2026 Texas Instruments Incorporated
+ *
+ * Generic GStreamer transform element for DSP kernel offload via TI RPMsg-DMA.
+ *
+ * Routes GStreamer buffers through C7x DSP kernels using zero-copy DMA buffers
+ * and synchronous RPMsg IPC. Supports STFT, ISTFT, deinterleave, and interleave
+ * operations with automatic state management.
+ */
+
+#ifndef __GST_DSP_KERNEL_H__
+#define __GST_DSP_KERNEL_H__
+
+#include <gst/gst.h>
+#include <gst/base/gstbasetransform.h>
+#include <stdint.h>
+#include "gsttirpmsgctx.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include "dmabuf.h"
+#ifdef __cplusplus
+}
+#endif
+
+G_BEGIN_DECLS
+
+#define GST_TYPE_DSP_KERNEL            (gst_dsp_kernel_get_type())
+#define GST_DSP_KERNEL(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj),  GST_TYPE_DSP_KERNEL, GstDspKernel))
+#define GST_DSP_KERNEL_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),   GST_TYPE_DSP_KERNEL, GstDspKernelClass))
+#define GST_IS_DSP_KERNEL(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj),  GST_TYPE_DSP_KERNEL))
+#define GST_IS_DSP_KERNEL_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),   GST_TYPE_DSP_KERNEL))
+
+typedef struct _GstDspKernel      GstDspKernel;
+typedef struct _GstDspKernelClass GstDspKernelClass;
+
+/* DSP operation types */
+typedef enum {
+    DSP_OP_PASSTHROUGH    = 0x0000,  /* No operation */
+    DSP_OP_STFT           = 0x1020,  /* STFT analysis (requires accumulation) */
+    DSP_OP_ISTFT          = 0x1030,  /* ISTFT synthesis (requires overlap-add) */
+    DSP_OP_DEINT_INTERLEAVE = 0x1040,  /* Deinterleave/Interleave (param2=flag: 0=deinterleave, 1=interleave) */
+} DspOpType;
+
+struct _GstDspKernel {
+    GstBaseTransform parent;
+
+    /* Configuration properties */
+    gchar   *rproc_device;
+    guint    rproc_id;
+    guint    remote_ep;
+    guint    msg_type;
+    guint    msg_resp_type;
+    guint    input_buf_size;
+    guint    output_buf_size;
+    guint    param0;
+    guint    param1;
+    guint    param2;
+    guint    hop_size;          /* For STFT/ISTFT */
+    guint    fft_size;          /* For STFT/ISTFT */
+    guint    window_frames;     /* For STFT/ISTFT */
+    guint    batch_size;        /* For STFT/ISTFT */
+
+    /* RPMsg and DMA */
+    GstTiRpmsgChan *rpmsg_chan;
+    guint32         sequence_number;
+    struct dma_buf_params dma_input;
+    struct dma_buf_params dma_output;
+    gboolean        dma_allocated;
+
+    /* STFT-specific state (accumulation) */
+    gint16  *stft_accumulator;
+    gsize    stft_accumulated_samples;
+    gsize    stft_total_samples;
+
+    /* ISTFT-specific state (overlap-add) */
+    gfloat  *istft_overlap_buffer;
+    gsize    istft_overlap_samples;
+};
+
+struct _GstDspKernelClass {
+    GstBaseTransformClass parent_class;
+};
+
+GType gst_dsp_kernel_get_type(void);
+
+G_END_DECLS
+
+#endif /* __GST_DSP_KERNEL_H__ */

--- a/ext/ti/gstti.c
+++ b/ext/ti/gstti.c
@@ -65,15 +65,21 @@
 
 #include <gst/gst.h>
 
+#ifndef SOC_AM62D
 #include "gstticolorconvert.h"
 #include "gsttiscaler.h"
 #include "gsttiperfoverlay.h"
 #include "gsttimosaic.h"
+#endif
 
 #if defined(DL_PLUGINS)
 #include "gsttidlpreproc.h"
 #include "gsttidlinferer.h"
 #include "gsttidlpostproc.h"
+#endif
+
+#if defined(TVM_PLUGINS)
+#include "gsttitvm.h"
 #endif
 
 /* entry point to initialize the plug-in
@@ -85,6 +91,7 @@ ti_init (GstPlugin * plugin)
 {
   gboolean ret = FALSE;
 
+#ifndef SOC_AM62D
   ret = gst_element_register (plugin, "ticolorconvert", GST_RANK_NONE,
       GST_TYPE_TI_COLOR_CONVERT);
   if (!ret) {
@@ -112,7 +119,7 @@ ti_init (GstPlugin * plugin)
     GST_ERROR ("Failed to register the timosaic element");
     goto out;
   }
-
+#endif
 #if defined(DL_PLUGINS)
   ret = gst_element_register (plugin, "tidlpreproc", GST_RANK_NONE,
       GST_TYPE_TI_DL_PRE_PROC);
@@ -120,7 +127,8 @@ ti_init (GstPlugin * plugin)
     GST_ERROR ("Failed to register the tidlpreproc element");
     goto out;
   }
-
+#endif
+#ifndef SOC_AM62D
   ret = gst_element_register (plugin, "tidlinferer", GST_RANK_NONE,
       GST_TYPE_TI_DL_INFERER);
   if (!ret) {
@@ -132,6 +140,15 @@ ti_init (GstPlugin * plugin)
       GST_TYPE_TI_DL_POST_PROC);
   if (!ret) {
     GST_ERROR ("Failed to register the tidlpostproc element");
+    goto out;
+  }
+#endif
+
+
+#if defined(TVM_PLUGINS)
+  ret = gst_element_register (plugin, "titvm", GST_RANK_NONE, GST_TYPE_TI_TVM);
+  if (!ret) {
+    GST_ERROR ("Failed to register the titvm element");
     goto out;
   }
 #endif

--- a/ext/ti/gstti.c
+++ b/ext/ti/gstti.c
@@ -82,6 +82,10 @@
 #include "gsttitvm.h"
 #endif
 
+#if defined(STFT_PLUGINS)
+#include "gstdspkernel.h"
+#endif
+
 /* entry point to initialize the plug-in
  * initialize the plug-in itself
  * register the element factories and other features
@@ -149,6 +153,16 @@ ti_init (GstPlugin * plugin)
   ret = gst_element_register (plugin, "titvm", GST_RANK_NONE, GST_TYPE_TI_TVM);
   if (!ret) {
     GST_ERROR ("Failed to register the titvm element");
+    goto out;
+  }
+#endif
+
+#if defined(STFT_PLUGINS)
+  ret =
+      gst_element_register (plugin, "tidspkernel", GST_RANK_NONE,
+      GST_TYPE_DSP_KERNEL);
+  if (!ret) {
+    GST_ERROR ("Failed to register the tidspkernel element");
     goto out;
   }
 #endif

--- a/ext/ti/gsttirpmsgctx.cpp
+++ b/ext/ti/gsttirpmsgctx.cpp
@@ -1,0 +1,99 @@
+/* SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2026 Texas Instruments Incorporated
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "gsttirpmsgctx.h"
+#include <gst/gst.h>
+
+extern "C"
+{
+#include "rpmsg.h"
+}
+
+GST_DEBUG_CATEGORY_STATIC (gst_ti_rpmsg_chan_debug);
+#define GST_CAT_DEFAULT gst_ti_rpmsg_chan_debug
+
+/* Process-wide registry of open RPMsg channels, guarded by s_lock. */
+static GMutex s_lock;
+static GList *s_channels = NULL;        /* list of GstTiRpmsgChan* */
+static gboolean s_debug_initialized = FALSE;
+
+GstTiRpmsgChan *
+gst_ti_rpmsg_chan_acquire (guint rproc_id, guint remote_ep)
+{
+  GstTiRpmsgChan *chan = NULL;
+
+  g_mutex_lock (&s_lock);
+
+  /* Initialize debug category once */
+  if (!s_debug_initialized) {
+    GST_DEBUG_CATEGORY_INIT (gst_ti_rpmsg_chan_debug, "tirpmsgchan", 0,
+        "TI RPMsg Channel Manager");
+    s_debug_initialized = TRUE;
+  }
+
+  /* Re-use an existing open channel for the same DSP endpoint. */
+  for (GList * l = s_channels; l; l = l->next) {
+    GstTiRpmsgChan *c = (GstTiRpmsgChan *) l->data;
+    if (c->rproc_id == rproc_id && c->remote_ep == remote_ep) {
+      g_atomic_int_inc (&c->refcount);
+      GST_INFO ("Reusing RPMsg channel (rproc=%u ep=%u fd=%d) refcount=%d",
+          rproc_id, remote_ep, c->fd, g_atomic_int_get (&c->refcount));
+      chan = c;
+      goto done;
+    }
+  }
+
+  /* No existing channel — open a new one. */
+  {
+    int fd = init_rpmsg ((int) rproc_id, (int) remote_ep);
+    if (fd < 0) {
+      GST_ERROR
+          ("init_rpmsg failed (rproc=%u ep=%u) — is DSP firmware loaded?",
+          rproc_id, remote_ep);
+      goto done;
+    }
+
+    chan = g_new0 (GstTiRpmsgChan, 1);
+    chan->rproc_id = rproc_id;
+    chan->remote_ep = remote_ep;
+    chan->fd = fd;
+    chan->refcount = 1;
+    g_mutex_init (&chan->mutex);
+
+    s_channels = g_list_prepend (s_channels, chan);
+    GST_INFO ("Opened RPMsg channel (rproc=%u ep=%u fd=%d)",
+        rproc_id, remote_ep, fd);
+  }
+
+done:
+  g_mutex_unlock (&s_lock);
+  return chan;
+}
+
+void
+gst_ti_rpmsg_chan_release (GstTiRpmsgChan * chan)
+{
+  if (!chan)
+    return;
+
+  g_mutex_lock (&s_lock);
+
+  if (g_atomic_int_dec_and_test (&chan->refcount)) {
+    GST_INFO ("Closing RPMsg channel (rproc=%u ep=%u fd=%d)",
+        chan->rproc_id, chan->remote_ep, chan->fd);
+    s_channels = g_list_remove (s_channels, chan);
+    cleanup_rpmsg (chan->fd);
+    g_mutex_clear (&chan->mutex);
+    g_free (chan);
+  } else {
+    GST_INFO ("Released RPMsg channel ref (rproc=%u ep=%u) refcount=%d",
+        chan->rproc_id, chan->remote_ep, g_atomic_int_get (&chan->refcount));
+  }
+
+  g_mutex_unlock (&s_lock);
+}

--- a/ext/ti/gsttirpmsgctx.h
+++ b/ext/ti/gsttirpmsgctx.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: GPL-2.0
+ * Copyright (C) 2026 Texas Instruments Incorporated
+ *
+ * Shared RPMsg channel manager for TI GStreamer plugins.
+ *
+ * All elements that target the same (rproc_id, remote_ep) pair
+ * share a single RPMsg file descriptor.  A per-channel mutex serializes
+ * send/recv pairs so concurrent elements (e.g. STFT and Deinterleave in
+ * separate GStreamer threads) cannot interleave messages to the DSP.
+ *
+ * Lifecycle:
+ *   gst_ti_rpmsg_chan_acquire() — first caller opens the channel via init_rpmsg();
+ *                                 subsequent callers get a reference to the same fd.
+ *   gst_ti_rpmsg_chan_release() — last caller closes the channel via cleanup_rpmsg().
+ */
+
+#ifndef __GST_TI_RPMSG_CTX_H__
+#define __GST_TI_RPMSG_CTX_H__
+
+#include <glib.h>
+
+G_BEGIN_DECLS
+
+typedef struct _GstTiRpmsgChan GstTiRpmsgChan;
+
+struct _GstTiRpmsgChan {
+    guint  rproc_id;    /* remote processor core ID */
+    guint  remote_ep;   /* RPMsg endpoint on DSP */
+    int    fd;          /* RPMsg character device file descriptor */
+    gint   refcount;    /* number of elements holding this channel */
+    GMutex mutex;       /* serializes one send/recv pair at a time */
+};
+
+/*
+ * Returns a pointer to the shared channel, or NULL on failure.
+ * Increments the reference count.  Thread-safe.
+ */
+GstTiRpmsgChan *gst_ti_rpmsg_chan_acquire(guint rproc_id, guint remote_ep);
+
+/*
+ * Decrements the reference count.  Closes and frees the channel when it
+ * reaches zero.  Thread-safe.  Passing NULL is a no-op.
+ */
+void gst_ti_rpmsg_chan_release(GstTiRpmsgChan *chan);
+
+/* Lock/unlock the channel's mutex around a send/recv pair. */
+static inline void gst_ti_rpmsg_chan_lock(GstTiRpmsgChan *chan) {
+    g_mutex_lock(&chan->mutex);
+}
+
+static inline void gst_ti_rpmsg_chan_unlock(GstTiRpmsgChan *chan) {
+    g_mutex_unlock(&chan->mutex);
+}
+
+G_END_DECLS
+
+#endif /* __GST_TI_RPMSG_CTX_H__ */

--- a/ext/ti/gsttitvm.cpp
+++ b/ext/ti/gsttitvm.cpp
@@ -1,0 +1,767 @@
+/*
+ * Copyright (c) [2026] Texas Instruments Incorporated
+ *
+ * All rights reserved not granted herein.
+ *
+ * Limited License.
+ *
+ * Texas Instruments Incorporated grants a world-wide, royalty-free,
+ * non-exclusive license under copyrights and patents it now or hereafter
+ * owns or controls to make, have made, use, import, offer to sell and sell
+ * ("Utilize") this software subject to the terms herein.  With respect to
+ * the foregoing patent license, such license is granted  solely to the extent
+ * that any such patent is necessary to Utilize the software alone.
+ * The patent license shall not apply to any combinations which include
+ * this software, other than combinations with devices manufactured by or
+ * for TI (“TI Devices”).  No hardware patent is licensed hereunder.
+ *
+ * Redistributions must preserve existing copyright notices and reproduce
+ * this license (including the above copyright notice and the disclaimer
+ * and (if applicable) source code license limitations below) in the
+ * documentation and/or other materials provided with the distribution
+ *
+ * Redistribution and use in binary form, without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * *	No reverse engineering, decompilation, or disassembly of this software
+ *      is permitted with respect to any software provided in binary form.
+ *
+ * *	Any redistribution and use are licensed by TI for use only with TI Devices.
+ *
+ * *	Nothing shall obligate TI to provide you with source code for the
+ *      software licensed and provided to you in object code.
+ *
+ * If software source code is provided to you, modification and redistribution
+ * of the source code are permitted provided that the following conditions are met:
+ *
+ * *	Any redistribution and use of the source code, including any resulting
+ *      derivative works, are licensed by TI for use only with TI Devices.
+ *
+ * *	Any redistribution and use of any object code compiled from the source
+ *      code and any resulting derivative works, are licensed by TI for use
+ *      only with TI Devices.
+ *
+ * Neither the name of Texas Instruments Incorporated nor the names of its
+ * suppliers may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * DISCLAIMER.
+ *
+ * THIS SOFTWARE IS PROVIDED BY TI AND TI’S LICENSORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL TI AND TI’S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EV
+ */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "gsttitvm.h"
+#include <gst/gst.h>
+#include <gst/base/gstbasetransform.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <chrono>
+#include <algorithm>
+
+/* TVM C++ Runtime includes */
+#include <tvm/runtime/module.h>
+#include <tvm/runtime/registry.h>
+#include <tvm/runtime/packed_func.h>
+#include <tvm/runtime/ndarray.h>
+#include <tvm/runtime/container/map.h>
+
+using namespace
+    tvm::runtime;
+
+GST_DEBUG_CATEGORY_STATIC (gst_ti_tvm_debug_category);
+#define GST_CAT_DEFAULT gst_ti_tvm_debug_category
+
+/* Prototypes */
+static void
+gst_ti_tvm_set_property (GObject * object, guint property_id,
+    const GValue * value, GParamSpec * pspec);
+
+static void
+gst_ti_tvm_get_property (GObject * object, guint property_id,
+    GValue * value, GParamSpec * pspec);
+
+static void
+gst_ti_tvm_dispose (GObject * object);
+
+static void
+gst_ti_tvm_finalize (GObject * object);
+
+static
+    gboolean
+gst_ti_tvm_start (GstBaseTransform * trans);
+
+static
+    gboolean
+gst_ti_tvm_stop (GstBaseTransform * trans);
+
+static GstCaps *
+gst_ti_tvm_transform_caps (GstBaseTransform * trans,
+    GstPadDirection direction, GstCaps * caps, GstCaps * filter);
+
+static
+    GstFlowReturn
+gst_ti_tvm_prepare_output_buffer (GstBaseTransform * trans,
+    GstBuffer * inbuf, GstBuffer ** outbuf);
+
+static
+    GstFlowReturn
+gst_ti_tvm_transform (GstBaseTransform * trans,
+    GstBuffer * inbuf, GstBuffer * outbuf);
+
+/* TVM-specific functions */
+static
+    gboolean
+gst_ti_tvm_load_model (GstTiTvm * tvm);
+
+static
+    GstFlowReturn
+gst_ti_tvm_run_inference_benchmark (GstTiTvm * tvm,
+    gfloat * input_data, gsize input_size);
+
+static void
+gst_ti_tvm_print_performance_stats (GstTiTvm * tvm);
+
+static gchar *
+gst_ti_tvm_load_json_file (const gchar * file_path);
+
+static gchar *
+gst_ti_tvm_load_param_file (const gchar * file_path, gsize * file_size);
+
+/* Pad templates */
+static
+    GstStaticPadTemplate
+    sink_factory = GST_STATIC_PAD_TEMPLATE ("sink",
+    GST_PAD_SINK,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS ("application/octet-stream")
+    );
+
+static
+    GstStaticPadTemplate
+    src_factory = GST_STATIC_PAD_TEMPLATE ("src",
+    GST_PAD_SRC,
+    GST_PAD_ALWAYS,
+    GST_STATIC_CAPS ("application/octet-stream")
+    );
+
+
+#define gst_ti_tvm_parent_class parent_class
+G_DEFINE_TYPE_WITH_CODE (GstTiTvm, gst_ti_tvm, GST_TYPE_BASE_TRANSFORM,
+    GST_DEBUG_CATEGORY_INIT (gst_ti_tvm_debug_category, "titvm", 0,
+        "TI TVM inference element"));
+
+static void
+gst_ti_tvm_class_init (GstTiTvmClass * klass)
+{
+  GObjectClass *
+      gobject_class = G_OBJECT_CLASS (klass);
+  GstBaseTransformClass *
+      base_transform_class = GST_BASE_TRANSFORM_CLASS (klass);
+
+  gst_element_class_add_pad_template (GST_ELEMENT_CLASS (klass),
+      gst_static_pad_template_get (&sink_factory));
+
+  gst_element_class_add_pad_template (GST_ELEMENT_CLASS (klass),
+      gst_static_pad_template_get (&src_factory));
+
+  gst_element_class_set_static_metadata (GST_ELEMENT_CLASS (klass),
+      "TI TVM Inference", "Transform/ML",
+      "TVM inference on TI processors with C7x DSP acceleration",
+      "Pratham Deshmukh <p-deshmukh@ti.com>");
+
+  gobject_class->set_property = gst_ti_tvm_set_property;
+  gobject_class->get_property = gst_ti_tvm_get_property;
+  gobject_class->dispose = gst_ti_tvm_dispose;
+  gobject_class->finalize = gst_ti_tvm_finalize;
+
+  base_transform_class->start = GST_DEBUG_FUNCPTR (gst_ti_tvm_start);
+  base_transform_class->stop = GST_DEBUG_FUNCPTR (gst_ti_tvm_stop);
+  base_transform_class->transform = GST_DEBUG_FUNCPTR (gst_ti_tvm_transform);
+  base_transform_class->transform_caps =
+      GST_DEBUG_FUNCPTR (gst_ti_tvm_transform_caps);
+  base_transform_class->prepare_output_buffer =
+      GST_DEBUG_FUNCPTR (gst_ti_tvm_prepare_output_buffer);
+
+  base_transform_class->passthrough_on_same_caps = TRUE;
+
+  /* Properties */
+  g_object_class_install_property (gobject_class, PROP_MODEL_PATH,
+      g_param_spec_string ("model-path", "Model Path",
+          "Path to TVM artifacts directory", DEFAULT_MODEL_PATH,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_ITERATIONS,
+      g_param_spec_int ("iterations", "Iterations",
+          "Number of inference iterations to run", 1, 1000, DEFAULT_ITERATIONS,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_BENCHMARK,
+      g_param_spec_boolean ("benchmark", "Benchmark",
+          "Enable performance benchmarking output", DEFAULT_BENCHMARK,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+}
+
+static void
+gst_ti_tvm_init (GstTiTvm * tvm)
+{
+  tvm->model_path = g_strdup (DEFAULT_MODEL_PATH);
+  tvm->iterations = DEFAULT_ITERATIONS;
+  tvm->benchmark = DEFAULT_BENCHMARK;
+
+  tvm->tvm_initialized = FALSE;
+  tvm->graph_executor = NULL;
+  tvm->set_input_func = NULL;
+  tvm->run_func = NULL;
+  tvm->get_output_func = NULL;
+
+  tvm->final_output = NULL;
+  tvm->output_num_floats = 0;
+
+  memset (&tvm->perf_data, 0, sizeof (tvm->perf_data));
+
+  tvm->inference_completed = FALSE;
+  tvm->current_iteration = 0;
+}
+
+static void
+gst_ti_tvm_set_property (GObject * object, guint property_id,
+    const GValue * value, GParamSpec * pspec)
+{
+  GstTiTvm *
+      tvm = GST_TI_TVM (object);
+
+  GST_OBJECT_LOCK (tvm);
+  switch (property_id) {
+    case PROP_MODEL_PATH:
+      g_free (tvm->model_path);
+      tvm->model_path = g_value_dup_string (value);
+      break;
+    case PROP_ITERATIONS:
+      tvm->iterations = g_value_get_int (value);
+      break;
+    case PROP_BENCHMARK:
+      tvm->benchmark = g_value_get_boolean (value);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+  GST_OBJECT_UNLOCK (tvm);
+}
+
+static void
+gst_ti_tvm_get_property (GObject * object, guint property_id,
+    GValue * value, GParamSpec * pspec)
+{
+  GstTiTvm *
+      tvm = GST_TI_TVM (object);
+
+  GST_OBJECT_LOCK (tvm);
+  switch (property_id) {
+    case PROP_MODEL_PATH:
+      g_value_set_string (value, tvm->model_path);
+      break;
+    case PROP_ITERATIONS:
+      g_value_set_int (value, tvm->iterations);
+      break;
+    case PROP_BENCHMARK:
+      g_value_set_boolean (value, tvm->benchmark);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
+      break;
+  }
+  GST_OBJECT_UNLOCK (tvm);
+}
+
+static void
+gst_ti_tvm_dispose (GObject * object)
+{
+  /* Clean up any remaining resources */
+
+  G_OBJECT_CLASS (parent_class)->dispose (object);
+}
+
+static void
+gst_ti_tvm_finalize (GObject * object)
+{
+  GstTiTvm *
+      tvm = GST_TI_TVM (object);
+
+  g_free (tvm->model_path);
+
+  if (tvm->perf_data.inference_times) {
+    g_free (tvm->perf_data.inference_times);
+    tvm->perf_data.inference_times = NULL;
+  }
+
+  G_OBJECT_CLASS (parent_class)->finalize (object);
+}
+
+static
+    gboolean
+gst_ti_tvm_start (GstBaseTransform * trans)
+{
+  GstTiTvm *
+      tvm = GST_TI_TVM (trans);
+
+  GST_DEBUG_OBJECT (tvm, "Starting TI TVM inference element");
+  g_print ("TI TVM Inference Element\n");
+  g_print ("========================\n");
+
+  /* Initialize TVM runtime */
+  if (!gst_ti_tvm_load_model (tvm)) {
+    GST_ERROR_OBJECT (tvm, "Failed to load TVM model");
+    return FALSE;
+  }
+
+  /* Allocate performance tracking arrays */
+  tvm->perf_data.inference_times = g_new0 (gint64, tvm->iterations);
+
+  GST_DEBUG_OBJECT (tvm, "TI TVM element started successfully");
+
+  return TRUE;
+}
+
+static
+    gboolean
+gst_ti_tvm_stop (GstBaseTransform * trans)
+{
+  GstTiTvm *
+      tvm = GST_TI_TVM (trans);
+
+  GST_DEBUG_OBJECT (tvm, "Stopping TI TVM inference element");
+
+  tvm->tvm_initialized = FALSE;
+
+  if (tvm->graph_executor) {
+    delete (Module *) tvm->graph_executor;
+    tvm->graph_executor = NULL;
+  }
+  if (tvm->set_input_func) {
+    delete (PackedFunc *) tvm->set_input_func;
+    tvm->set_input_func = NULL;
+  }
+  if (tvm->run_func) {
+    delete (PackedFunc *) tvm->run_func;
+    tvm->run_func = NULL;
+  }
+  if (tvm->get_output_func) {
+    delete (PackedFunc *) tvm->get_output_func;
+    tvm->get_output_func = NULL;
+  }
+  if (tvm->final_output) {
+    delete (NDArray *) tvm->final_output;
+    tvm->final_output = NULL;
+  }
+
+  GST_DEBUG_OBJECT (tvm, "TI TVM element stopped");
+
+  return TRUE;
+}
+
+/* Caps negotiation */
+static GstCaps *
+gst_ti_tvm_transform_caps (GstBaseTransform * trans, GstPadDirection direction,
+    GstCaps * caps, GstCaps * filter)
+{
+  GstCaps *
+      othercaps;
+
+  othercaps = gst_caps_new_simple ("application/octet-stream", NULL, NULL);
+
+  if (filter) {
+    GstCaps *
+        intersect = gst_caps_intersect_full (othercaps, filter,
+        GST_CAPS_INTERSECT_FIRST);
+    gst_caps_unref (othercaps);
+    othercaps = intersect;
+  }
+
+  return othercaps;
+}
+
+/* Prepare output buffer with correct size */
+static
+    GstFlowReturn
+gst_ti_tvm_prepare_output_buffer (GstBaseTransform * trans, GstBuffer * inbuf,
+    GstBuffer ** outbuf)
+{
+  GstTiTvm *
+      tvm = GST_TI_TVM (trans);
+  gsize output_size;
+
+  /* If we already know the output size from previous inference, use it */
+  if (tvm->output_num_floats > 0) {
+    output_size = tvm->output_num_floats * sizeof (float);
+    GST_DEBUG_OBJECT (tvm, "Allocating output buffer: %zu bytes (known size)",
+        output_size);
+  } else {
+    /* First run:
+     * Allocate buffer same size as input.
+     * After first inference, we'll know exact size for subsequent buffers. */
+    output_size = gst_buffer_get_size (inbuf);
+    GST_DEBUG_OBJECT (tvm,
+        "Allocating output buffer: %zu bytes (input size, first run)",
+        output_size);
+  }
+
+  /* Allocate output buffer with correct size */
+  *outbuf = gst_buffer_new_allocate (NULL, output_size, NULL);
+  if (!*outbuf) {
+    GST_ERROR_OBJECT (tvm, "Failed to allocate output buffer of size %zu",
+        output_size);
+    return GST_FLOW_ERROR;
+  }
+
+  return GST_FLOW_OK;
+}
+
+static
+    GstFlowReturn
+gst_ti_tvm_transform (GstBaseTransform * trans, GstBuffer * inbuf,
+    GstBuffer * outbuf)
+{
+  GstTiTvm *
+      tvm = GST_TI_TVM (trans);
+  GstMapInfo in_map, out_map;
+  GstFlowReturn ret;
+
+  /* Map input buffer */
+  if (!gst_buffer_map (inbuf, &in_map, GST_MAP_READ)) {
+    GST_ERROR_OBJECT (tvm, "Failed to map input buffer");
+    return GST_FLOW_ERROR;
+  }
+
+  gfloat *
+      input_data = (gfloat *) in_map.data;
+  gsize input_size = in_map.size / sizeof (gfloat);
+
+  GST_DEBUG_OBJECT (tvm, "transform: %zu floats (%zu bytes)", input_size,
+      in_map.size);
+
+  /* Run inference benchmark */
+  ret = gst_ti_tvm_run_inference_benchmark (tvm, input_data, input_size);
+
+  /* Copy inference output to output buffer */
+  if (ret == GST_FLOW_OK && tvm->final_output && tvm->output_num_floats > 0) {
+    NDArray *
+        out = (NDArray *) tvm->final_output;
+    gsize out_bytes = tvm->output_num_floats * sizeof (float);
+
+    /* Map output buffer (write-only) */
+    if (!gst_buffer_map (outbuf, &out_map, GST_MAP_WRITE)) {
+      GST_ERROR_OBJECT (tvm, "Failed to map output buffer");
+      gst_buffer_unmap (inbuf, &in_map);
+      return GST_FLOW_ERROR;
+    }
+
+    /* Copy output data to output buffer (sized by prepare_output_buffer) */
+    out->CopyToBytes (out_map.data, out_bytes);
+    gst_buffer_unmap (outbuf, &out_map);
+
+    /* Set actual output size */
+    gst_buffer_set_size (outbuf, (gssize) out_bytes);
+  }
+
+  /* Unmap input buffer */
+  gst_buffer_unmap (inbuf, &in_map);
+
+  if (ret != GST_FLOW_OK)
+    GST_ERROR_OBJECT (tvm, "Inference failed");
+
+  return ret;
+}
+
+static
+    gboolean
+gst_ti_tvm_load_model (GstTiTvm * tvm)
+{
+  try {
+    gchar *
+        lib_path = g_strdup_printf ("%s/deploy_lib.so", tvm->model_path);
+    gchar *
+        graph_path = g_strdup_printf ("%s/deploy_graph.json", tvm->model_path);
+    gchar *
+        param_path =
+        g_strdup_printf ("%s/deploy_param.params", tvm->model_path);
+
+    GST_INFO_OBJECT (tvm, "[TVM] Initializing with artifacts from: %s",
+        tvm->model_path);
+
+    /* Load TVM artifacts (same as C application) */
+    Module lib = Module::LoadFromFile (lib_path);
+    gchar *
+        graph_json = gst_ti_tvm_load_json_file (graph_path);
+
+    if (!graph_json) {
+      GST_ERROR_OBJECT (tvm, "Failed to load graph JSON from %s", graph_path);
+      g_free (lib_path);
+      g_free (graph_path);
+      g_free (param_path);
+      return FALSE;
+    }
+
+    auto graph_executor_create = Registry::Get ("tvm.graph_executor.create");
+    if (!graph_executor_create) {
+      GST_ERROR_OBJECT (tvm, "tvm.graph_executor.create not found in registry");
+      g_free (lib_path);
+      g_free (graph_path);
+      g_free (param_path);
+      g_free (graph_json);
+      return FALSE;
+    }
+
+    Module executor;
+    try {
+      executor =
+          (*graph_executor_create) (String (graph_json), lib, int (kDLCPU),
+          int (0));
+    } catch (const std::exception & e1)
+    {
+      GST_ERROR_OBJECT (tvm, "graph_executor.create failed: %s", e1.what ());
+      g_free (lib_path);
+      g_free (graph_path);
+      g_free (param_path);
+      g_free (graph_json);
+      return FALSE;
+    }
+
+    /* Load parameters */
+    gsize param_size;
+    gchar *
+        param_data = gst_ti_tvm_load_param_file (param_path, &param_size);
+    if (!param_data) {
+      GST_ERROR_OBJECT (tvm, "Failed to load parameters from %s", param_path);
+      g_free (lib_path);
+      g_free (graph_path);
+      g_free (param_path);
+      g_free (graph_json);
+      return FALSE;
+    }
+
+    GST_INFO_OBJECT (tvm, "[TVM] Loading parameters: %s", param_path);
+    auto load_params = executor.GetFunction ("load_params");
+    TVMByteArray param_array = { param_data, param_size };
+    load_params (param_array);
+    GST_INFO_OBJECT (tvm, "[TVM] Parameters loaded (%zu bytes)", param_size);
+
+    tvm->graph_executor = new Module (executor);
+    PackedFunc *
+        set_input = new PackedFunc (executor.GetFunction ("set_input"));
+    PackedFunc *
+        run = new PackedFunc (executor.GetFunction ("run"));
+    PackedFunc *
+        get_output = new PackedFunc (executor.GetFunction ("get_output"));
+
+    tvm->set_input_func = set_input;
+    tvm->run_func = run;
+    tvm->get_output_func = get_output;
+
+    GST_INFO_OBJECT (tvm,
+        "[TVM] Input configuration: index=0, shape=[dynamic]");
+
+    tvm->tvm_initialized = TRUE;
+
+    g_free (lib_path);
+    g_free (graph_path);
+    g_free (param_path);
+    g_free (graph_json);
+    g_free (param_data);
+
+    return TRUE;
+
+  }
+  catch (const std::exception & e)
+  {
+    GST_ERROR_OBJECT (tvm, "TVM initialization failed: %s", e.what ());
+    return FALSE;
+  }
+}
+
+static
+    GstFlowReturn
+gst_ti_tvm_run_inference_benchmark (GstTiTvm * tvm, gfloat * input_data,
+    gsize input_size)
+{
+  try {
+    PackedFunc *
+        set_input = (PackedFunc *) tvm->set_input_func;
+    PackedFunc *
+        run = (PackedFunc *) tvm->run_func;
+    PackedFunc *
+        get_output = (PackedFunc *) tvm->get_output_func;
+
+    /* Create input NDArray once (reused across iterations) */
+    std::vector < int64_t > shape = { static_cast < int64_t > (input_size) };
+    NDArray input_array = NDArray::Empty (shape, DLDataType {
+        kDLFloat, 32, 1}, DLDevice {
+        kDLCPU, 0});
+    input_array.CopyFromBytes (input_data, input_size * sizeof (float));
+
+    if (tvm->benchmark) {
+      g_print ("\n[TVM] Running inference benchmark (%d iterations)...\n",
+          tvm->iterations);
+      g_print ("------------------------------\n");
+    }
+
+    /* Run inference iterations */
+    for (gint i = 0; i < tvm->iterations; i++) {
+      auto start_time = std::chrono::high_resolution_clock::now ();
+
+      (*set_input) (0, input_array);
+      (*run) ();
+      NDArray output_array = (*get_output) (0);
+
+      auto end_time = std::chrono::high_resolution_clock::now ();
+      auto duration =
+          std::chrono::duration_cast < std::chrono::microseconds >
+          (end_time - start_time);
+      gdouble time_ms = duration.count () / 1000.0;
+
+      if (i == 0) {
+        /* First run includes initialization overhead */
+        tvm->perf_data.first_run_time = duration.count ();
+        if (tvm->benchmark) {
+          g_print ("First run (includes init): %.2f ms\n", time_ms);
+        }
+
+        /* Get output shape from first run */
+        gsize out_floats = 1;
+        for (int j = 0; j < output_array->ndim; j++) {
+          out_floats *= output_array->shape[j];
+        }
+        tvm->output_num_floats = out_floats;
+
+        if (tvm->benchmark) {
+          g_print ("Output shape: (");
+          for (int j = 0; j < output_array->ndim; j++) {
+            g_print ("%s%ld", (j > 0) ? ", " : "", output_array->shape[j]);
+          }
+          g_print (")\n");
+        }
+      } else {
+        /* Subsequent runs for performance measurement */
+        tvm->perf_data.inference_times[i - 1] = duration.count ();
+        if (tvm->benchmark) {
+          g_print ("Run %d: %.2f ms\n", i + 1, time_ms);
+        }
+      }
+
+      /* Store final output for returning to pipeline */
+      if (i == tvm->iterations - 1) {
+        if (tvm->final_output) {
+          delete (NDArray *) tvm->final_output;
+        }
+        tvm->final_output = new NDArray (output_array);
+      }
+    }
+
+    /* Calculate and print performance statistics */
+    if (tvm->benchmark && tvm->iterations > 1) {
+      gst_ti_tvm_print_performance_stats (tvm);
+    }
+
+    tvm->inference_completed = TRUE;
+    return GST_FLOW_OK;
+
+  }
+  catch (const std::exception & e)
+  {
+    GST_ERROR_OBJECT (tvm, "Inference benchmark failed: %s", e.what ());
+    return GST_FLOW_ERROR;
+  }
+}
+
+static void
+gst_ti_tvm_print_performance_stats (GstTiTvm * tvm)
+{
+  gint num_runs = tvm->iterations - 1;  /* Exclude first run */
+
+  if (num_runs <= 0) {
+    return;
+  }
+
+  gdouble sum = 0.0;
+  gdouble min_time = G_MAXDOUBLE;
+  gdouble max_time = 0.0;
+
+  for (gint i = 0; i < num_runs; i++) {
+    gdouble time_ms = tvm->perf_data.inference_times[i] / 1000.0;
+    sum += time_ms;
+    if (time_ms < min_time)
+      min_time = time_ms;
+    if (time_ms > max_time)
+      max_time = time_ms;
+  }
+
+  gdouble avg_time = sum / num_runs;
+  gdouble fps = 1000.0 / avg_time;
+
+  tvm->perf_data.avg_time = avg_time;
+  tvm->perf_data.min_time = min_time;
+  tvm->perf_data.max_time = max_time;
+  tvm->perf_data.fps = fps;
+
+  g_print ("\n");
+  g_print ("Performance Results:\n");
+  g_print ("  Average: %.2f ms\n", avg_time);
+  g_print ("  Min:     %.2f ms\n", min_time);
+  g_print ("  Max:     %.2f ms\n", max_time);
+  g_print ("  FPS:     %.1f\n", fps);
+  g_print ("\n");
+  g_print ("Inference completed successfully!\n");
+  g_print ("  Average inference time: %.2f ms\n", avg_time);
+  g_print ("  Using TVM+TIDL on TI C7x DSP\n");
+  g_print ("\n");
+}
+
+/* Helper functions */
+static gchar *
+gst_ti_tvm_load_json_file (const gchar * file_path)
+{
+  GError *
+      error = NULL;
+  gchar *
+      contents = NULL;
+  gsize length;
+
+  if (!g_file_get_contents (file_path, &contents, &length, &error)) {
+    g_warning ("Failed to read file %s: %s", file_path, error->message);
+    g_error_free (error);
+    return NULL;
+  }
+
+  return contents;
+}
+
+static gchar *
+gst_ti_tvm_load_param_file (const gchar * file_path, gsize * file_size)
+{
+  GError *
+      error = NULL;
+  gchar *
+      contents = NULL;
+
+  if (!g_file_get_contents (file_path, &contents, file_size, &error)) {
+    g_warning ("Failed to read parameter file %s: %s", file_path,
+        error->message);
+    g_error_free (error);
+    return NULL;
+  }
+
+  return contents;
+}

--- a/ext/ti/gsttitvm.cpp
+++ b/ext/ti/gsttitvm.cpp
@@ -63,6 +63,7 @@
 #endif
 
 #include "gsttitvm.h"
+#include "gsttirpmsgctx.h"
 #include <gst/gst.h>
 #include <gst/base/gstbasetransform.h>
 #include <string.h>
@@ -78,8 +79,45 @@
 #include <tvm/runtime/ndarray.h>
 #include <tvm/runtime/container/map.h>
 
+extern "C"
+{
+#include "rpmsg.h"
+#include "dmabuf.h"
+}
+
 using namespace
     tvm::runtime;
+
+/* RPMsg message types for audio mode */
+#define C7X_MSG_DEINTERLEAVE      0x1010
+#define C7X_MSG_DEINTERLEAVE_RESP 0x2010
+#define C7X_MSG_INTERLEAVE        0x1040
+#define C7X_MSG_INTERLEAVE_RESP   0x2040
+#define C7X_STATUS_SUCCESS        0
+
+struct c7x_msg_hdr
+{
+  uint32_t
+      type;
+  uint32_t
+      seq;
+  uint32_t
+      len;
+  int32_t
+      status;
+} __attribute__((packed));
+
+struct audio_msg
+{
+  struct c7x_msg_hdr
+      hdr;
+  uint32_t
+      input_buffer;
+  uint32_t
+      output_buffer;
+  uint32_t
+      data_size;
+} __attribute__((packed));
 
 GST_DEBUG_CATEGORY_STATIC (gst_ti_tvm_debug_category);
 #define GST_CAT_DEFAULT gst_ti_tvm_debug_category
@@ -212,6 +250,30 @@ gst_ti_tvm_class_init (GstTiTvmClass * klass)
       g_param_spec_boolean ("benchmark", "Benchmark",
           "Enable performance benchmarking output", DEFAULT_BENCHMARK,
           (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_AUDIO_MODE,
+      g_param_spec_boolean ("audio-mode", "Audio Mode",
+          "Enable audio enhancement mode (deinterleave/interleave via C7x DSP)",
+          DEFAULT_AUDIO_MODE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_RPROC_DEVICE,
+      g_param_spec_string ("rproc-device", "Remoteproc Device",
+          "Remoteproc cdev for DMA buffer physical address lookup",
+          DEFAULT_RPROC_DEVICE,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_RPROC_ID,
+      g_param_spec_uint ("rproc-id", "Remote Processor ID",
+          "Linux remoteproc core ID (8 = C7x_0 on AM62D)",
+          0, G_MAXUINT, DEFAULT_RPROC_ID,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
+
+  g_object_class_install_property (gobject_class, PROP_REMOTE_EP,
+      g_param_spec_uint ("remote-ep", "Remote RPMsg Endpoint",
+          "RPMsg endpoint number running DSP firmware",
+          0, G_MAXUINT, DEFAULT_REMOTE_EP,
+          (GParamFlags) (G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS)));
 }
 
 static void
@@ -220,12 +282,23 @@ gst_ti_tvm_init (GstTiTvm * tvm)
   tvm->model_path = g_strdup (DEFAULT_MODEL_PATH);
   tvm->iterations = DEFAULT_ITERATIONS;
   tvm->benchmark = DEFAULT_BENCHMARK;
+  tvm->audio_mode = DEFAULT_AUDIO_MODE;
+  tvm->rproc_device = g_strdup (DEFAULT_RPROC_DEVICE);
+  tvm->rproc_id = DEFAULT_RPROC_ID;
+  tvm->remote_ep = DEFAULT_REMOTE_EP;
 
   tvm->tvm_initialized = FALSE;
   tvm->graph_executor = NULL;
   tvm->set_input_func = NULL;
   tvm->run_func = NULL;
   tvm->get_output_func = NULL;
+
+  tvm->rpmsg_ctx = NULL;
+  tvm->dma_input = NULL;
+  tvm->dma_deint = NULL;
+  tvm->dma_inter = NULL;
+  tvm->dma_allocated = FALSE;
+  tvm->sequence_number = 1;
 
   tvm->final_output = NULL;
   tvm->output_num_floats = 0;
@@ -255,6 +328,19 @@ gst_ti_tvm_set_property (GObject * object, guint property_id,
     case PROP_BENCHMARK:
       tvm->benchmark = g_value_get_boolean (value);
       break;
+    case PROP_AUDIO_MODE:
+      tvm->audio_mode = g_value_get_boolean (value);
+      break;
+    case PROP_RPROC_DEVICE:
+      g_free (tvm->rproc_device);
+      tvm->rproc_device = g_value_dup_string (value);
+      break;
+    case PROP_RPROC_ID:
+      tvm->rproc_id = g_value_get_uint (value);
+      break;
+    case PROP_REMOTE_EP:
+      tvm->remote_ep = g_value_get_uint (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -280,6 +366,18 @@ gst_ti_tvm_get_property (GObject * object, guint property_id,
     case PROP_BENCHMARK:
       g_value_set_boolean (value, tvm->benchmark);
       break;
+    case PROP_AUDIO_MODE:
+      g_value_set_boolean (value, tvm->audio_mode);
+      break;
+    case PROP_RPROC_DEVICE:
+      g_value_set_string (value, tvm->rproc_device);
+      break;
+    case PROP_RPROC_ID:
+      g_value_set_uint (value, tvm->rproc_id);
+      break;
+    case PROP_REMOTE_EP:
+      g_value_set_uint (value, tvm->remote_ep);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -302,6 +400,7 @@ gst_ti_tvm_finalize (GObject * object)
       tvm = GST_TI_TVM (object);
 
   g_free (tvm->model_path);
+  g_free (tvm->rproc_device);
 
   if (tvm->perf_data.inference_times) {
     g_free (tvm->perf_data.inference_times);
@@ -321,6 +420,7 @@ gst_ti_tvm_start (GstBaseTransform * trans)
   GST_DEBUG_OBJECT (tvm, "Starting TI TVM inference element");
   g_print ("TI TVM Inference Element\n");
   g_print ("========================\n");
+  g_print ("[TVM] Audio mode: %s\n", tvm->audio_mode ? "enabled" : "disabled");
 
   /* Initialize TVM runtime */
   if (!gst_ti_tvm_load_model (tvm)) {
@@ -330,6 +430,54 @@ gst_ti_tvm_start (GstBaseTransform * trans)
 
   /* Allocate performance tracking arrays */
   tvm->perf_data.inference_times = g_new0 (gint64, tvm->iterations);
+
+  /* Audio mode: acquire RPMsg channel and allocate DMA buffers */
+  if (tvm->audio_mode) {
+    tvm->rpmsg_ctx = gst_ti_rpmsg_chan_acquire (tvm->rproc_id, tvm->remote_ep);
+    if (!tvm->rpmsg_ctx) {
+      GST_ERROR_OBJECT (tvm,
+          "Failed to acquire rpmsg channel (rproc_id=%u, remote_ep=%u)",
+          tvm->rproc_id, tvm->remote_ep);
+      return FALSE;
+    }
+    g_print ("[TVM] RPMsg channel acquired (rproc=%u ep=%u fd=%d)\n",
+        tvm->rproc_id, tvm->remote_ep, ((GstTiRpmsgChan *) tvm->rpmsg_ctx)->fd);
+
+    /* Allocate DMA buffers for deinterleave/interleave operations */
+    tvm->dma_input = g_new0 (struct dma_buf_params, 1);
+    tvm->dma_deint = g_new0 (struct dma_buf_params, 1);
+    tvm->dma_inter = g_new0 (struct dma_buf_params, 1);
+
+    int
+        r1 = dmabuf_heap_init ((char *) "linux,cma", TVM_AUDIO_BUFFER_SIZE,
+        tvm->rproc_device, (struct dma_buf_params *) tvm->dma_input);
+    int
+        r2 = dmabuf_heap_init ((char *) "linux,cma", TVM_AUDIO_BUFFER_SIZE,
+        tvm->rproc_device, (struct dma_buf_params *) tvm->dma_deint);
+    int
+        r3 = dmabuf_heap_init ((char *) "linux,cma", TVM_AUDIO_BUFFER_SIZE,
+        tvm->rproc_device, (struct dma_buf_params *) tvm->dma_inter);
+
+    if (r1 != 0 || r2 != 0 || r3 != 0) {
+      GST_ERROR_OBJECT (tvm, "DMA alloc failed (r1=%d r2=%d r3=%d)", r1, r2,
+          r3);
+      if (r1 == 0)
+        dmabuf_heap_destroy ((struct dma_buf_params *) tvm->dma_input);
+      if (r2 == 0)
+        dmabuf_heap_destroy ((struct dma_buf_params *) tvm->dma_deint);
+      if (r3 == 0)
+        dmabuf_heap_destroy ((struct dma_buf_params *) tvm->dma_inter);
+      g_free (tvm->dma_input);
+      g_free (tvm->dma_deint);
+      g_free (tvm->dma_inter);
+      gst_ti_rpmsg_chan_release ((GstTiRpmsgChan *) tvm->rpmsg_ctx);
+      return FALSE;
+    }
+
+    tvm->dma_allocated = TRUE;
+    g_print ("[TVM] Audio mode DMA buffers allocated (%u bytes each)\n",
+        TVM_AUDIO_BUFFER_SIZE);
+  }
 
   GST_DEBUG_OBJECT (tvm, "TI TVM element started successfully");
 
@@ -366,6 +514,22 @@ gst_ti_tvm_stop (GstBaseTransform * trans)
   if (tvm->final_output) {
     delete (NDArray *) tvm->final_output;
     tvm->final_output = NULL;
+  }
+
+  /* Clean up audio mode resources */
+  if (tvm->audio_mode && tvm->dma_allocated) {
+    dmabuf_heap_destroy ((struct dma_buf_params *) tvm->dma_input);
+    dmabuf_heap_destroy ((struct dma_buf_params *) tvm->dma_deint);
+    dmabuf_heap_destroy ((struct dma_buf_params *) tvm->dma_inter);
+    g_free (tvm->dma_input);
+    g_free (tvm->dma_deint);
+    g_free (tvm->dma_inter);
+    tvm->dma_allocated = FALSE;
+  }
+
+  if (tvm->rpmsg_ctx) {
+    gst_ti_rpmsg_chan_release ((GstTiRpmsgChan *) tvm->rpmsg_ctx);
+    tvm->rpmsg_ctx = NULL;
   }
 
   GST_DEBUG_OBJECT (tvm, "TI TVM element stopped");
@@ -430,6 +594,126 @@ gst_ti_tvm_prepare_output_buffer (GstBaseTransform * trans, GstBuffer * inbuf,
   return GST_FLOW_OK;
 }
 
+/* Audio mode helper: Deinterleave complex spectral data via C7x DSP */
+static
+    gboolean
+gst_ti_tvm_deinterleave_audio (GstTiTvm * tvm, const guint8 * interleaved_data,
+    gsize data_size, guint8 ** deinterleaved_out)
+{
+  struct dma_buf_params *
+      dma_in = (struct dma_buf_params *) tvm->dma_input;
+  struct dma_buf_params *
+      dma_out = (struct dma_buf_params *) tvm->dma_deint;
+  GstTiRpmsgChan *
+      ctx = (GstTiRpmsgChan *) tvm->rpmsg_ctx;
+
+  /* Copy interleaved data to input DMA buffer */
+  dmabuf_sync (dma_in->dma_buf_fd, DMA_BUF_SYNC_START);
+  memcpy (dma_in->kern_addr, interleaved_data, data_size);
+  dmabuf_sync (dma_in->dma_buf_fd, DMA_BUF_SYNC_END);
+
+  /* Send deinterleave request to C7x */
+  struct audio_msg
+  req = { };
+  req.hdr.type = C7X_MSG_DEINTERLEAVE;
+  req.hdr.seq = tvm->sequence_number++;
+  req.hdr.len = sizeof (req);
+  req.hdr.status = 0;
+  req.input_buffer = (uint32_t) dma_in->phys_addr;
+  req.output_buffer = (uint32_t) dma_out->phys_addr;
+  req.data_size = (uint32_t) data_size;
+
+  if (send_msg (ctx->fd, (char *) &req, sizeof (req)) < 0) {
+    GST_ERROR_OBJECT (tvm, "send_msg DEINTERLEAVE failed");
+    return FALSE;
+  }
+
+  /* Receive response */
+  struct audio_msg
+  resp = { };
+  int
+      resp_len = sizeof (resp);
+  if (recv_msg (ctx->fd, sizeof (resp), (char *) &resp, &resp_len) < 0) {
+    GST_ERROR_OBJECT (tvm, "recv_msg DEINTERLEAVE_RESP failed");
+    return FALSE;
+  }
+
+  if (resp.hdr.type != C7X_MSG_DEINTERLEAVE_RESP
+      || resp.hdr.status != C7X_STATUS_SUCCESS) {
+    GST_ERROR_OBJECT (tvm, "Deinterleave failed: type=0x%x status=%d",
+        resp.hdr.type, resp.hdr.status);
+    return FALSE;
+  }
+
+  /* Copy deinterleaved result from DMA buffer */
+  dmabuf_sync (dma_out->dma_buf_fd, DMA_BUF_SYNC_START);
+  *deinterleaved_out = (guint8 *) g_malloc (data_size);
+  memcpy (*deinterleaved_out, dma_out->kern_addr, data_size);
+  dmabuf_sync (dma_out->dma_buf_fd, DMA_BUF_SYNC_END);
+
+  return TRUE;
+}
+
+/* Audio mode helper: Interleave complex spectral data via C7x DSP */
+static
+    gboolean
+gst_ti_tvm_interleave_audio (GstTiTvm * tvm, const guint8 * deinterleaved_data,
+    gsize data_size, guint8 ** interleaved_out)
+{
+  struct dma_buf_params *
+      dma_in = (struct dma_buf_params *) tvm->dma_deint;
+  struct dma_buf_params *
+      dma_out = (struct dma_buf_params *) tvm->dma_inter;
+  GstTiRpmsgChan *
+      ctx = (GstTiRpmsgChan *) tvm->rpmsg_ctx;
+
+  /* Copy deinterleaved data to input DMA buffer */
+  dmabuf_sync (dma_in->dma_buf_fd, DMA_BUF_SYNC_START);
+  memcpy (dma_in->kern_addr, deinterleaved_data, data_size);
+  dmabuf_sync (dma_in->dma_buf_fd, DMA_BUF_SYNC_END);
+
+  /* Send interleave request to C7x */
+  struct audio_msg
+  req = { };
+  req.hdr.type = C7X_MSG_INTERLEAVE;
+  req.hdr.seq = tvm->sequence_number++;
+  req.hdr.len = sizeof (req);
+  req.hdr.status = 0;
+  req.input_buffer = (uint32_t) dma_in->phys_addr;
+  req.output_buffer = (uint32_t) dma_out->phys_addr;
+  req.data_size = (uint32_t) data_size;
+
+  if (send_msg (ctx->fd, (char *) &req, sizeof (req)) < 0) {
+    GST_ERROR_OBJECT (tvm, "send_msg INTERLEAVE failed");
+    return FALSE;
+  }
+
+  /* Receive response */
+  struct audio_msg
+  resp = { };
+  int
+      resp_len = sizeof (resp);
+  if (recv_msg (ctx->fd, sizeof (resp), (char *) &resp, &resp_len) < 0) {
+    GST_ERROR_OBJECT (tvm, "recv_msg INTERLEAVE_RESP failed");
+    return FALSE;
+  }
+
+  if (resp.hdr.type != C7X_MSG_INTERLEAVE_RESP
+      || resp.hdr.status != C7X_STATUS_SUCCESS) {
+    GST_ERROR_OBJECT (tvm, "Interleave failed: type=0x%x status=%d",
+        resp.hdr.type, resp.hdr.status);
+    return FALSE;
+  }
+
+  /* Copy interleaved result from DMA buffer */
+  dmabuf_sync (dma_out->dma_buf_fd, DMA_BUF_SYNC_START);
+  *interleaved_out = (guint8 *) g_malloc (data_size);
+  memcpy (*interleaved_out, dma_out->kern_addr, data_size);
+  dmabuf_sync (dma_out->dma_buf_fd, DMA_BUF_SYNC_END);
+
+  return TRUE;
+}
+
 static
     GstFlowReturn
 gst_ti_tvm_transform (GstBaseTransform * trans, GstBuffer * inbuf,
@@ -447,8 +731,27 @@ gst_ti_tvm_transform (GstBaseTransform * trans, GstBuffer * inbuf,
   }
 
   gfloat *
-      input_data = (gfloat *) in_map.data;
-  gsize input_size = in_map.size / sizeof (gfloat);
+      input_data = NULL;
+  gsize input_size = 0;
+  guint8 *
+      deinterleaved_data = NULL;
+  gboolean need_free_deint = FALSE;
+
+  /* Audio mode: deinterleave first */
+  if (tvm->audio_mode) {
+    if (!gst_ti_tvm_deinterleave_audio (tvm, in_map.data, in_map.size,
+            &deinterleaved_data)) {
+      GST_ERROR_OBJECT (tvm, "Deinterleave failed");
+      gst_buffer_unmap (inbuf, &in_map);
+      return GST_FLOW_ERROR;
+    }
+    input_data = (gfloat *) deinterleaved_data;
+    input_size = in_map.size / sizeof (gfloat);
+    need_free_deint = TRUE;
+  } else {
+    input_data = (gfloat *) in_map.data;
+    input_size = in_map.size / sizeof (gfloat);
+  }
 
   GST_DEBUG_OBJECT (tvm, "transform: %zu floats (%zu bytes)", input_size,
       in_map.size);
@@ -465,19 +768,48 @@ gst_ti_tvm_transform (GstBaseTransform * trans, GstBuffer * inbuf,
     /* Map output buffer (write-only) */
     if (!gst_buffer_map (outbuf, &out_map, GST_MAP_WRITE)) {
       GST_ERROR_OBJECT (tvm, "Failed to map output buffer");
+      if (need_free_deint)
+        g_free (deinterleaved_data);
       gst_buffer_unmap (inbuf, &in_map);
       return GST_FLOW_ERROR;
     }
 
-    /* Copy output data to output buffer (sized by prepare_output_buffer) */
-    out->CopyToBytes (out_map.data, out_bytes);
+    /* Audio mode: interleave after TVM inference */
+    if (tvm->audio_mode) {
+      guint8 *
+          tvm_output = (guint8 *) g_malloc (out_bytes);
+      out->CopyToBytes (tvm_output, out_bytes);
+
+      guint8 *
+          interleaved_data = NULL;
+      if (!gst_ti_tvm_interleave_audio (tvm, tvm_output, out_bytes,
+              &interleaved_data)) {
+        GST_ERROR_OBJECT (tvm, "Interleave failed");
+        g_free (tvm_output);
+        gst_buffer_unmap (outbuf, &out_map);
+        if (need_free_deint)
+          g_free (deinterleaved_data);
+        gst_buffer_unmap (inbuf, &in_map);
+        return GST_FLOW_ERROR;
+      }
+
+      memcpy (out_map.data, interleaved_data, out_bytes);
+      g_free (tvm_output);
+      g_free (interleaved_data);
+    } else {
+      /* Non-audio mode: direct copy */
+      out->CopyToBytes (out_map.data, out_bytes);
+    }
+
     gst_buffer_unmap (outbuf, &out_map);
 
     /* Set actual output size */
     gst_buffer_set_size (outbuf, (gssize) out_bytes);
   }
 
-  /* Unmap input buffer */
+  /* Clean up */
+  if (need_free_deint)
+    g_free (deinterleaved_data);
   gst_buffer_unmap (inbuf, &in_map);
 
   if (ret != GST_FLOW_OK)

--- a/ext/ti/gsttitvm.h
+++ b/ext/ti/gsttitvm.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) [2026] Texas Instruments Incorporated
+ *
+ * All rights reserved not granted herein.
+ *
+ * Limited License.
+ *
+ * Texas Instruments Incorporated grants a world-wide, royalty-free,
+ * non-exclusive license under copyrights and patents it now or hereafter
+ * owns or controls to make, have made, use, import, offer to sell and sell
+ * ("Utilize") this software subject to the terms herein.  With respect to
+ * the foregoing patent license, such license is granted  solely to the extent
+ * that any such patent is necessary to Utilize the software alone.
+ * The patent license shall not apply to any combinations which include
+ * this software, other than combinations with devices manufactured by or
+ * for TI (“TI Devices”).  No hardware patent is licensed hereunder.
+ *
+ * Redistributions must preserve existing copyright notices and reproduce
+ * this license (including the above copyright notice and the disclaimer
+ * and (if applicable) source code license limitations below) in the
+ * documentation and/or other materials provided with the distribution
+ *
+ * Redistribution and use in binary form, without modification, are permitted
+ * provided that the following conditions are met:
+ *
+ * *	No reverse engineering, decompilation, or disassembly of this software
+ *      is permitted with respect to any software provided in binary form.
+ *
+ * *	Any redistribution and use are licensed by TI for use only with TI
+ * Devices.
+ *
+ * *	Nothing shall obligate TI to provide you with source code for the
+ *      software licensed and provided to you in object code.
+ *
+ * If software source code is provided to you, modification and redistribution
+ * of the source code are permitted provided that the following conditions are
+ * met:
+ *
+ * *	Any redistribution and use of the source code, including any resulting
+ *      derivative works, are licensed by TI for use only with TI Devices.
+ *
+ * *	Any redistribution and use of any object code compiled from the source
+ *      code and any resulting derivative works, are licensed by TI for use
+ *      only with TI Devices.
+ *
+ * Neither the name of Texas Instruments Incorporated nor the names of its
+ * suppliers may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * DISCLAIMER.
+ *
+ * THIS SOFTWARE IS PROVIDED BY TI AND TI’S LICENSORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL TI AND TI’S LICENSORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __GST_TI_TVM_H__
+#define __GST_TI_TVM_H__
+
+#include <gst/gst.h>
+#include <gst/base/gstbasetransform.h>
+
+G_BEGIN_DECLS
+
+/* Element type macros */
+#define GST_TYPE_TI_TVM \
+  (gst_ti_tvm_get_type())
+#define GST_TI_TVM(obj) \
+  (G_TYPE_CHECK_INSTANCE_CAST((obj),GST_TYPE_TI_TVM,GstTiTvm))
+#define GST_TI_TVM_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_CAST((klass),GST_TYPE_TI_TVM,GstTiTvmClass))
+#define GST_IS_TI_TVM(obj) \
+  (G_TYPE_CHECK_INSTANCE_TYPE((obj),GST_TYPE_TI_TVM))
+#define GST_IS_TI_TVM_CLASS(klass) \
+  (G_TYPE_CHECK_CLASS_TYPE((klass),GST_TYPE_TI_TVM))
+
+typedef struct _GstTiTvm      GstTiTvm;
+typedef struct _GstTiTvmClass GstTiTvmClass;
+
+/* TVM inference performance data */
+struct TiTvmPerformanceData {
+    gint64 first_run_time;        /* First run latency (includes init) */
+    gint64 *inference_times;      /* Array of inference times (excluding first run) */
+    gdouble avg_time;             /* Average inference time */
+    gdouble min_time;             /* Minimum inference time */
+    gdouble max_time;             /* Maximum inference time */
+    gdouble fps;                  /* Frames per second */
+};
+
+/* GStreamer TI TVM element structure */
+struct _GstTiTvm
+{
+    GstBaseTransform element;
+
+    /* Properties */
+    gchar *model_path;            /* Path to TVM artifacts directory */
+    gint iterations;              /* Number of inference iterations */
+    gboolean benchmark;           /* Enable performance benchmarking */
+
+    /* TVM runtime state */
+    gboolean tvm_initialized;     /* TVM runtime initialization status */
+    void *graph_executor;         /* TVM graph executor handle */
+    void *set_input_func;         /* TVM set_input function */
+    void *run_func;               /* TVM run function */
+    void *get_output_func;        /* TVM get_output function */
+
+    /* Input/output data */
+    void *final_output;           /* Final inference output buffer */
+    gsize output_num_floats;      /* Dynamic output size determined at inference time */
+
+    /* Performance tracking */
+    struct TiTvmPerformanceData perf_data;
+
+    /* Execution state */
+    gboolean inference_completed; /* Whether inference has run */
+    gint current_iteration;       /* Current iteration number */
+};
+
+struct _GstTiTvmClass
+{
+    GstBaseTransformClass parent_class;
+};
+
+/* Function declarations */
+GType gst_ti_tvm_get_type (void);
+
+/* Element property IDs */
+enum
+{
+    PROP_0,
+    PROP_MODEL_PATH,
+    PROP_ITERATIONS,
+    PROP_BENCHMARK
+};
+
+/* Default values */
+#define DEFAULT_MODEL_PATH ""
+#define DEFAULT_ITERATIONS 1
+#define DEFAULT_BENCHMARK TRUE
+
+G_END_DECLS
+
+#endif /* __GST_TI_TVM_H__ */

--- a/ext/ti/gsttitvm.h
+++ b/ext/ti/gsttitvm.h
@@ -67,6 +67,10 @@
 #include <gst/gst.h>
 #include <gst/base/gstbasetransform.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 G_BEGIN_DECLS
 
 /* Element type macros */
@@ -103,6 +107,10 @@ struct _GstTiTvm
     gchar *model_path;            /* Path to TVM artifacts directory */
     gint iterations;              /* Number of inference iterations */
     gboolean benchmark;           /* Enable performance benchmarking */
+    gboolean audio_mode;          /* Enable audio enhancement mode (deinterleave/interleave) */
+    gchar *rproc_device;          /* Remoteproc device for RPMsg */
+    guint rproc_id;               /* Remote processor core ID (8 = C7x_0 on AM62D) */
+    guint remote_ep;              /* RPMsg endpoint number */
 
     /* TVM runtime state */
     gboolean tvm_initialized;     /* TVM runtime initialization status */
@@ -110,6 +118,14 @@ struct _GstTiTvm
     void *set_input_func;         /* TVM set_input function */
     void *run_func;               /* TVM run function */
     void *get_output_func;        /* TVM get_output function */
+
+    /* Audio mode: RPMsg context and DMA buffers */
+    void *rpmsg_ctx;              /* Shared RPMsg context (GstTiRpmsgCtx*) */
+    void *dma_input;              /* DMA buffer for interleaved input (struct dma_buf_params*) */
+    void *dma_deint;              /* DMA buffer for deinterleaved data (struct dma_buf_params*) */
+    void *dma_inter;              /* DMA buffer for interleaved output (struct dma_buf_params*) */
+    gboolean dma_allocated;       /* DMA buffers allocated flag */
+    guint32 sequence_number;      /* RPMsg sequence number */
 
     /* Input/output data */
     void *final_output;           /* Final inference output buffer */
@@ -137,14 +153,29 @@ enum
     PROP_0,
     PROP_MODEL_PATH,
     PROP_ITERATIONS,
-    PROP_BENCHMARK
+    PROP_BENCHMARK,
+    PROP_AUDIO_MODE,
+    PROP_RPROC_DEVICE,
+    PROP_RPROC_ID,
+    PROP_REMOTE_EP
 };
 
 /* Default values */
 #define DEFAULT_MODEL_PATH ""
 #define DEFAULT_ITERATIONS 1
 #define DEFAULT_BENCHMARK TRUE
+#define DEFAULT_AUDIO_MODE FALSE
+#define DEFAULT_RPROC_DEVICE "/dev/remoteproc0"
+#define DEFAULT_RPROC_ID 8
+#define DEFAULT_REMOTE_EP 13
+
+/* Audio mode DMA buffer sizes (for 401 frames × 161 bins × 2 channels × float) */
+#define TVM_AUDIO_BUFFER_SIZE 516488  /* 401 * 161 * 2 * 4 bytes */
 
 G_END_DECLS
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __GST_TI_TVM_H__ */

--- a/ext/ti/meson.build
+++ b/ext/ti/meson.build
@@ -1,13 +1,21 @@
+host_soc = run_command('sh', '-c', 'echo $SOC', check: false).stdout().strip()
+
 # Define source code
 gst_ti_plugin_sources = [
   'gstti.c',
-  'gstticolorconvert.c',
-  'gsttiscaler.c',
-  'gsttiperfoverlay.cpp',
-  'gsttimosaic.c',
 ]
 
-if get_option('dl-plugins').enabled()
+# Sources that need tiovx/edgeai headers — not available on am62d
+if host_soc != 'am62d'
+  gst_ti_plugin_sources += [
+    'gstticolorconvert.c',
+    'gsttiscaler.c',
+    'gsttiperfoverlay.cpp',
+    'gsttimosaic.c',
+  ]
+endif
+
+if get_option('dl-plugins').enabled() and host_soc != 'am62d'
   gst_ti_plugin_sources += [
     'gsttidlpreproc.cpp',
     'gsttidlinferer.cpp',
@@ -15,18 +23,34 @@ if get_option('dl-plugins').enabled()
   ]
 endif
 
-gst_ti_plugin_headers = [
-  'gstticolorconvert.h',
-  'gsttiscaler.h',
-  'gsttiperfoverlay.h',
-  'gsttimosaic.h',
-]
-
-if get_option('dl-plugins').enabled()
+if get_option('tvm-plugins').enabled() and get_option('enable-tvm')
   gst_ti_plugin_sources += [
+    'gsttitvm.cpp',
+  ]
+endif
+
+gst_ti_plugin_headers = []
+
+if host_soc != 'am62d'
+  gst_ti_plugin_headers += [
+    'gstticolorconvert.h',
+    'gsttiscaler.h',
+    'gsttiperfoverlay.h',
+    'gsttimosaic.h',
+  ]
+endif
+
+if get_option('dl-plugins').enabled() and host_soc != 'am62d'
+  gst_ti_plugin_headers += [
     'gsttidlpreproc.h',
     'gsttidlinferer.h',
     'gsttidlpostproc.h',
+  ]
+endif
+
+if get_option('tvm-plugins').enabled() and get_option('enable-tvm')
+  gst_ti_plugin_headers += [
+    'gsttitvm.h',
   ]
 endif
 

--- a/ext/ti/meson.build
+++ b/ext/ti/meson.build
@@ -29,6 +29,13 @@ if get_option('tvm-plugins').enabled() and get_option('enable-tvm')
   ]
 endif
 
+if get_option('stft-plugins').enabled()
+  gst_ti_plugin_sources += [
+    'gsttirpmsgctx.cpp',
+    'gstdspkernel.cpp',
+  ]
+endif
+
 gst_ti_plugin_headers = []
 
 if host_soc != 'am62d'
@@ -51,6 +58,13 @@ endif
 if get_option('tvm-plugins').enabled() and get_option('enable-tvm')
   gst_ti_plugin_headers += [
     'gsttitvm.h',
+  ]
+endif
+
+if get_option('stft-plugins').enabled()
+  gst_ti_plugin_headers += [
+    'gsttirpmsgctx.h',
+    'gstdspkernel.h',
   ]
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -35,16 +35,29 @@ if SOC == ''
   error('MESON_FAIL SOC not set.')
 endif
 
-# TI dependencies
-imaging_deps = dependency('imaging')
-tiovx_deps = dependency('tiovx')
-ti_vision_apps_dep = dependency('ti_vision_apps')
-edgeai_tiovx_modules_dep = dependency('edgeai_tiovx_modules')
-edgeai_tiovx_kernels_dep = dependency('edgeai_tiovx_kernels')
-ti_stereo_perception_dep = dependency('ti_stereo_perception')
-edgeai_dl_inferer_dep = dependency('edgeai_dl_inferer')
-edgeai_apps_utils_dep = dependency('edgeai_apps_utils')
+if SOC == 'j721e' or SOC == 'j721s2' or SOC == 'j784s4' or SOC == 'j742s2' or SOC == 'j722s' or SOC == 'am62a'
+  imaging_deps             = dependency('imaging')
+  tiovx_deps               = dependency('tiovx')
+  ti_vision_apps_dep       = dependency('ti_vision_apps')
+  edgeai_tiovx_modules_dep = dependency('edgeai_tiovx_modules')
+  edgeai_tiovx_kernels_dep = dependency('edgeai_tiovx_kernels')
+  ti_stereo_perception_dep = dependency('ti_stereo_perception')
+  edgeai_apps_utils_dep = dependency('edgeai_apps_utils')
+else
+  imaging_deps             = declare_dependency()
+  tiovx_deps               = declare_dependency()
+  ti_vision_apps_dep       = declare_dependency()
+  edgeai_tiovx_modules_dep = declare_dependency()
+  edgeai_tiovx_kernels_dep = declare_dependency()
+  ti_stereo_perception_dep = declare_dependency()
+  edgeai_apps_utils_dep    = declare_dependency()
+endif
 
+if get_option('dl-plugins').enabled()
+  edgeai_dl_inferer_dep = dependency('edgeai_dl_inferer')
+else
+  edgeai_dl_inferer_dep = declare_dependency()
+endif
 
 # Find TIOVX dependencies and headers
 c = meson.get_compiler('c')
@@ -63,10 +76,53 @@ plugin_deps = [
  math_dep
  ]
 
+# tvm-plugins on am62d: TVM headers and libtvm_runtime are already installed
+# in the sysroot.
+if get_option('tvm-plugins').enabled() and get_option('enable-tvm')
+  tvm_runtime_lib = c.find_library('tvm_runtime', required : false)
+
+  # Pass TVM include paths as compiler flags
+  tvm_includes = [
+    '-I/usr/include/tvm/tvm/include',
+    '-I/usr/include/tvm/tvm/3rdparty/dmlc-core/include',
+    '-I/usr/include/tvm/tvm/3rdparty/dlpack/include',
+  ]
+
+  if tvm_runtime_lib.found()
+    tvm_dep = declare_dependency(
+      compile_args : tvm_includes,
+      dependencies : [tvm_runtime_lib]
+    )
+    plugin_deps += [tvm_dep]
+    message('TVM runtime library found - plugin will link against libtvm_runtime')
+  else
+    tvm_dep = declare_dependency(compile_args : tvm_includes)
+    plugin_deps += [tvm_dep]
+    warning('TVM runtime library not found in sysroot - plugin will compile but may fail to load at runtime')
+  endif
+endif
+
+# stft-plugins on am62d: needs ti_rpmsg_dma library for RPMsg/DMA functions
+if get_option('stft-plugins').enabled()
+  ti_rpmsg_dma_lib = c.find_library('ti_rpmsg_dma', required : true)
+
+  rpmsg_dma_dep = declare_dependency(
+    dependencies : [ti_rpmsg_dma_lib]
+  )
+  plugin_deps += [rpmsg_dma_dep]
+  message('ti_rpmsg_dma library found - plugin will link against libti_rpmsg_dma')
+endif
+
 if get_option('dl-plugins').enabled()
   plugin_deps += [
    edgeai_dl_inferer_dep,
    ]
+endif
+
+if get_option('tvm-plugins').enabled()
+  if SOC != 'am62d'
+    error('MESON_FAIL tvm-plugins is only supported on am62d (got SOC=', SOC, ')')
+  endif
 endif
 
 if SOC == 'j721e' or SOC == 'j721s2' or SOC == 'j784s4' or SOC == 'j742s2' or SOC == 'j722s' or SOC == 'am62a'
@@ -191,12 +247,19 @@ elif SOC == 'am62x'
 elif SOC == 'am62p'
   c_args += ['-DSOC_AM62P']
   c_args += ['-DTARGET_CPU_A53']
+elif SOC == 'am62d'
+  c_args += ['-DSOC_AM62D']
+  c_args += ['-DTARGET_CPU_A53']
 else
   error('MESON_FAIL SOC =', SOC, 'Not supported')
 endif
 
-if get_option('dl-plugins').enabled()
+if get_option('dl-plugins').enabled() and SOC != 'am62d'
   c_args += ['-DDL_PLUGINS']
+endif
+
+if get_option('tvm-plugins').enabled()
+  c_args += ['-DTVM_PLUGINS']
 endif
 
 if get_option('enable-tidl').enabled() and SOC != 'am62x' and SOC != 'am62p'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,6 +5,8 @@ option('doc', type : 'feature', value : 'disabled', yield : true, description : 
 option('profiling', type : 'feature', value : 'disabled', yield : true, description: 'Enable profiling building')
 option('dl-plugins', type : 'feature', value : 'enabled', yield : true, description: 'Enable DL Plugins')
 option('enable-tidl', type : 'feature', value : 'enabled', yield : true, description: 'Enable TIDL Offload')
+option('tvm-plugins', type : 'feature', value : 'disabled', yield : true, description: 'Enable TVM inference plugin (titvm)')
+option('enable-tvm', type : 'boolean', value : false, description: 'Enable TVM compilation (requires TVM headers available)')
 
 # Common options
 option('package-name', type : 'string', yield : true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -7,6 +7,7 @@ option('dl-plugins', type : 'feature', value : 'enabled', yield : true, descript
 option('enable-tidl', type : 'feature', value : 'enabled', yield : true, description: 'Enable TIDL Offload')
 option('tvm-plugins', type : 'feature', value : 'disabled', yield : true, description: 'Enable TVM inference plugin (titvm)')
 option('enable-tvm', type : 'boolean', value : false, description: 'Enable TVM compilation (requires TVM headers available)')
+option('stft-plugins', type : 'feature', value : 'disabled', yield : true, description: 'Enable STFT/ISTFT DSP offload plugins via rpmsg')
 
 # Common options
 option('package-name', type : 'string', yield : true,


### PR DESCRIPTION
Implement TVM-based inference element with TI C7x DSP acceleration using the TVM runtime with TIDL backend for TI AM62D platform.

Current Implementation:

Binary tensor inference support
  - Accepts raw float32 tensor input (application/octet-stream)
  - Produces float32 tensor output (application/octet-stream)
  - Direct TVM C++ runtime API integration

Performance benchmarking
  - Configurable inference iterations (iterations property)
  - Min/avg/max/fps statistics (benchmark property)
  - First inference includes model loading overhead
  - Subsequent inferences show true runtime performance

Model loading
  - Loads TVM artifacts: deploy_lib.so, deploy_graph.json, deploy_param.params
  - Artifacts must be compiled for AM62D C7x DSP with TVM TIDL backend
  - model-path property specifies artifacts directory

Properties:
  - model-path:  Path to TVM artifacts directory (required)
  - iterations:  Number of inference runs (default: 1)
  - benchmark:   Enable performance statistics (default: true)

Pipeline Example:
gst-launch-1.0 filesrc location=input_tensor.bin blocksize=1048576 ! \ titvm model-path=/usr/share/tvm/artifacts iterations=1 ! \ filesink location=output_tensor.bin

TODO:

Audio enhancement pipeline integration
  - Add audio-mode property for complex spectral data processing
  - Implement deinterleave/interleave operations via C7x RPMsg
  - Integrate with STFT/ISTFT preprocessing/postprocessing elements
  - Add fft-size and input-shape properties for audio models