### PR TITLE
tiovxisp: add IMX230 Pivariety support

### DIFF
--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -1078,6 +1078,8 @@ static const gchar *target_id_to_target_name (gint target_id);
 
 static int32_t get_imx219_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms);
 
+static int32_t get_imx230_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms);
+
 static int32_t get_imx390_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms);
 
 static int32_t get_imx728_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms);
@@ -1134,6 +1136,7 @@ gst_tiovx_isp_class_init (GstTIOVXISPClass * klass)
           "                                   SENSOR_ONSEMI_AR0820_UB953_LI\n"
           "                                   SENSOR_ONSEMI_AR0233_UB953_MARS\n"
           "                                   SENSOR_SONY_IMX219_RPI\n"
+          "                                   SENSOR_SONY_IMX230_PIVARIETY\n"
           "                                   SENSOR_SONY_IMX728_UB971_D3\n"
           "                                   SENSOR_OX05B1S\n"
           "                                   SENSOR_OV2312_UB953_LI",
@@ -2284,6 +2287,9 @@ gst_tiovx_isp_postprocess (GstTIOVXMiso * miso)
       get_ov2312_ae_dyn_params (&sink_pad->sensor_in_data.ae_dynPrms);
     } else if (g_strcmp0 (self->sensor_name, "SENSOR_OX05B1S") == 0) {
       get_ox05b1s_ae_dyn_params (&sink_pad->sensor_in_data.ae_dynPrms);
+    } else if (g_strcmp0 (self->sensor_name,
+            "SENSOR_SONY_IMX230_PIVARIETY") == 0) {
+      get_imx230_ae_dyn_params (&sink_pad->sensor_in_data.ae_dynPrms);
     } else if (g_strcmp0 (self->sensor_name, "SENSOR_SONY_IMX728_UB971_D3") == 0) {
       get_imx728_ae_dyn_params (&sink_pad->sensor_in_data.ae_dynPrms);
     } else {
@@ -2428,6 +2434,38 @@ get_imx390_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
 }
 
 static int32_t
+get_imx230_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
+{
+  int32_t status = -1;
+  uint8_t count = 0;
+
+  g_return_val_if_fail (p_ae_dynPrms, status);
+
+  p_ae_dynPrms->targetBrightnessRange.min = 68;
+  p_ae_dynPrms->targetBrightnessRange.max = 78;
+  p_ae_dynPrms->targetBrightness = 73;
+  p_ae_dynPrms->threshold = 5;
+  p_ae_dynPrms->enableBlc = 1;
+  p_ae_dynPrms->exposureTimeStepSize = 2;
+
+  p_ae_dynPrms->exposureTimeRange[count].min = 1074;
+  p_ae_dynPrms->exposureTimeRange[count].max = 33333;
+
+  p_ae_dynPrms->analogGainRange[count].min = 1024;
+  p_ae_dynPrms->analogGainRange[count].max = 8192;
+
+  p_ae_dynPrms->digitalGainRange[count].min = 256;
+  p_ae_dynPrms->digitalGainRange[count].max = 256;
+
+  count++;
+
+  p_ae_dynPrms->numAeDynParams = count;
+  status = 0;
+
+  return status;
+}
+
+static int32_t
 get_imx728_ae_dyn_params (IssAeDynamicParams * p_ae_dynPrms)
 {
   int32_t status = -1;
@@ -2550,6 +2588,12 @@ gst_tiovx_isp_map_2A_values (GstTIOVXISP * self, int exposure_time,
     }
     *exposure_time_mapped = exposure_time;
     *analog_gain_mapped = gIMX390GainsTable[i][1];
+  } else if (g_strcmp0 (self->sensor_name,
+          "SENSOR_SONY_IMX230_PIVARIETY") == 0) {
+    *exposure_time_mapped =
+        CLAMP (exposure_time, 1074, 63568);
+    *analog_gain_mapped =
+        CLAMP ((analog_gain * 100) / 1024, 100, 800);
   } else if (g_strcmp0 (self->sensor_name, "SENSOR_SONY_IMX728_UB971_D3") == 0) {
     gint i = 0;
     for (i = 0; i < ISS_IMX728_GAIN_TBL_SIZE - 1; i++) {


### PR DESCRIPTION
## Summary

Add TIOVX ISP support for the Arducam Pivariety Sony IMX230 sensor.

This change adds the `SENSOR_SONY_IMX230_PIVARIETY` sensor path, sensor-specific auto-exposure parameters, and the exposure/gain mapping required for IMX230 operation.

## Changes

- Add `SENSOR_SONY_IMX230_PIVARIETY` to the supported sensor list.
- Add IMX230-specific AE dynamic parameters.
- Add IMX230 handling in the ISP post-processing path.
- Add IMX230 exposure and analog-gain mapping in `gst_tiovx_isp_map_2A_values()`.

### AE parameters

- Target brightness range: 68-78
- Target brightness: 73
- Threshold: 5
- BLC enabled
- Exposure step size: 2
- Exposure range: 1074-33333 us
- Analog gain range: 1024-8192
- Digital gain: fixed at 256

### 2A mapping

- Exposure clamp: 1074-63568
- Analog gain conversion: `(analog_gain * 100) / 1024`
- Analog gain clamp: 100-800

## Validation

Validated on:

- T3 Gemstone O1
- Arducam Pivariety Sony IMX230
- IMX230 firmware version `0x10001`
- 1920x1080
- Media bus format: `SRGGB10_1X10`
- V4L2 capture format: `RG10`
- GStreamer Bayer format: `rggb10`
- TIOVX ISP pipeline

Live ISP output was successfully captured and visually validated using the RGGB10 configuration.

## DCC profile

The IMX230 DCC profile used for validation is maintained separately:

https://github.com/ereennk/imx230-dcc-profile

Validated DCC revision:

https://github.com/ereennk/imx230-dcc-profile/commit/ce7dc61

Generated DCC binaries and generated headers are intentionally not included in this PR.

A companion `edgeai-tiovx-modules` change provides the IMX230 sensor-to-DCC-ID mapping (`dccId = 230`).

## Scope

This PR intentionally contains only the IMX230-specific TIOVX ISP integration. Existing sensor implementations and their parameters are left unchanged.
