### PR TITLE
j7*: Fix DMA buffer allocation for zero-copy sharing

### DIFF
--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -1424,8 +1424,16 @@ gst_tiovx_isp_read_2a_config_file (GstTIOVXIspPad * self)
     goto out;
   }
 
-  self->dcc_2a_buf =
+  #if !defined(SOC_AM62A)
+  {
+    self->dcc_2a_buf =
+      (uint8_t *) tivxMemAlloc (self->dcc_2a_buf_size, TIVX_MEM_EXTERNAL_SHARED);
+  }
+  else {
+    self->dcc_2a_buf =
       (uint8_t *) tivxMemAlloc (self->dcc_2a_buf_size, TIVX_MEM_EXTERNAL);
+  }
+  
   fread (self->dcc_2a_buf, 1, self->dcc_2a_buf_size, dcc_2a_file);
   fclose (dcc_2a_file);
 

--- a/gst-libs/gst/tiovx/gsttiovxallocator.c
+++ b/gst-libs/gst/tiovx/gsttiovxallocator.c
@@ -166,7 +166,14 @@ gst_tiovx_allocator_alloc (GstAllocator * allocator, gsize size,
     goto out;
   }
 
-  status = tivxMemBufferAlloc (&ti_memory->mem_ptr, size, TIVX_MEM_EXTERNAL);
+  #if !defined(SOC_AM62A)
+  {
+    status = tivxMemBufferAlloc (&ti_memory->mem_ptr, size, TIVX_MEM_EXTERNAL_SHARED);
+  }
+  else {
+    status = tivxMemBufferAlloc (&ti_memory->mem_ptr, size, TIVX_MEM_EXTERNAL);
+  }
+  
   if (status != VX_SUCCESS) {
     GST_ERROR_OBJECT (allocator, "Unable to allocate dma memory buffer: %d",
         status);


### PR DESCRIPTION
Change memory allocation from TIVX_MEM_EXTERNAL to TIVX_MEM_EXTERNAL_SHARED for multi-cam codec application to enable DMA-heap backed buffers.

The tiovxmemalloc plugin was allocating buffers from APP_MEM_HEAP_DDR (local-only memory), causing failures when attempting to share buffers with remote cores via tivxReferenceImportHandle. This resulted in errors:
- Failed to get physical address for virt addr
- Buffer may be APP_MEM_HEAP_DDR (local-only, not DMA-heap backed)
- Failed to get dmaBufFd for virtPtr
- tivxReferenceImportHandle: addr[0] is INVALID

Changes:
- gsttiovxallocator.c: Use TIVX_MEM_EXTERNAL_SHARED for tivxMemBufferAlloc
- gsttiovxisp.c: Use TIVX_MEM_EXTERNAL_SHARED for DCC 2A buffer allocation
- Both changes conditional on !defined(SOC_AM62A)

This enables zero-copy buffer sharing between Linux MPU and remote C7x/R5F cores for decode pipeline in app_multi_cam_codec.