### PR TITLE
[gst-tiovx]: Replace runtime check with preprocessor directive

### DIFF
--- a/gst-libs/gst/tiovx/gsttiovxallocator.c
+++ b/gst-libs/gst/tiovx/gsttiovxallocator.c
@@ -167,12 +167,10 @@ gst_tiovx_allocator_alloc (GstAllocator * allocator, gsize size,
   }
 
   #if !defined(SOC_AM62A)
-  {
-    status = tivxMemBufferAlloc (&ti_memory->mem_ptr, size, TIVX_MEM_EXTERNAL_SHARED);
-  }
-  else {
-    status = tivxMemBufferAlloc (&ti_memory->mem_ptr, size, TIVX_MEM_EXTERNAL);
-  }
+  status = tivxMemBufferAlloc (&ti_memory->mem_ptr, size, TIVX_MEM_EXTERNAL_SHARED);
+  #else
+  status = tivxMemBufferAlloc (&ti_memory->mem_ptr, size, TIVX_MEM_EXTERNAL);
+  #endif
   
   if (status != VX_SUCCESS) {
     GST_ERROR_OBJECT (allocator, "Unable to allocate dma memory buffer: %d",


### PR DESCRIPTION
- Replace runtime conditional with compile-time preprocessor check for memory allocation type selection