### PR TITLE
[tiovx]: Replace runtime check with preprocessor directive

### DIFF
--- a/ext/tiovx/gsttiovxisp.c
+++ b/ext/tiovx/gsttiovxisp.c
@@ -1425,14 +1425,10 @@ gst_tiovx_isp_read_2a_config_file (GstTIOVXIspPad * self)
   }
 
   #if !defined(SOC_AM62A)
-  {
-    self->dcc_2a_buf =
-      (uint8_t *) tivxMemAlloc (self->dcc_2a_buf_size, TIVX_MEM_EXTERNAL_SHARED);
-  }
-  else {
-    self->dcc_2a_buf =
-      (uint8_t *) tivxMemAlloc (self->dcc_2a_buf_size, TIVX_MEM_EXTERNAL);
-  }
+  self->dcc_2a_buf = (uint8_t *) tivxMemAlloc (self->dcc_2a_buf_size, TIVX_MEM_EXTERNAL_SHARED);
+  #else
+  self->dcc_2a_buf = (uint8_t *) tivxMemAlloc (self->dcc_2a_buf_size, TIVX_MEM_EXTERNAL);
+  #endif
   
   fread (self->dcc_2a_buf, 1, self->dcc_2a_buf_size, dcc_2a_file);
   fclose (dcc_2a_file);


### PR DESCRIPTION
- Replace runtime conditional with compile-time preprocessor check for
memory allocation type selection